### PR TITLE
oradb-create: added support for db_unique_name in 12.2

### DIFF
--- a/roles/oradb-create/defaults/main.yml
+++ b/roles/oradb-create/defaults/main.yml
@@ -38,6 +38,7 @@
   autostartup_service: false
 
   dbca_templatename: General_Purpose.dbc
+  dbca_initParams: "{% if '12.2' in item.0.oracle_version_db %} -initParams db_name={{item.0.oracle_db_name}}{% if item.0.oracle_db_unique_name is defined %},db_unique_name={{item.0.oracle_db_unique_name}}{% endif %}{% endif %}"
 
 # This is an example layout of a database installation
   oracle_databases:                                            # Dictionary describing the databases to be installed

--- a/roles/oradb-create/tasks/main.yml
+++ b/roles/oradb-create/tasks/main.yml
@@ -36,7 +36,7 @@
     - dbcaresponse
 
   - name: Create database(s)
-    shell: "time {{ oracle_home_db }}/bin/dbca -createDatabase -responseFile {{ oracle_rsp_stage }}/{{ oracle_dbca_rsp }} -silent -redoLogFileSize {{ item.0.redolog_size_in_mb }} "
+    shell: "time {{ oracle_home_db }}/bin/dbca -createDatabase -responseFile {{ oracle_rsp_stage }}/{{ oracle_dbca_rsp }} -silent -redoLogFileSize {{ item.0.redolog_size_in_mb }} {{ dbca_initParams }}"
     with_together:
        - "{{oracle_databases}}"
        - "{{checkdbexist.results}}"

--- a/roles/oradb-create/templates/dbca-create-db.rsp.12.2.0.1.j2
+++ b/roles/oradb-create/templates/dbca-create-db.rsp.12.2.0.1.j2
@@ -39,7 +39,7 @@ gdbName={{ item.0.oracle_db_name }}
 # Default value : <db_name> specified in GDBNAME
 # Mandatory     : No
 #-----------------------------------------------------------------------------
-sid={{ item.0.oracle_db_name }}
+sid={{ item.0.oracle_db_instance_name | default(item.0.oracle_db_name) }}
 
 #-----------------------------------------------------------------------------
 # Name          : databaseConfigType


### PR DESCRIPTION
The parameters for db_name and db_unique_name can't be
set with the response file. More details in MOS 2376010.1.

The support for db_unique_name is needed for a Data-Guard environment.
The instance_name could be defined as well.