### PR TITLE
Change the variable oracle_sysconfig by oracle_sysctl.

### DIFF
--- a/orahost/defaults/main.yml
+++ b/orahost/defaults/main.yml
@@ -152,7 +152,7 @@
       - kmod-oracleasm
 
      
-  oracle_sysconfig:
+  oracle_sysctl:
       - { name: kernel.shmall, value: 4294967296 }
       - { name: kernel.shmmax, value: 68719476736 }
       - { name: kernel.shmmni, value: 4096 }

--- a/orahost/tasks/main.yml
+++ b/orahost/tasks/main.yml
@@ -202,8 +202,8 @@
 
   - name: Oracle-recommended kernel settings
     sysctl: name={{ item.name }} value="{{ item.value }}" state=present reload=yes ignoreerrors=yes
-    with_items: oracle_sysconfig
-    tags: sysconfig
+    with_items: oracle_sysctl
+    tags: sysctl
 
   - name: Oracle-recommended PAM config
     lineinfile: dest=/etc/pam.d/login state=present line="session required pam_limits.so"


### PR DESCRIPTION
```
$ pwd
ansible-oracle
$ grep -R oracle_sysconfig *
orahost/defaults/main.yml:  oracle_sysconfig:
orahost/tasks/main.yml:    with_items: oracle_sysconfig
```

IMHO, that names of the variable *_sysconfig, which indeed is used by the module sysctl,
and the values finally go to /etc/sysctl.conf, not something in /etc/sysconfig/ dir.

So, my opinion+question is, this variable needs to be called like: oracle_sysctl :+1: 
