### PR TITLE
Some enhancements to ansible-oracle

### DIFF
--- a/oradb-create/defaults/main.yml
+++ b/oradb-create/defaults/main.yml
@@ -25,6 +25,8 @@
   hostgroup_hub: "{{ hostgroup }}-hub"
   hostgroup_leaf: "{{ hostgroup }}-leaf"
 
+  oracle_characterset: AL32UTF8                            # Use this characterset as default when no variable is set in oracle_databases
+  oracle_nationalcharacterset: AL16UTF8                    # Use this characterset as default when no variable is set in oracle_databases
 
 
 # This is an example layout of a database installation
@@ -42,6 +44,8 @@
           storage_type: FS                                     # Database storage to be used. ASM or FS. 
           service_name: orcl_serv                               # Inital service to be created (not in use yet)
           oracle_init_params: "open_cursors=300,processes=700" # Specific parameters to be set during installation. Comma-separated list
+          characterset: AL32UTF8                               # Characterset of the database
+          nationalcharacterset: AL16UTF16                      # National Characterset of the database
           oracle_db_mem_percent: 30                            # Amount of RAM to be used for SGA
           oracle_database_type: MULTIPURPOSE                   # MULTIPURPOSE|DATA_WAREHOUSING|OLTP
           redolog_size_in_mb: 100

--- a/oradb-create/tasks/main.yml
+++ b/oradb-create/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 
   - name: Check if database is already created
-    shell: grep {{ item.oracle_db_name }}:{{ oracle_home_db }} /etc/oratab |wc -l
+    shell: grep ^{{ item.oracle_db_name }}:{{ oracle_home_db }} /etc/oratab |wc -l
     with_items: oracle_databases
     when: item.oracle_db_name is defined
     tags:
     - checkifdbexists
     - oradbcreate
+    - dbcaresponse
     register: checkdbexist
 
 #  - debug: var=checkdbexist.stdout

--- a/oradb-create/tasks/main.yml
+++ b/oradb-create/tasks/main.yml
@@ -6,6 +6,7 @@
     when: item.oracle_db_name is defined
     tags:
     - checkifdbexists
+    - oradbcreate
     register: checkdbexist
 
 #  - debug: var=checkdbexist.stdout

--- a/oradb-create/tasks/main.yml
+++ b/oradb-create/tasks/main.yml
@@ -30,14 +30,14 @@
 #    debug: msg="memfree={{ ansible_memfree_mb }}M totalmem={{ ansible_memtotal_mb }}M need 616M free"
 #    failed_when: "{{ ansible_memfree_mb }} < 616"
 
-  - name: Create database(s)
+  - name: Create database(s) (1)
     shell: "time {{ oracle_home_db_install }}/bin/dbca -responseFile {{ oracle_rsp_stage }}/{{ oracle_dbca_rsp }} -silent -redoLogFileSize {{ item.0.redolog_size_in_mb }} "
     with_together:
        - oracle_databases
        - checkdbexist.results
     sudo: yes
     sudo_user: "{{ oracle_user }}"
-    when: master_node and item.1.stdout != "1" and "{{ item.0.state }}"|upper == "PRESENT"
+    when: master_node and item.0.oracle_home is not defined and item.1.stdout != "1" and "{{ item.0.state }}"|upper == "PRESENT"
     tags:
       - oradbcreate
     register: oradbcreate
@@ -47,6 +47,25 @@
     tags:
      - oradbcreate
     when: oradbcreate.changed
+
+  - name: Create database(s) (2)
+    shell: "time {{ item.0.oracle_home }}/bin/dbca -responseFile {{ oracle_rsp_stage }}/{{ oracle_dbca_rsp }} -silent -redoLogFileSize {{ item.0.redolog_size_in_mb }} "
+    with_together:
+       - oracle_databases
+       - checkdbexist.results
+    sudo: yes
+    sudo_user: "{{ oracle_user }}"
+    when: master_node and item.0.oracle_home is defined and item.1.stdout != "1" and "{{ item.0.state }}"|upper == "PRESENT"
+    tags:
+      - oradbcreate
+    register: oradbcreate
+
+  - debug: var=oradbcreate.stdout_lines
+    with_items: oradbcreate.results
+    tags:
+     - oradbcreate
+    when: oradbcreate.changed
+
 
 #  - name: Add default services to databases
 #    shell: "{{ oracle_home_db }}/bin/srvctl add service -db {{ item.value.oracle_database }} 
