### PR TITLE
oraswdb-install: Options in oracle executable are configurable for 12.2

### DIFF
--- a/roles/oraswdb-install/defaults/main.yml
+++ b/roles/oraswdb-install/defaults/main.yml
@@ -42,6 +42,8 @@
   configure_cluster: false
   autostartup_service: false # automatic startup/stop databases service
 
+  oracle_EE_options: "{% if item.oracle_version_db == '12.2.0.1' %}{{ oracle_EE_options_122 }}{% endif %}"
+
   glogin_default_nocdb:
         - "set sqlprompt \"_user @ _connect_identifier:>\""
         - "set time on"
@@ -74,3 +76,10 @@
       oracle_edition: EE
       oracle_db_name: orcl
       oracle_db_type: SI
+
+  # disable all options who requires extra licences
+  oracle_EE_options_122:
+    - {option: oaa          , state: !!str "disable" }
+    - {option: olap         , state: !!str "disable" }
+    - {option: partitioning , state: !!str "disable" }
+    - {option: rat          , state: !!str "disable" }

--- a/roles/oraswdb-install/tasks/main.yml
+++ b/roles/oraswdb-install/tasks/main.yml
@@ -180,6 +180,34 @@
     tags:
       - runroot
 
+  # oracle_EE_options = '' => Nothing to do
+  - name: set facts for chopt
+    no_log: true
+    set_fact:
+      oracle_databaseschopt: "{{oracle_databaseschopt|default([]) + [ item | combine({'oracle_EE_options': oracle_EE_options})]}}"
+    with_items:
+     - "{{oracle_databases}}"
+    when: oracle_EE_options != ''
+    tags:
+      - dbchopt
+
+  # licence options in 12.2 must be changed by chopt
+  # => use this method for all >= 11.2 (Doc ID 948061.1)
+  # test -f => reduce number of executions when > 1 database in oracle_databases
+  - name: Change Database options with chopt
+    shell: "test -f {{ oracle_home_db }}/install/{{item.1.state}}_{{item.1.option}}.log || {{ oracle_home_db }}/bin/chopt {{item.1.state}} {{item.1.option}} ; echo "
+    debugger: on_failed
+    with_subelements:
+      - "{{oracle_databaseschopt}}"
+      - oracle_EE_options
+    become: yes
+    become_user: "{{ oracle_user }}"
+    register: choptout
+    changed_when: '"Writing" in choptout.stdout'
+    when: item.0.oracle_edition == 'EE' and item.1.option is defined
+    tags:
+      - dbchopt
+
   - name: Generate glogin.sql
     template: src=glogin.sql.j2 dest="{{ oracle_home_db }}/sqlplus/admin/glogin.sql" backup=yes
     with_items:


### PR DESCRIPTION
The licensed options in the Oracle binaries are configurable.
The following variable could be used to change the default:

  oracle_EE_options_122:
    - {option: oaa          , state: !!str "disable" }
    - {option: olap         , state: !!str "disable" }
    - {option: partitioning , state: !!str "disable" }
    - {option: rat          , state: !!str "disable" }

To activate an option set state to 'enable'.
More details could be found in Doc ID 948061.1

The task only changes an option, if a file for
 $ORACLE_HOME/install/<enable|disable>_<option>.log is not existing!