### PR TITLE
oraswdb-install: Options in oracle executable are configurable

### DIFF
--- a/roles/oraswdb-install/defaults/main.yml
+++ b/roles/oraswdb-install/defaults/main.yml
@@ -28,8 +28,21 @@
   oracle_rsp_stage: "{{ oracle_stage }}/rsp"
   oracle_inventory_loc: /u01/app/oraInventory
   oracle_base: /u01/app/oracle
-  oracle_home_db: "{% if dbh is defined %}{% if dbh.oracle_home is defined %}{{ dbh.oracle_home }}{% else %}{{ oracle_base}}/{{ dbh.oracle_version_db }}/{{ dbh.home }}{% endif %}{% elif item.0 is defined %}{% if item.0.oracle_home is defined %}{{ item.0.oracle_home}}{% else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}{% endif %}{% elif item is defined %}{% if item.oracle_home is defined %}{{ item.oracle_home}}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}{% endif %}"
-  #oracle_home_db: "{% if item is defined %}{% if item.oracle_home is defined %}{{ item.oracle_home}}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}{% else %}{% if dbh.oracle_home is defined %}{{ dbh.oracle_home }}{% else %}{{ oracle_base }}/{{ dbh.oracle_version_db }}/{{ dbh.home }}{% endif %}{% endif %}"
+
+  oracle_home_db: "{% if dbh is defined %}
+                     {%- if dbh.oracle_home is defined %}{{ dbh.oracle_home }}
+                     {%- else %}{{ oracle_base}}/{{ dbh.oracle_version_db }}/{{ dbh.home }}
+                     {%- endif %}
+                   {%- elif item.0 is defined %}
+                     {%- if item.0.oracle_home is defined %}{{ item.0.oracle_home}}
+                     {%- else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}
+                     {%- endif %}
+                   {%- elif item is defined %}
+                     {%- if item.oracle_home is defined %}{{ item.oracle_home}}
+                     {%- else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}
+                     {%- endif %}
+                   {%- endif %}"
+
 
   oracle_profile_name: "{% if item is defined %}{% if item.oracle_home is defined %}.profile_{{ item.oracle_home |basename}}_{{ item.oracle_version_db}}{% elif item.home is defined %}.profile_{{ item.home }}_{{item.oracle_version_db}}{% elif item.oracle_home is defined %}.profile_{{item.oracle_home |basename}}_{{item.oracle_version_db}}{% endif %}{% else %}{% if dbh.oracle_home is defined %}.profile_{{ dbh.oracle_home |basename}}_{{ dbh.oracle_version_db}}{% elif dbh.home is defined %}.profile_{{ dbh.home }}_{{dbh.oracle_version_db}}{% else %}.profile_{{dbh.home}}_{{dbh.oracle_db_name}}{% endif%}{%endif %}"    # Name of profile-file. Sets up the environment for that ORACLE_HOME
   oracle_hostname: "{{ ansible_fqdn }}"                            # Full (FQDN) name of the host
@@ -42,6 +55,34 @@
   hostinitdaemon: "{% if    ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 7   %}systemd
                    {%- elif ansible_os_family == 'Suse'   and ansible_distribution_major_version | int >= 12 %}systemd
                    {%- else %}{% if ansible_service_mgr is defined %}{{ ansible_service_mgr }}{% else %}init{% endif %}{% endif %}"
+
+  oracle_EE_options: "{%- if dbh.oracle_version_db in ('12.2.0.1') %}{{ oracle_EE_options_122 }}
+                      {%- elif dbh.oracle_version_db in ('12.1.0.1', '12.1.0.2') %}{{oracle_EE_options_121}}
+                      {%- elif dbh.oracle_version_db == '11.2.0.4' %}{{oracle_EE_options_112}}
+                      {%- endif %}"
+  oracle_EE_option_state: "{% if item.state is defined and item.state %}enable{% else %}disable{% endif %}"
+
+  # disable all options who requires extra licences
+  oracle_EE_options_112:
+    - {option: dm           , state: false }
+    - {option: dv           , state: false }
+    - {option: lbac         , state: false }
+    - {option: olap         , state: false }
+    - {option: partitioning , state: false }
+    - {option: rat          , state: false }
+
+  oracle_EE_options_121:
+    - {option: dm           , state: false }
+    - {option: olap         , state: false }
+    - {option: partitioning , state: false }
+    - {option: rat          , state: false }
+
+  oracle_EE_options_122:
+    - {option: oaa          , state: false }
+    - {option: olap         , state: false }
+    - {option: partitioning , state: false }
+    - {option: rat          , state: false }
+
 
   oracle_directories:
           - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775 }

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -48,6 +48,25 @@
    - oradbinstall
   ignore_errors: true
 
+# oracle_EE_options = '' => Nothing to do
+# licence options in 11.2+ must be changed by chopt
+# => use this method for all >= 11.2 (Doc ID 948061.1)
+# test -f => reduce number of executions when > 1 database in oracle_databases for same ORACLE_HOME
+- name: Change Database options with chopt
+  shell: "test -f {{ oracle_home_db }}/install/{{oracle_EE_option_state}}_{{item.option}}.log || {{ oracle_home_db }}/bin/chopt {{oracle_EE_option_state}} {{item.option}}"
+  debugger: on_failed
+  with_items:
+    - "{{oracle_EE_options}}"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: choptout
+  changed_when: '"Writing" in choptout.stdout'
+  when: dbh.oracle_edition == 'EE' and oracle_EE_options is defined
+  loop_control:
+    label: "{{ oracle_home_db }} {{oracle_EE_option_state}} {{item.option}}"
+  tags:
+    - dbchopt
+
 - name: install-home-db | Run root script after installation
   shell: "{{ oracle_home_db }}/root.sh"
   run_once: "{{ configure_cluster}}"


### PR DESCRIPTION
The licensed options in the Oracle binaries are configurable.
All options are disabled by default!

The following variable could be used to change the default:

```
  oracle_EE_options_112:
    - {option: dm           , state: false }
    - {option: dv           , state: false }
    - {option: lbac         , state: false }
    - {option: olap         , state: false }
    - {option: partitioning , state: false }
    - {option: rat          , state: false }

  oracle_EE_options_121:
    - {option: dm           , state: false }
    - {option: olap         , state: false }
    - {option: partitioning , state: false }
    - {option: rat          , state: false }

  oracle_EE_options_122:
    - {option: oaa          , state: false }
    - {option: olap         , state: false }
    - {option: partitioning , state: false }
    - {option: rat          , state: false }
```

To activate an option set state to 'True'.
More details could be found in Doc ID 948061.1

The task only changes an option, if a file for
$ORACLE_HOME/install/<enable|disable>_.log is not existing!