### PR TITLE
bugfix Mount nfs share with installation media

### DIFF
--- a/oraswdb-install/tasks/main.yml
+++ b/oraswdb-install/tasks/main.yml
@@ -9,7 +9,7 @@
 
   - name: Mount nfs share with installation media
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=mounted
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: install_from_nfs|bool
     tags:
       - nfsmountdb
 
@@ -207,7 +207,7 @@
 
   - name: Unmount nfs share with installation media
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=absent
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: install_from_nfs|bool
     tags:
       - nfsunmountdb
     

--- a/oraswgi-install/tasks/main.yml
+++ b/oraswgi-install/tasks/main.yml
@@ -10,7 +10,7 @@
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=mounted
     tags:
       - nfsmountgi
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: install_from_nfs|bool
 
   - name: Add new dotprofile (GI)
     template: src=dotprofile-gi.j2 dest={{ grid_user_home }}/{{ oracle_profile_name_gi }} owner={{ grid_install_user }} group={{ oracle_group }} mode=755 backup=yes
@@ -235,5 +235,5 @@
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=absent
     tags:
       - nfsunmount
-    when: not oracle_sw_copy|bool and not oracle_sw_unpack|bool
+    when: install_from_nfs|bool
     tags: nfsunmountgi


### PR DESCRIPTION
Installing from unpacked local files without using a nfs server
was not possible, due to wrong when clause in tasks for mount/umount
of nfs.
The detection of install_from_nfs has been fixed and works like expected.