### PR TITLE
Bugfix: the supported OS check should use version semantics

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -5,7 +5,7 @@
     assert:
       that:
         - "ansible_os_family == '{{ os_family_supported }}'"
-        - "ansible_distribution_version >= '{{ os_min_supported_version }}'"
+        - "ansible_distribution_version | version_compare('{{ os_min_supported_version }}', '>=')"
     tags:
      - oscheck
 


### PR DESCRIPTION
As soon as you upgrade to Oracle Linux 6.10, the version check will fail.