### PR TITLE
orahost: added support for physical Volume on Block Device without a …

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -182,6 +182,7 @@
         - filesystem
     tags: hostfs
 
+  # create partition only when device != pvname
   - name: filesystem | Create partition and pv
     shell:  parted -a optimal {{ item.1.device }} "mklabel gpt mkpart primary 1 -1"
     args:
@@ -189,7 +190,7 @@
     with_subelements:
         - "{{host_fs_layout}}"
         - disk
-    when: configure_host_disks
+    when: configure_host_disks and item.1.device != item.1.pvname
     tags: hostfs
 
   - name: filesystem | Create vg


### PR DESCRIPTION
…partition

Use same name for device and pvname to disable the creation
of a partition.

   host_fs_layout:
...
      disk:
        - {device: /dev/sde, pvname: /dev/sde}