### PR TITLE
sufficient permissions to access the inventory '/u01/app/oraInventory'

### DIFF
--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -30,6 +30,7 @@
   grid_install_user: "{% if role_separation %}{{grid_user }}{% else %}{{ oracle_user }}{% endif %}"
   configure_oracle_sudo: true
   etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ansible_all_ipv4_addresses[1]}}{% else %}{{ansible_default_ipv4.address}}{%endif%}"
+  oracle_inventory_loc: /u01/app/oraInventory
 
   oracle_user_home: "/home/{{ oracle_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
   grid_user_home: "/home/{{ grid_install_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -247,6 +247,10 @@
         - filesystem
     tags: hostfs
 
+  - name: filesystem | Create directory for oraInventory
+    file: path={{ oracle_inventory_loc }} state=directory owner={{ oracle_user }} group={{ oracle_group }} mode=775
+    tags: hostfs
+
   - name: Oracle-recommended kernel settings
     sysctl: name={{ item.name }} value="{{ item.value }}" state=present reload=yes ignoreerrors=yes
     with_items: "{{oracle_sysctl}}"


### PR DESCRIPTION
A problem with creating the inventory occurs when host_fs_layout has
a definition with /u01 and /u01/app/oracle/diag. The result is a missing
permission to create /u01/app/oraInventory.
This has been fixed.