### PR TITLE
hostroles for compatibility against SLES12.1

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -39,3 +39,33 @@
       - python-devel
       - python-pip
       - libselinux-python
+
+  common_packages_sles:
+      - screen
+#      - facter
+      - procps
+      - module-init-tools
+      - ethtool
+      - bc
+#      - nc
+      - bind-utils
+#      - nfs-utils
+      - make
+      - sysstat
+      - unzip
+#      - openssh-clients
+#      - compat-libcap1
+#      - twm
+#      - collectl
+#      - rlwrap
+#      - tigervnc-server
+      - ntp
+      - expect
+#      - git
+      - lvm2
+#      - xfsprogs
+#      - btrfs-progs
+#      - tmux
+#      - python-devel
+#      - python-pip
+#      - libselinux-python

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,20 +20,27 @@
 
   - name: Install EPEL Repo
     yum: name={{ epel_rpm }} state=installed
-    when: configure_epel_repo
+    when: configure_epel_repo and ansible_os_family == 'RedHat'
     tags:
      - epelrepo
 
   - name: Get newest repo-file for OL6 (public-yum)
     get_url: dest={{ repo_dir}}/{{ ol6_repo_file }}  url=http://public-yum.oracle.com/{{ ol6_repo_file }} backup=yes
-    when: configure_public_yum_repo #and ansible_lsb.id == 'OracleServer' and ansible_lsb.major_release|int == 6
+    when: configure_public_yum_repo and ansible_lsb.id == 'OracleServer' and ansible_lsb.major_release|int == 6
     tags:
      - ol6repo
 
-  - name: Install common packages
+  - name: Install common packages OL/RHEL
     yum: name={{ item }} state=installed
     with_items: "{{common_packages }}"
-    when: install_os_packages
+    when: install_os_packages and ansible_pkg_mgr=="yum"
+    tags:
+      - commonpackages
+   
+  - name: Install common packages SLES12
+    zypper: name={{ item }} state=installed
+    with_items: "{{ common_packages_sles }}"
+    when: install_os_packages and ansible_pkg_mgr=="zypper" 
     tags:
       - commonpackages
 

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
   master_node: true
-  os_family_supported: "RedHat"
-  os_min_supported_version: "6.4"
+  os_family_supported: "{% if ansible_os_family == 'Suse' %}Suse{% else %}RedHat{% endif %}"
+  os_min_supported_version: "{% if ansible_os_family == 'Suse' %}12.1{% else %}6.4{% endif %}"
 
 # Users & groups
 
@@ -157,10 +157,49 @@
       - parted
       - nc
 
+  oracle_packages_sles:
+      - ksh
+      - binutils
+      - gcc
+      - gcc48
+      - glibc
+      - glibc-32bit
+      - glibc-devel
+      - glibc-devel-32bit
+      - mksh
+      - libaio1
+      - libaio-devel
+      - libcap1
+      - libstdc++48-devel
+      - libstdc++48-devel
+      - libstdc++6
+      - libstdc++6-32bit
+      - libstdc++-devel
+      - libstdc++-devel-32bit
+      - libgcc_s1
+      - libgcc_s1-32bit
+      - make
+      - sysstat
+      - xorg-x11-driver-video
+      - xorg-x11-server
+      - xorg-x11-essentials
+      - xorg-x11-Xvnc
+      - xorg-x11-fonts-core
+      - xorg-x11
+      - xorg-x11-server-extra
+      - xorg-x11-libs
+      - xorg-x11-fonts
+
   oracle_asm_packages:
       - "{{ asmlib_rpm }}"
       - oracleasm-support
       - kmod-oracleasm
+
+  oracle_asm_packages_sles:
+      - oracleasm-kmp-default
+      - oracleasm-kmp-xen
+      - oracleasm-support
+
 
 
   oracle_sysctl:

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -8,33 +8,45 @@
     tags:
      - oscheck
 
-  - name: Install packages required by Oracle
+  - name: Install packages required by Oracle on OL/RHEL
     yum: name={{ item }} state=installed
     with_items: "{{oracle_packages}}"
-    when: install_os_packages
-    tags: os_packages
+    when: install_os_packages and ansible_os_family == 'RedHat'
+    tags: os_packages, oscheck
 
-  - name: Install packages required by Oracle for ASMlib
+  - name: Install packages required by Oracle on SLES
+    zypper: name={{ item }} state=installed
+    with_items: "{{ oracle_packages_sles }}"
+    when: install_os_packages and ansible_os_family == 'Suse'
+    tags: os_packages, oscheck
+
+  - name: Install packages required by Oracle for ASMlib on OL/RHEL
     yum: name={{ item }} state=installed
     with_items: "{{oracle_asm_packages}}"
