### PR TITLE
use latest epel-release instead of fixed version

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -2,8 +2,8 @@
 ---
 
   epel_rpm: "{% if ansible_distribution_major_version|int==6%}{{ epel6_rpm }}{%elif ansible_distribution_major_version|int==7 %}{{ epel7_rpm }}{% else %}None{% endif %}"
-  epel7_rpm: http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
-  epel6_rpm: http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+  epel7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  epel6_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   ol_repo_file: "{% if ansible_distribution_major_version|int==6%}{{ ol6_repo_file }}{%elif ansible_distribution_major_version|int==7 %}{{ ol7_repo_file }}{% else %}None{% endif %}"
   ol6_repo_file: public-yum-ol6.repo
   ol7_repo_file: public-yum-ol7.repo


### PR DESCRIPTION
Use the latest epel-release package to download from fedoraproject.org instead of fixed version as these URL's get obsolete.