@@ -81,12 +100,20 @@
     - dbs.results
     tags: dotprofile_db
 
-  - name: Update oratab
+  - name: Update oratab (1)
     lineinfile: dest=/etc/oratab line="{{ item.1.stdout }}:{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}:N" state=present
     with_together:
        - oracle_databases
        - dbs.results
-    when: item.0.oracle_db_type != "SI"
+    when: item.0.oracle_db_type == "SI" and item.0.oracle_home is not defined
+    tags: update_oratab
+    
+  - name: Update oratab (2)
+    lineinfile: dest=/etc/oratab line="{{ item.1.stdout }}:{{ item.0.oracle_home }}:N" state=present
+    with_together:
+       - oracle_databases
+       - dbs.results
+    when: item.0.oracle_db_type == "SI" and item.0.oracle_home is defined
     tags: update_oratab
     
   - name: Check if database is running

--- a/oradb-create/templates/dbca-create-db.rsp.12.1.0.2.j2
+++ b/oradb-create/templates/dbca-create-db.rsp.12.1.0.2.j2
@@ -549,7 +549,11 @@ RECOVERYGROUPNAME={{ oracle_reco_dir_asm }}
 # Default value : "US7ASCII"
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
-CHARACTERSET = "AL32UTF8"
+{% if item.0.characterset is defined %}
+CHARACTERSET= "{{ item.0.characterset }}"
+{% else %}
+CHARACTERSET = "{{ oracle_characterset }}"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : NATIONALCHARACTERSET
@@ -559,7 +563,11 @@ CHARACTERSET = "AL32UTF8"
 # Default value : "AL16UTF16"
 # Mandatory     : No
 #-----------------------------------------------------------------------------
-NATIONALCHARACTERSET= "AL16UTF16"
+{% if item.0.nationalcharacterset is defined %}
+NATIONALCHARACTERSET= "{{ item.0.nationalcharacterset }}"
+{% else %}
+NATIONALCHARACTERSET= "{{ oracle_nationalcharacterset }}"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : REGISTERWITHDIRSERVICE

--- a/orahost-storage/tasks/main.yml
+++ b/orahost-storage/tasks/main.yml
@@ -34,21 +34,22 @@
     when: master_node and device_persistence == 'asmlib'
     tags: asmlib
 
+  # oracleasm scandisks is not possible with service module.
   - name: ASMlib | Rescan ASM disks
     shell: service oracleasm scandisks
     when: device_persistence == 'asmlib'
-    tags: asmlib
+    tags: asmlib, lsasmlib
 
   - name: ASMlib | List ASM disks
     shell: service oracleasm listdisks
     when: device_persistence == 'asmlib'
     register: listdisks
-    tags: asmlib
+    tags: asmlib, lsasmlib
 
   - name: List ASM disks
     debug: var=listdisks.stdout_lines
     when: device_persistence == 'asmlib'
-    tags: asmlib
+    tags: asmlib, lsasmlib
 
   - name: udev | Create device to label mappings for udev
     template: src=udev-label-device-mapping.txt.j2 dest={{ oracle_stage }}/udev/udev-{{ item.diskgroup }}

--- a/orahost/defaults/main.yml
+++ b/orahost/defaults/main.yml
@@ -68,7 +68,7 @@
                                              
   host_fs_layout:    # Sets up filesystem on host. If storage_type=FS under oracle_databases, this is where the mapping between device/fs is described
       u01:
-        {mntp: /u01, device: /dev/sdb, vgname: vgora, pvname: /dev/sdb1, lvname: lvora, fstype: ext4}
+        {mntp: /u01, device: /dev/sdb, vgname: vgora, pvname: /dev/sdb1, lvsize: 14G, lvname: lvora, fstype: ext4}
 
 
   #asm_diskgroups: 

--- a/orahost/tasks/main.yml
+++ b/orahost/tasks/main.yml
@@ -177,7 +177,7 @@
     tags: hostfs
 
   - name: filesystem | create lv
