### PR TITLE
Separate asmlib package requirements 

### DIFF
--- a/orahost/defaults/main.yml
+++ b/orahost/defaults/main.yml
@@ -130,8 +130,6 @@
       - compat-libcap1
       - twm
       - kmod-oracleasm
-      - "{{ asmlib_rpm }}"
-      - oracleasm-support
       - xorg-x11-xauth
       - xorg-x11-xinit
       - libXtst
@@ -148,6 +146,11 @@
       - btrfs-progs
       - parted
       - nc
+
+  oracle_asm_packages:
+      - "{{ asmlib_rpm }}"
+      - oracleasm-support
+
      
   oracle_sysconfig:
       - { name: kernel.shmall, value: 4294967296 }

--- a/orahost/defaults/main.yml
+++ b/orahost/defaults/main.yml
@@ -129,7 +129,6 @@
       - openssh-clients
       - compat-libcap1
       - twm
-      - kmod-oracleasm
       - xorg-x11-xauth
       - xorg-x11-xinit
       - libXtst
@@ -150,6 +149,7 @@
   oracle_asm_packages:
       - "{{ asmlib_rpm }}"
       - oracleasm-support
+      - kmod-oracleasm
 
      
   oracle_sysconfig:

--- a/orahost/tasks/main.yml
+++ b/orahost/tasks/main.yml
@@ -14,6 +14,12 @@
     when: install_os_packages
     tags: os_packages
 
+  - name: Install packages required by Oracle for ASMlib
+    yum: name={{ item }} state=installed
+    with_items: oracle_asm_packages 
+    when: install_os_packages and device_persistence == 'asmlib'
+    tags: os_packages
+
   - name: Disable iptables 
     service: name=iptables state=stopped enabled=no
     when: disable_iptables


### PR DESCRIPTION
Suggesting this patch so that udev persistence does not require asmlib packages. 

This is for role: orahost

Split the ASMlib RPM packages out of the main package list and put them in their own.
If user selects device_persistence == 'asmlib' then this RPM group is installed.