### PR TITLE
added support for failgroup parameter in create diskgroup

### DIFF
--- a/oraasm-createdg/templates/asmca-createdg.sh.j2
+++ b/oraasm-createdg/templates/asmca-createdg.sh.j2
@@ -5,19 +5,29 @@
        -diskGroupName {{ item.diskgroup }} \
 {% if device_persistence == 'udev' %}
      {% for disk in  item.disk    %}
-       -disk '{{ oracle_asm_disk_string }}{{ disk.asmlabel }}' \
+       {% if disk.failgroup is defined %} \
+           -diskList '{{ oracle_asm_disk_string }}{{ disk.asmlabel }}' \
+               -failuregroup {{ item.disk.failgroup }} \
+       {% else %}
+         -disk '{{ oracle_asm_disk_string }}{{ disk.asmlabel }}' \
+       {% endif %}
      {% endfor %}
 {% elif device_persistence == 'asmlib' %}
      {% for disk in  item.disk    %}
-       -disk 'ORCL:{{ disk.asmlabel|upper }}' \
-     {% endfor %}{% else %}
-     {% endif %}
-     {% for a in item.properties %}
+       {% if disk.failgroup is defined %} \
+           -diskList 'ORCL:{{ disk.asmlabel|upper }}' \
+               -failuregroup {{ disk.failgroup }} \
+       {% else %}
+         -disk 'ORCL:{{ disk.asmlabel|upper }}' \
+       {% endif %}
+     {% endfor %}
+{% else %}
+{% endif %}
+\
+{% for a in item.properties %}
         -redundancy {{ a.redundancy }} \
         -au_size {{ a.ausize}} \
-      {% endfor %}
-     {% for attr in item.attributes %}
-     -{{ attr.name }} '{{ attr.value }}' \
-     {% endfor %}
-
-     
+{% endfor %}
+{% for attr in item.attributes %}
+        -{{ attr.name }} '{{ attr.value }}' \
+{% endfor %}


### PR DESCRIPTION
Failure groups could be named when diskgroups are in high or
normal redundancy. Oracle doesn't support Failure Groups in
external redundancy. Please do not use them!

Example:
```
    - diskgroup: test
      properties:
        - {redundancy: normal, ausize: 4}
      attributes:
        - {name: compatible.rdbms, value: 11.2.0.4.0}
        - {name: compatible.asm, value: 12.1.0.2.0}
      disk:
        - {device: /dev/sdf, asmlabel: test01, failgroup: fg1}
        - {device: /dev/sdg, asmlabel: test02, failgroup: fg2}
```
