### PR TITLE
added psmisc for 12.1+ opatch apply

### DIFF
--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -125,6 +125,7 @@
   oracle_packages:
       - libselinux-python
       - procps
+      - psmisc
       - module-init-tools
       - ethtool
       - bc


### PR DESCRIPTION
The RPM psmisc has been added for opatch.
'fuser' is needed for opatch from Version 12.1
Details: Support-Note 1581604.1