### PR TITLE
oraswgi-install: modified rules for 12.2.0.1

### DIFF
--- a/roles/oraswgi-install/tasks/12.2.0.1.yml
+++ b/roles/oraswgi-install/tasks/12.2.0.1.yml
@@ -20,7 +20,7 @@
     become_user: "{{ grid_install_user }}"
     tags:
     - oragridswunpack
-    when: checkgiinstall.stdout != "1" and oracle_install_version_gi == item.version and not oracle_sw_copy|bool and oracle_sw_unpack|bool
+    when: checkgiinstall.stdout != "1" and oracle_install_version_gi == item.version
 
   - name: Install cvuqdisk rpm
     yum: name="{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}" state=present


### PR DESCRIPTION
The way Oralce is installed has been changed with 12.2.
The easiest way is unarchiving the archive in the desired
ORACLE_HOME. That's why oracle_sw_copy and oracle_sw_unpack
are not needed in this situation.