### PR TITLE
preparation for using different ORACLE_HOME for each Database

### DIFF
--- a/cxoracle/defaults/main.yml
+++ b/cxoracle/defaults/main.yml
@@ -2,7 +2,7 @@
    install_cx_oracle: true
    use_proxy: false
    http_proxy:
-   oracle_home: "{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}"
+   oracle_home: "{% if item.oracle_home is defined %}{{ item.oracle_home }}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}"
    oracle_env:
          ORACLE_HOME: "{{ oracle_home }}"
    extra_args: "{% if use_proxy==true %}--proxy={{ http_proxy }}{% else %}{% endif %}"

--- a/oradb-create/defaults/main.yml
+++ b/oradb-create/defaults/main.yml
@@ -8,8 +8,9 @@
   oracle_dba_group: dba                          # Primary group for oracle_user. 
   grid_dba_group: asmdba                          # Primary group for oracle_user. 
 
-  oracle_home_db: "{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}"      # ORACLE_HOME path
-  oracle_home_db_install: "{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}" # This is only used when installing the db server and creating the databases
+  oracle_home_db: "{% if item.0 is defined %}{% if item.0.oracle_home is defined %}{{ item.0.oracle_home}}{% else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}{% endif %}{% else %}{% if item.oracle_home is defined %}{{ item.oracle_home }}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}{% endif %}"
+
+  oracle_home_db_install: "{{ oracle_home_db }}"     # This variable should be removed at a later time
   oracle_stage: /u01/stage
   oracle_rsp_stage: "{{ oracle_stage }}/rsp"
   oracle_inventory_loc: /u01/app/oraInventory

--- a/oradb-delete/defaults/main.yml
+++ b/oradb-delete/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-  oracle_home_db: "{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}"      # ORACLE_HOME path
-  oracle_home_db_install: "{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}" # This is only used when installing the db server and creating the databases
+  oracle_home_db: "{% if item.0 is defined %}{% if item.0.oracle_home is defined %}{{ item.0.oracle_home}}{% else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}{% endif %}{% else %}{% if item.oracle_home is defined %}{{ item.oracle_home }}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}{% endif %}"
+  oracle_home_db_install: "{{ oracle_home_db }}"     # This variable should be removed at a later time
   oracle_stage: /u01/stage
   oracle_rsp_stage: "{{ oracle_stage }}/rsp"
   oracle_inventory_loc: /u01/app/oraInventory

--- a/oraswdb-install/defaults/main.yml
+++ b/oraswdb-install/defaults/main.yml
@@ -32,8 +32,8 @@
   oracle_rsp_stage: "{{ oracle_stage }}/rsp"
   oracle_inventory_loc: /u01/app/oraInventory
   oracle_base: /u01/app/oracle
-  oracle_home_db: "{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}"      # ORACLE_HOME path
-  oracle_home_db_install: "{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}" # This is only used when installing the db server and creating the databases
+  oracle_home_db: "{% if item.0 is defined %}{% if item.0.oracle_home is defined %}{{ item.0.oracle_home}}{% else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}{% endif %}{% else %}{% if item.oracle_home is defined %}{{ item.oracle_home }}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}{% endif %}"
+  oracle_home_db_install: "{{ oracle_home_db }}"     # This variable should be removed at a later time
 
   oracle_profile_name: "{% if item.oracle_db_name is defined %}.profile_{{ item.oracle_db_name }}{% else %}.profile_{{ item.home }}{% endif %}"    # Name of profile-file. Sets up the environment for that database. One per database
   oracle_hostname: "{{ ansible_fqdn }}"                            # Full (FQDN) name of the host


### PR DESCRIPTION
This change is the 1st preparation which is needed for the possibility
to define a custom ORACLE_HOME for each database.

The following examples shows the usage of a custom ORACLE_HOME for the
racdb database. The value from home is ignored but the variable is requirred!
oracle_version_db is requirred for choosing the correct installation
media.

Example:
  oracle_databases:
        - home: dbhome_1
          oracle_db_name: racdb
          oracle_home: /u01/app/oracle/product/12.1.0.2/dbhome_1
          oracle_version_db: 12.1.0.2