-    lvol: vg={{ item.value.vgname }} lv={{ item.value.lvname }} size=100%FREE state=present
+    lvol: vg={{ item.value.vgname }} lv={{ item.value.lvname }} size={{ item.value.lvsize }} state=present
     with_dict: host_fs_layout
     when: configure_host_disks
     tags: hostfs

--- a/oraswdb-install/defaults/main.yml
+++ b/oraswdb-install/defaults/main.yml
@@ -41,6 +41,7 @@
   oracle_sw_source_local: /tmp  # Path to all software if using the copy module when putting software on the host(s)
   is_sw_source_local: true
   configure_cluster: false
+  configure_gloginsql: true
 
   oracle_sw_image_db: 
        - { filename: linuxamd64_12102_database_1of2.zip, version: 12.1.0.2 }

--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -144,7 +144,7 @@
      - checkdbswinstall.results
     sudo: yes
     sudo_user: "{{ oracle_user }}"
-    when: master_node and item.1.stdout != "1" #and oracle_sw_unpack
+    when: master_node #and item.1.stdout != "1" #and oracle_sw_unpack
     tags:
       - oradbinstall
     register: oradbinstall
@@ -169,7 +169,7 @@
     with_together:
      - oracle_databases
      - checkdbswinstall.results
-    when: master_node and item.1.stdout != "1" 
+    when: master_node #and item.1.stdout != "1" 
     #with_items: oracle_databases
     #when: master_node
     tags:

--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -9,7 +9,7 @@
 
   - name: Mount nfs share with installation media
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=mounted
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool and install_from_nfs|bool
     tags:
       - nfsmountdb
 

--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -178,6 +178,7 @@
   - name: Add additional info to glogin.sql (1)
     lineinfile: dest="{{ oracle_home_db }}/sqlplus/admin/glogin.sql" line='set sqlprompt "_user @ _connect_identifier:>"' backup=yes
     with_items: oracle_databases
+    when: configure_gloginsql|bool
     sudo: yes
     sudo_user: "{{ oracle_user }}"
     tags: 
@@ -186,6 +187,7 @@
   - name: Add additional info to glogin.sql (2)
     lineinfile: dest="{{ oracle_home_db }}/sqlplus/admin/glogin.sql" line='set time on' backup=yes
     with_items: oracle_databases
+    when: configure_gloginsql|bool
     tags: 
       - glogin
   

--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -5,6 +5,10 @@
     with_items: oracle_databases 
     tags: 
     - checkifdbinstall
+    - responsefileswdb
+    - responsefileswdb
+    - oradbinstall
+    - runroot
     register: checkdbswinstall
 
   - name: Mount nfs share with installation media
@@ -164,39 +168,64 @@
 #    tags:
 #      - runroot
 
-  - name: Run root script after installation
-    shell: "{{ oracle_home_db_install }}/root.sh"
+
+  - name: Run root script after installation (1)
+    shell: "{{ db_oracle_home_install }}/root.sh"
     with_together:
      - oracle_databases
      - checkdbswinstall.results
-    when: master_node #and item.1.stdout != "1" 
-    #with_items: oracle_databases
+    when: master_node and db_oracle_home_install is defined and item.1.stdout != "1"
     #when: master_node
     tags:
       - runroot
 
-  - name: Add additional info to glogin.sql (1)
+  - name: Run root script after installation (2)
+    shell: "{{ item.0.oracle_home }}/root.sh"
+    with_together:
+     - oracle_databases
+     - checkdbswinstall.results
+    when: master_node and item.0.oracle_home is defined and item.1.stdout != "1" 
+    tags:
+      - runroot
+
+  - name: Add additional info to glogin.sql (1.1)
     lineinfile: dest="{{ oracle_home_db }}/sqlplus/admin/glogin.sql" line='set sqlprompt "_user @ _connect_identifier:>"' backup=yes
     with_items: oracle_databases
-    when: configure_gloginsql|bool
+    when: configure_gloginsql|bool and oracle_home_db is defined and item.0.oracle_home is not defined
     sudo: yes
     sudo_user: "{{ oracle_user }}"
     tags: 
       - glogin
 
