### PR TITLE
Added another when condition in mount nfs share and removed wrong item.1.stdout

### DIFF
--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -144,7 +144,7 @@
      - checkdbswinstall.results
     sudo: yes
     sudo_user: "{{ oracle_user }}"
-    when: master_node and item.1.stdout != "1" #and oracle_sw_unpack
+    when: master_node #and item.1.stdout != "1" #and oracle_sw_unpack
     tags:
       - oradbinstall
     register: oradbinstall
@@ -169,7 +169,7 @@
     with_together:
      - oracle_databases
      - checkdbswinstall.results
-    when: master_node and item.1.stdout != "1" 
+    when: master_node #and item.1.stdout != "1" 
     #with_items: oracle_databases
     #when: master_node
     tags:

--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -9,7 +9,7 @@
 
   - name: Mount nfs share with installation media
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=mounted
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool and install_from_nfs|bool
     tags:
       - nfsmountdb
 

--- a/oraswdb-install/templates/dotprofile-db.j2
+++ b/oraswdb-install/templates/dotprofile-db.j2
@@ -5,9 +5,16 @@ export PS1='[$LOGNAME'@'$ORACLE_SID `basename $PWD`]$'
 
 # Set up the Oracle parameters
         umask 022
-        ORACLE_BASE={{ oracle_base }}
+        ORACLE_SID={{ item.oracle_db_name }}
+        export ORACLE_SID
+        ORACLE_HOME=$(grep "^${ORACLE_SID}:" /etc/oratab | cut -d":" -f2)
+        if [ -x ${ORACLE_HOME}/bin/orabase ] ; then
+                ORACLE_BASE=$(${ORACLE_HOME}/bin/orabase)
+        else
+                ORACLE_BASE={{ oracle_base }}
+                ORACLE_HOME={{ oracle_home_db }}
+        fi
         export ORACLE_BASE
-        ORACLE_HOME={{ oracle_home_db }}
         export ORACLE_HOME
         NLS_LANG=american_america.al32utf8
         export NLS_LANG
@@ -21,8 +28,6 @@ export PS1='[$LOGNAME'@'$ORACLE_SID `basename $PWD`]$'
         export TNS_ADMIN
         SQLPATH=/home/oracle/.Scripts
         export SQLPATH
-        ORACLE_SID={{ item.oracle_db_name }}
-        export ORACLE_SID
         export ORA_DB_UNQ_NAME=
         export NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'
 


### PR DESCRIPTION
I tried an installation with extracted archives on a local machine with following variables:
install_from_nfs:     False
oracle_sw_copy:       False
oracle_sw_unpack:     False

This is not possible, because the Task 'Mount nfs share with installation media' is executed and not required in this situation.

I removed the item.1.stdout != "1"  due to strange errors in Ansible while running the playbook. They were removed at other steps and I think we don't need them.