### PR TITLE
oracleasm: replace expect configuration with commandline

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -285,17 +285,9 @@
     file: dest={{ oracle_stage }}/udev mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
     when: device_persistence == 'udev'
 
-
-  - name: Asmlib | Configure Oracle Asmlib (1)
-    template: src=oracleasm-configure.expect.j2  dest={{ oracle_rsp_stage }}/asmlib-configure.expect owner=root mode=0777 force=yes
+  - name: Asmlib | Configure Oracle Asmlib
+    shell: "oracleasm configure -u {{ grid_install_user }} -g {{ asmdba_group }} -b -s y -e"
     when: device_persistence == 'asmlib'
-    tags:
-      - asmlibconfig
-    register: asmlib_expect_config
-
-  - name: Asmlib | Configure Oracle Asmlib (2)
-    shell: "{{ oracle_rsp_stage }}/asmlib-configure.expect"
-    when: device_persistence == 'asmlib' and asmlib_expect_config.changed
     tags:
       - asmlibconfig
 
@@ -307,7 +299,7 @@
 
   - name: Asmlib | Restart Asmlib
     service: name=oracleasm  state=restarted
-    when: device_persistence == 'asmlib' and asmlib_expect_config.changed
+    when: device_persistence == 'asmlib'
     tags:
       - asmlibconfig
 


### PR DESCRIPTION
The configuration with expect doesn't work with newer versions of
oracleasm. This has been changed to a direct configuration with
commandline parameter. This is not really known but easy to use
and availible for a very long time and should work with older
versions as well.