-  - name: Add additional info to glogin.sql (2)
+  - name: Add additional info to glogin.sql (1.2)
     lineinfile: dest="{{ oracle_home_db }}/sqlplus/admin/glogin.sql" line='set time on' backup=yes
     with_items: oracle_databases
-    when: configure_gloginsql|bool
+    when: configure_gloginsql|bool and oracle_home_db is defined and item.0.oracle_home is not defined
     tags: 
       - glogin
-  
-  - name: Check opatch lsinventory (DB)
+ 
+  - name: Add additional info to glogin.sql (2.2)
+    lineinfile: dest="{{ item.0.oracle_home }}/sqlplus/admin/glogin.sql" line='set sqlprompt "_user @ _connect_identifier:>"' backup=yes
+    with_items: oracle_databases
+    when: configure_gloginsql|bool and item.0.oracle_home is defined
+    sudo: yes
+    sudo_user: "{{ oracle_user }}"
+    tags:
+      - glogin
+
+  - name: Add additional info to glogin.sql (2.2)
+    lineinfile: dest="{{ item.0.oracle_home }}/sqlplus/admin/glogin.sql" line='set time on' backup=yes
+    with_items: oracle_databases
+    when: configure_gloginsql|bool and item.0.oracle_home is defined
+    tags:
+      - glogin
+ 
+  - name: Check opatch lsinventory (DB) (1)
     shell: "{{ oracle_home_db }}/OPatch/opatch lsinventory"
     with_items: oracle_databases
     sudo: yes
     sudo_user: "{{ oracle_user }}"
-    when: master_node  
+    when: master_node and item.oracle_home is not defined
     register: opatchls
     tags:
      - opatchls
@@ -206,6 +235,23 @@
     when: master_node
     tags:
      - opatchls
+
+  - name: Check opatch lsinventory (DB) (2)
+    shell: "{{ item.oracle_home }}/OPatch/opatch lsinventory"
+    with_items: oracle_databases
+    sudo: yes
+    sudo_user: "{{ oracle_user }}"
+    when: master_node and item.oracle_home is defined
+    register: opatchls
+    tags:
+     - opatchls
+
+  - debug: var=opatchls.stdout_lines
+    with_items: opatchls.results
+    when: master_node and item.oracle_home is defined
+    tags:
+     - opatchls
+
 
   - name: Unmount nfs share with installation media
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=absent

--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -148,7 +148,7 @@
      - checkdbswinstall.results
     sudo: yes
     sudo_user: "{{ oracle_user }}"
-    when: master_node #and item.1.stdout != "1" #and oracle_sw_unpack
+    when: master_node and item.1.stdout != "1" #and oracle_sw_unpack
     tags:
       - oradbinstall
     register: oradbinstall

--- a/oraswdb-install/templates/db-install.rsp.11.2.0.3.j2
+++ b/oraswdb-install/templates/db-install.rsp.11.2.0.3.j2
@@ -89,7 +89,11 @@ SELECTED_LANGUAGES=en
 #------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Home.
 #------------------------------------------------------------------------------
+{% if item.0.oracle_home is defined %}
+ORACLE_HOME={{ item.0.oracle_home }}
+{% else %}
 ORACLE_HOME={{ oracle_home_db_install }}
+{% endif %}
 
 #------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Base. 

--- a/oraswdb-install/templates/db-install.rsp.11.2.0.4.j2
+++ b/oraswdb-install/templates/db-install.rsp.11.2.0.4.j2
@@ -89,7 +89,11 @@ SELECTED_LANGUAGES=en
 #------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Home.
 #------------------------------------------------------------------------------
+{% if item.0.oracle_home is defined %}
+ORACLE_HOME={{ item.0.oracle_home }}
+{% else %}
 ORACLE_HOME={{ oracle_home_db_install }}
+{% endif %}
 
 #------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Base. 

--- a/oraswdb-install/templates/db-install.rsp.12.1.0.1.j2
+++ b/oraswdb-install/templates/db-install.rsp.12.1.0.1.j2
@@ -90,7 +90,11 @@ SELECTED_LANGUAGES=en
 #-------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Home. 
 #-------------------------------------------------------------------------------
