### PR TITLE
copy custom dbca_templatename to ORACLE_HOME

### DIFF
--- a/roles/oradb-create/tasks/main.yml
+++ b/roles/oradb-create/tasks/main.yml
@@ -17,6 +17,14 @@
     - checkifdbexists
     register: checkdbexist
 
+  - name: Copy custom dbca Templates to ORACLE_HOME/assistants/dbca/templates
+    template: src={{ item.0.dbca_templatename }} dest={{ oracle_home_db }}/assistants/dbca/templates/{{ item.0.dbca_templatename }} owner={{ oracle_user }} group={{ oracle_group }} mode=640
+    with_together:
+       - "{{oracle_databases}}"
+    when: item.0.dbca_templatename is defined and item.0.dbca_templatename not in('New_Database.dbt','General_Purpose.dbc','New_Database.dbt')
+    tags:
+      - customdbcatemplate
+
   - name: Create responsefile for dbca
     template: src=dbca-create-db.rsp.{{ item.0.oracle_version_db }}.j2 dest={{ oracle_rsp_stage }}/{{ oracle_dbca_rsp }}  owner={{ oracle_user }} group={{ oracle_group }} mode=644 backup=no
     #debug: var=msg


### PR DESCRIPTION
Custom dbca-templates can be used within dbca_templatename inside
oracle_databases. The file is copied as a jinja2 template when the
value is not 'New_Database.dbt' ,'General_Purpose.dbc' or
'New_Database.dbt'.