### PR TITLE
bugfix for templateName in dbca-create-db.rsp.12.2.0.1.j2

### DIFF
--- a/roles/oradb-create/templates/dbca-create-db.rsp.12.2.0.1.j2
+++ b/roles/oradb-create/templates/dbca-create-db.rsp.12.2.0.1.j2
@@ -232,9 +232,9 @@ nodelist={% for host in groups[hostgroup] -%} {{host}} {%- if not loop.last -%} 
 #-----------------------------------------------------------------------------
 #templateName={{ oracle_home_db }}/assistants/dbca/templates/General_Purpose.dbc
 {% if item.0.dbca_templatename is defined %}
-templateName="{{item.0.dbca_templatename}}"
+templateName={{item.0.dbca_templatename}}
 {% else %}
-templateName="{{dbca_templatename}}"
+templateName={{dbca_templatename}}
 {% endif %}
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The DBCA creates the following error when templateName with '"'
are used:
[FATAL] [DBT-10325] Template file option is not specified.