### PR TITLE
enhancements in orahost-logrotate

### DIFF
--- a/orahost-logrotate/defaults/main.yml
+++ b/orahost-logrotate/defaults/main.yml
@@ -1,23 +1,22 @@
 ---
 # defaults file for orahost-logrotate
+oracle_base: /u01/app/oracle
 
 logrotate_config:
         - name: oracle_alert
-          file: "/u01/app/oracle/diag/rdbms/*/*/trace/*alert*.log"
+          file: "{{ oracle_base }}/diag/rdbms/*/*/trace/*alert*.log {{ oracle_base }}/diag/asm/*/*/trace/alert*+ASM*.log"
           options:
             - missingok
             - notifempty
             - weekly
             - rotate 3
-            - copytruncate
             - dateext
         - name: oracle_listener
-          file: "/u01/app/oracle/diag/tnslsnr/*/*/trace/*listener*.log"
+          file: "{{ oracle_base }}/diag/tnslsnr/*/*/trace/*listener*.log"
           options:
             - missingok
             - notifempty
             - weekly
             - rotate 3
-            - copytruncate
             - dateext
             - compress


### PR DESCRIPTION
The new role orahost-logrotate has been enhanced and modified.
oracle_base is used to get the right directories for logfiles.
Removed copytruncate, this is not required anymore from 11.2 onwards.
Added missing alert.log for ASM.