### PR TITLE
oraswdb-install: save detection of init or systemd from fact

### DIFF
--- a/roles/oraswdb-install/defaults/main.yml
+++ b/roles/oraswdb-install/defaults/main.yml
@@ -39,6 +39,9 @@
   is_sw_source_local: true
   configure_cluster: false
   autostartup_service: false # automatic startup/stop databases service
+  hostinitdaemon: "{% if    ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 7   %}systemd
+                   {%- elif ansible_os_family == 'Suse'   and ansible_distribution_major_version | int >= 12 %}systemd
+                   {%- else %}init{% endif %}"
 
   oracle_directories:
           - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775 }

--- a/roles/oraswdb-install/tasks/init.yml
+++ b/roles/oraswdb-install/tasks/init.yml
@@ -2,11 +2,11 @@
   template: src=dbora.j2 dest=/etc/init.d/dbora owner=root mode=750
   become: true
   with_items: "{{oracle_databases}}"
-  when: autostartup_service and checkinitdaemons.stdout == "init"
+  when: autostartup_service and hostinitdaemon == "init"
   tags: autostartup_service
 
 - name: install-home-db | Register dbora service (init.d)
   command: "chkconfig --add dbora"
   become: true
-  when: autostartup_service and checkinitdaemons.stdout == "init"
+  when: autostartup_service and hostinitdaemon == "init"
   tags: autostartup_service

--- a/roles/oraswdb-install/tasks/main.yml
+++ b/roles/oraswdb-install/tasks/main.yml
@@ -92,13 +92,6 @@
     tags:
       - nfsunmountdb
 
-  - name: install-home-db | Check if systemd or init.d is used
-    shell: ps -e|grep " 1 ?"|cut -d " " -f15
-    tags:
-    - checkinitdaemons
-    - autostartup_service
-    register: checkinitdaemons
+  - include_tasks: "{{ hostinitdaemon }}.yml"
     when: autostartup_service
-
-  - include_tasks: "{{ checkinitdaemons.stdout }}.yml"
-    when: autostartup_service
+    tags: autostartup_service

--- a/roles/oraswdb-install/tasks/systemd.yml
+++ b/roles/oraswdb-install/tasks/systemd.yml
@@ -2,10 +2,10 @@
   template: src=oracle-rdbms-service.j2 dest=/etc/systemd/system/oracle-rdbms.service owner=root
   become: true
   with_items: "{{oracle_databases}}"
-  when: autostartup_service and checkinitdaemons.stdout == "systemd"
+  when: autostartup_service and hostinitdaemon == "systemd"
   tags: autostartup_service
 
 - name: install-home-db | Register oracle-rdbms service (system.d)
   systemd: name=oracle-rdbms daemon_reload=yes enabled=yes
-  when: autostartup_service and checkinitdaemons.stdout == "systemd" #and ansible_version.full >= "2.2"
+  when: autostartup_service and hostinitdaemon == "systemd"
   tags: autostartup_service


### PR DESCRIPTION
The detection of init or systemd has been changed.
systemd: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 7
systemd: ansible_os_family == 'Suse'   and ansible_distribution_major_version | int >= 12

All other versions will use init.

The variable hostinitdaemon could be used to set a fixed value.