+{% if item.0.oracle_home is defined %}
+ORACLE_HOME={{ item.0.oracle_home }}
+{% else %}
 ORACLE_HOME={{ oracle_home_db_install }}
+{% endif %}
 
 #-------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Base. 

--- a/oraswdb-install/templates/db-install.rsp.12.1.0.2.j2
+++ b/oraswdb-install/templates/db-install.rsp.12.1.0.2.j2
@@ -90,7 +90,11 @@ SELECTED_LANGUAGES=en
 #-------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Home. 
 #-------------------------------------------------------------------------------
+{% if item.0.oracle_home is defined %}
+ORACLE_HOME={{ item.0.oracle_home }}
+{% else %}
 ORACLE_HOME={{ oracle_home_db_install }}
+{% endif %}
 
 #-------------------------------------------------------------------------------
 # Specify the complete path of the Oracle Base. 

--- a/oraswdb-install/templates/dotprofile-db.j2
+++ b/oraswdb-install/templates/dotprofile-db.j2
@@ -5,9 +5,16 @@ export PS1='[$LOGNAME'@'$ORACLE_SID `basename $PWD`]$'
 
 # Set up the Oracle parameters
         umask 022
-        ORACLE_BASE={{ oracle_base }}
+        ORACLE_SID={{ item.oracle_db_name }}
+        export ORACLE_SID
+        ORACLE_HOME=$(grep "^${ORACLE_SID}:" /etc/oratab | cut -d":" -f2)
+        if [ -x ${ORACLE_HOME}/bin/orabase ] ; then
+                ORACLE_BASE=$(${ORACLE_HOME}/bin/orabase)
+        else
+                ORACLE_BASE={{ oracle_base }}
+                ORACLE_HOME={{ oracle_home_db }}
+        fi
         export ORACLE_BASE
-        ORACLE_HOME={{ oracle_home_db }}
         export ORACLE_HOME
         NLS_LANG=american_america.al32utf8
         export NLS_LANG
@@ -21,8 +28,6 @@ export PS1='[$LOGNAME'@'$ORACLE_SID `basename $PWD`]$'
         export TNS_ADMIN
         SQLPATH=/home/oracle/.Scripts
         export SQLPATH
-        ORACLE_SID={{ item.oracle_db_name }}
-        export ORACLE_SID
         export ORA_DB_UNQ_NAME=
         export NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'
 

--- a/oraswdb-install/templates/run-db-install.sh.j2
+++ b/oraswdb-install/templates/run-db-install.sh.j2
@@ -1,9 +1,14 @@
 # {{ ansible_managed }}
 #!/bin/bash
+{% if item.0.oracle_home is defined %}
+oracle_home={{ item.0.oracle_home }}
+{% else %}
+oracle_home={{ oracle_home_db_install }}
+{% endif %}
 
-chkifinstalled=`grep "{{ oracle_home_db_install }}" "{{ oracle_inventory_loc }}/ContentsXML/inventory.xml" |wc -l`
+chkifinstalled=`grep $oracle_home "{{ oracle_inventory_loc }}/ContentsXML/inventory.xml" |wc -l`
 if [[ $chkifinstalled == 1 ]]; then
- echo "Error: ORACLE_HOME: {{ oracle_home_db_install }} already present. Exiting"
+ echo "Error: ORACLE_HOME: "$oracle_home" already present. Exiting"
  exit 0
 else
 {{ oracle_stage_install }}/{{ item.0.oracle_version_db }}/database/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -ignoreSysPrereqs -silent -waitforcompletion

--- a/oraswgi-install/defaults/main.yml
+++ b/oraswgi-install/defaults/main.yml
@@ -59,6 +59,7 @@
   oracle_gi_nic_priv: eth1                       # Default interface for interconnect traffic. Only used in RAC
 
   run_configtoolallcommand: true
+  configure_gloginsql: true
   oracle_cluster_mgmdb: true
   oracle_gi_cluster_type: STANDARD              # STANDARD | FLEX
   oracle_install_option_gi: HA_CONFIG

--- a/oraswgi-install/tasks/main.yml
+++ b/oraswgi-install/tasks/main.yml
@@ -10,7 +10,7 @@
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=mounted
     tags:
       - nfsmountgi
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool and install_from_nfs|bool
 
   - name: Add new dotprofile (GI)
     template: src=dotprofile-gi.j2 dest={{ grid_user_home }}/{{ oracle_profile_name_gi }} owner={{ grid_install_user }} group={{ oracle_group }} mode=755 backup=yes

