### PR TITLE
Added Support for Characterset for each Database

### DIFF
--- a/roles/oradb-create/templates/dbca-create-db.rsp.11.2.0.3.j2
+++ b/roles/oradb-create/templates/dbca-create-db.rsp.11.2.0.3.j2
@@ -456,7 +456,11 @@ RECOVERYGROUPNAME={{ oracle_reco_dir_asm }}
 # Default value : "US7ASCII"
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
+{% if item.0.characterset is defined %}
+CHARACTERSET = "{{ item.0.characterset }}"
+{% else %}
 CHARACTERSET = "AL32UTF8"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : NATIONALCHARACTERSET
@@ -466,7 +470,11 @@ CHARACTERSET = "AL32UTF8"
 # Default value : "AL16UTF16"
 # Mandatory     : No
 #-----------------------------------------------------------------------------
+{% if item.0.ncharacterset is defined %}
+NATIONALCHARACTERSET= "{{ item.0.ncharacterset }}"
+{% else %}
 NATIONALCHARACTERSET= "AL16UTF16"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : REGISTERWITHDIRSERVICE

--- a/roles/oradb-create/templates/dbca-create-db.rsp.11.2.0.4.j2
+++ b/roles/oradb-create/templates/dbca-create-db.rsp.11.2.0.4.j2
@@ -463,7 +463,11 @@ RECOVERYGROUPNAME={{ oracle_reco_dir_asm }}
 # Default value : "US7ASCII"
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
+{% if item.0.characterset is defined %}
+CHARACTERSET = "{{ item.0.characterset }}"
+{% else %}
 CHARACTERSET = "AL32UTF8"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : NATIONALCHARACTERSET
@@ -473,7 +477,11 @@ CHARACTERSET = "AL32UTF8"
 # Default value : "AL16UTF16"
 # Mandatory     : No
 #-----------------------------------------------------------------------------
+{% if item.0.ncharacterset is defined %}
+NATIONALCHARACTERSET= "{{ item.0.ncharacterset }}"
+{% else %}
 NATIONALCHARACTERSET= "AL16UTF16"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : REGISTERWITHDIRSERVICE

--- a/roles/oradb-create/templates/dbca-create-db.rsp.12.1.0.1.j2
+++ b/roles/oradb-create/templates/dbca-create-db.rsp.12.1.0.1.j2
@@ -560,7 +560,12 @@ RECOVERYGROUPNAME={{ oracle_reco_dir_asm }}
 # Default value : "US7ASCII"
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
+{% if item.0.characterset is defined %}
+CHARACTERSET = "{{ item.0.characterset }}"
+{% else %}
 CHARACTERSET = "AL32UTF8"
+{% endif %}
+
 
 #-----------------------------------------------------------------------------
 # Name          : NATIONALCHARACTERSET
@@ -570,7 +575,11 @@ CHARACTERSET = "AL32UTF8"
 # Default value : "AL16UTF16"
 # Mandatory     : No
 #-----------------------------------------------------------------------------
+{% if item.0.ncharacterset is defined %}
+NATIONALCHARACTERSET= "{{ item.0.ncharacterset }}"
+{% else %}
 NATIONALCHARACTERSET= "AL16UTF16"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : REGISTERWITHDIRSERVICE

--- a/roles/oradb-create/templates/dbca-create-db.rsp.12.1.0.2.j2
+++ b/roles/oradb-create/templates/dbca-create-db.rsp.12.1.0.2.j2
@@ -563,7 +563,12 @@ RECOVERYGROUPNAME={{ oracle_reco_dir_asm }}
 # Default value : "US7ASCII"
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
+#
+{% if item.0.characterset is defined %}
+CHARACTERSET = "{{ item.0.characterset }}"
+{% else %}
 CHARACTERSET = "AL32UTF8"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : NATIONALCHARACTERSET
@@ -573,7 +578,11 @@ CHARACTERSET = "AL32UTF8"
 # Default value : "AL16UTF16"
 # Mandatory     : No
 #-----------------------------------------------------------------------------
+{% if item.0.ncharacterset is defined %}
+NATIONALCHARACTERSET= "{{ item.0.ncharacterset }}"
+{% else %}
 NATIONALCHARACTERSET= "AL16UTF16"
+{% endif %}
 
 #-----------------------------------------------------------------------------
 # Name          : REGISTERWITHDIRSERVICE


### PR DESCRIPTION
The characterset and the ncharacterset can be defined for each database.
The old defaults are still used, until the parameter has been defined in
oracle_databases.

Example:
```
  oracle_databases:
    - home: db_home1
      oracle_db_name: ORCL
      characterset: WE8MSWIN1252
      ncharacterset: AL16UTF16
```