-    when: install_os_packages and device_persistence == 'asmlib'
-    tags: os_packages
+    when: install_os_packages and device_persistence == 'asmlib' and  ansible_os_family == 'RedHat'
+    tags: os_packages, oscheck
+
+  - name: Install packages required by Oracle for ASMlib on SLES
+    zypper: name={{ item }} state=installed
+    with_items: "{{ oracle_asm_packages_sles }}"
+    when: install_os_packages and device_persistence == 'asmlib' and  ansible_os_family == 'Suse'
+    tags: os_packages, oscheck, asm1
 
   - name: Disable iptables
     service: name=iptables state=stopped enabled=no
-    when: disable_iptables
+    when: disable_iptables and ansible_os_family == 'RedHat'
     tags: iptables
     register: iptables
 
   - name: Disable selinux (permanently)
     selinux: state=disabled
-    when: disable_selinux
+    when: disable_selinux and ansible_os_family == 'RedHat'
     tags: selinux
     register: selinux
 
   - name: Disable selinux (runtime)
     shell: setenforce 0
-    when: disable_selinux
+    when: disable_selinux and ansible_os_family == 'RedHat'
     tags: selinux
     ignore_errors: true
 
@@ -232,8 +244,14 @@
 
   - name: Oracle-recommended security limits
     template: src=oracle-seclimits.conf.j2 dest=/etc/security/limits.d/99-oracle-limits.conf backup=yes
+    when: ansible_os_family == 'RedHat'
     tags: seclimit
 
+  - name: Oracle-recommended security limits on SLES
+    pam_limits: domain=oracle limit_type={{ item.name.split(' ')[0] }} limit_item={{ item.name.split(' ')[1] }} value={{ item.value }}
+    with_items: "{{ oracle_seclimits }}"
+    when: ansible_os_family == 'Suse'
+    tags: seclimit
 
   - name: Count number of kernel lines that needs to be changed (numa=off transparent_hugepage=never)
     shell: cat /etc/grub.conf | grep title |wc -l
@@ -248,6 +266,7 @@
               regexp='(^\s+kernel(\s+(?!transparent_hugepage=never)[\w=/\-\.]+)*)\s*$'
               line='\1 transparent_hugepage=never'
     with_sequence: start=0 end={{ count.stdout }}
+    when: ansible_os_family == 'RedHat'
     tags: thpnuma
 
   - name: Disable Numa (in grub.conf)
@@ -259,7 +278,7 @@
               line='\1 numa=off'
     with_sequence: start=0 end={{ count.stdout }}
     tags: thpnuma
-    when: disable_numa_boot
+    when: disable_numa_boot and ansible_os_family == 'RedHat'
 
   - name: Disable Transparent Hugepages (runtime)
     shell: if test -f /sys/kernel/mm/transparent_hugepage/enabled; then echo never > /sys/kernel/mm/transparent_hugepage/enabled; fi;
@@ -267,14 +286,14 @@
 
   - name: Network | Setup ip-address for RAC Interconnect
     template: src=ifcfg-eth1.j2 dest=/etc/sysconfig/network-scripts/ifcfg-eth1 owner=root mode=0644
-    when: configure_interconnect and configure_cluster
+    when: configure_interconnect and configure_cluster and ansible_os_family == 'RedHat'
     tags:
      - eth1
     register: ic
 
   - name: Network | Bring up eth1
     service: name=network  state=restarted
-    when: configure_interconnect and configure_cluster and ic.changed
+    when: configure_interconnect and configure_cluster and ic.changed and ansible_os_family == 'RedHat'
     tags:
      - eth1
 


### PR DESCRIPTION
ansible-oracle gets compatibility against Suse Linux Enterprise Server.
Currently only 12.1 is supported.

The Firewall could not be disabled at the moment. You have to disable it
before using ansible-oracle. Normaly the installation of SLES12.1 disables
the sshd from outside and a change in the firewall is requirred. Please
disable it at this point.

Known Issues:
- missing oracleasm-support on SLES
SuSe includes the kernel modules for ASMlib but the oracleasm-support is
missing on the installation media. Please install it before using ansible-oracle
with enabled ASM support.
The RPM can be downloaded from Oracle:
http://www.oracle.com/technetwork/server-storage/linux/asmlib/sles12-2714894.html