--- a/oraswgi-install/tasks/main.yml
+++ b/oraswgi-install/tasks/main.yml
@@ -3,7 +3,19 @@
   - name: Check if GI is already installed
     shell: grep "{{ oracle_home_gi }}" "{{ oracle_inventory_loc }}/ContentsXML/inventory.xml" |wc -l
     tags: 
+    - asmcaa
     - checkifgiinstall
+    - crsctl
+    - olsnodes
+    - opatchls
+    - oragridinstall
+    - responsefileconfigtool
+    - responsefilegi
+    - runconfigtool
+    - runroot
+    - srvctlasm
+    - updatenodelist
+    - srvctlasm
     register: checkgiinstall
 
   - name: Mount nfs share with installation media
@@ -236,4 +248,5 @@
     tags:
       - nfsunmount
     when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
-    tags: nfsunmountgi
+    tags:
+     - nfsunmountgi

--- a/oraswgi-install/tasks/main.yml
+++ b/oraswgi-install/tasks/main.yml
@@ -193,13 +193,13 @@
     lineinfile: dest="{{ oracle_home_gi }}/sqlplus/admin/glogin.sql" line='set sqlprompt "_user @ _connect_identifier:>"' backup=yes
     tags:
       - glogin
-    when: checkgiinstall.stdout != "1"
+    when: checkgiinstall.stdout != "1" and configure_gloginsql|bool
 
   - name: Add additional info to glogin.sql (2)
     lineinfile: dest="{{ oracle_home_gi }}/sqlplus/admin/glogin.sql" line='set time on' backup=yes
     tags:
       - glogin
-    when: checkgiinstall.stdout != "1"
+    when: checkgiinstall.stdout != "1" and configure_gloginsql|bool
 
   - name: Check opatch lsinventory (GI)
     shell: "{{ oracle_home_gi }}/OPatch/opatch lsinventory"


### PR DESCRIPTION
I added a lot feautures to ansible-oracle. I'll delete my 1st pull request because this one will replace it. I reverted the change for removed item.1.stdout in role oraswdb-install as it was a wrong solution for the problem.

The added feautures:
- added lvsize to filesystem | create lv
This is an incompatble change. Sorry for that, but the old way with '100%FREE' is not working when ansible is called the 2nd time. I added another variable lvsize to fix this problem and added the possibility to created more then 1 logical Volume in the Volume Group. You could create /u01, /u01/app/oracle/diag etc. as different Filesystems in 1 Volume Group.
The incompatible Change is only for user who defined a custom variable for host_fs_layout and a physical Volume which is less then 14GB. The default is changed to a fixed size of 14GB for the filesystem. This should be enought for 1 Grid-Infrastructure and 1 ORACLE_HOME in a lab environment.

- Custom ORACLE_HOME for each Database
Add oracle_home to oracle_databases for custom ORACLE_HOME. oracle_home_db is used when no oracle_home is defined in oracle_databases.

- Custom Characterset for each database
Add characterset and/or nationalcharacterset in oracle_databases to define a custom characterset for each database. The old defaults are used when no value is defined in oracle_databases

- Bugfix for install_from_nfs
Installing without nfs wasn't possible. Thias has been fixed.

- dotprofile save against changed ORACLE_HOME in oratab
The ORACLE_HOME is not fixed anymore. It is determined from oratab when possible. Otherwise the old behavior with a fixed value is used.. This makes dotprofile reliable against changes for ORACLE_HOME in oratab.

- added some tags in oradb-create and oraswgi-install
I added a lot of tags to the 1st task in each role. The tags are required due to dependency between subtasks and the 1st task.

- changes in gloginsql could be disabled
Define configure_gloginsql=False to disable changing the gloginsql. The file will be change by default.

- better detection of ORACLE_SID in oratab
I changed the searchstring, because a # in from of an entry wasn't ignored.

- added lsasmlib
I added some tags in role orahost-storage. An -t lsasmlib could be used to get information for the Disks from oracleasm.
