### PR TITLE
orahost: Make device_persistence consistent against other roles

### DIFF
--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -72,7 +72,7 @@
   configure_cluster: false
   oracle_stage: /u01/stage
   oracle_rsp_stage: "{{ oracle_stage }}/rsp"
-  device_persistence: udev
+  device_persistence: asmlib
   install_os_packages: true
   disable_selinux: true
   disable_firewall: true


### PR DESCRIPTION
All other roles use device_persistence: asmlib as default except
orahost. This has been fixed.