### PR TITLE
oradb-manage-*: support for service_name + listener_port

### DIFF
--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -2,7 +2,7 @@
 
   hostgroup: "{{ group_names[0] }}"
   oracle_dbca_rsp: "dbca_{{ dbh.oracle_db_name }}.rsp"        # Name of responsefile used by dbca. One per database
-  oracle_netca_rsp: "netca_{{ item.home }}_{{ listener_name_template }}.rsp"
+  oracle_netca_rsp: "netca_{{ dbh.home }}_{{ listener_name_template }}.rsp"
   oracle_user: oracle                        # User that will own the Oracle Installations.
   oracle_user_home: "/home/{{ oracle_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
   oracle_group: oinstall                          # Primary group for oracle_user.
@@ -52,10 +52,10 @@
   oracle_gi_cluster_type: STANDARD
   hostgroup_hub: "{{ hostgroup }}-hub"
   hostgroup_leaf: "{{ hostgroup }}-leaf"
-  create_listener: "{% if oracle_install_option_gi is defined %}False{% elif oracle_install_option_gi is undefined %}{% if item.listener_name is defined %}True{% else %}False{% endif %}{% endif %}"
-  listener_name_template: "{% if item.listener_name is defined %}{{ item.listener_name }}{% else %}{{ listener_name }}{% endif %}"
-  listener_protocols_template: "{% if item.listener_protocols is defined %}{{ item.listener_protocols }}{% else %}{{ listener_protocols }}{% endif %}"
-  listener_port_template: "{% if item.listener_port is defined %}{{ item.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+  create_listener: "{% if oracle_install_option_gi is defined %}False{% elif oracle_install_option_gi is undefined %}{% if dbh.listener_name is defined %}True{% else %}False{% endif %}{% endif %}"
+  listener_name_template: "{% if dbh.listener_name is defined %}{{ dbh.listener_name }}{% else %}{{ listener_name }}{% endif %}"
+  listener_protocols_template: "{% if dbh.listener_protocols is defined %}{{ dbh.listener_protocols }}{% else %}{{ listener_protocols }}{% endif %}"
+  listener_port_template: "{% if dbh.listener_port is defined %}{{ dbh.listener_port }}{% else %}{{ listener_port }}{% endif %}"
   listener_name: LISTENER
   listener_protocols: TCP
   listener_port: 1521

--- a/roles/oradb-manage-db/tasks/listener.yml
+++ b/roles/oradb-manage-db/tasks/listener.yml
@@ -1,19 +1,17 @@
 - name: listener | Create responsefile for listener configuration
-  template: src=netca.rsp.{{ item.oracle_version_db }}.j2 dest={{ oracle_rsp_stage }}/{{ oracle_netca_rsp }}
+  template: src=netca.rsp.{{ dbh.oracle_version_db }}.j2 dest={{ oracle_rsp_stage }}/{{ oracle_netca_rsp }}
   become: true
   become_user: "{{ oracle_user }}"
-  with_items:
-      - "{{ oracle_databases }}"
   when: create_listener
+#  when: create_listener and oracle_install_option_gi is defined and oracle_install_option_gi
   tags: responsefile_netca, listener_install
 
 - name: listener | Create listener
   shell: "{{ oracle_home_db }}/bin/netca -responseFile {{ oracle_rsp_stage }}/{{ oracle_netca_rsp }} -silent"
-  with_items:
-      - "{{ oracle_databases }}"
   args:
       creates: "{{ oracle_home_db }}/network/admin/listener.ora"
   become: true
   become_user: "{{ oracle_user }}"
   when: create_listener
+#  when: create_listener and oracle_install_option_gi is defined and oracle_install_option_gi
   tags: listener_install

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -8,7 +8,11 @@
   tags: set_fact
 
 - include_tasks: listener.yml
-  when: create_listener
+  with_items:
+      - "{{ oracle_databases }}"
+  loop_control:
+    loop_var: dbh
+  when: create_listener and oracle_databases is defined
   tags: listener
 
 - name: manage-db | Add change-pdb script

--- a/roles/oradb-manage-db/tasks/manage-db.yml
+++ b/roles/oradb-manage-db/tasks/manage-db.yml
@@ -71,6 +71,7 @@
 - name: manage-db | create/manage database
   oracle_db:
         oracle_home={{ oracle_home_db}}
+        port={{ listener_port_template }}
         sys_password={{ dbca_sys_pass }}
         db_name={{ dbh.oracle_db_name }}
         db_unique_name={{ dbh.oracle_db_unique_name |default(omit) }}
@@ -117,6 +118,7 @@
 - name: manage-db | remove database
   oracle_db:
         oracle_home={{ oracle_home_db }}
+        port={{ listener_port_template }}
         sys_password={{ dbca_sys_pass }}
         db_name={{ dbh.oracle_db_name }}
         state={{ dbh.state}}

--- a/roles/oradb-manage-grants/defaults/main.yml
+++ b/roles/oradb-manage-grants/defaults/main.yml
@@ -9,6 +9,13 @@ db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_
 db_password_pdb: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][db_user] is defined%}{{dbpasswords[item.0.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_mode: sysdba
 
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 user_cdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{dbpasswords[item.0.oracle_db_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 user_pdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] is defined%}{{dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-grants/tasks/main.yml
+++ b/roles/oradb-manage-grants/tasks/main.yml
@@ -6,7 +6,7 @@
           state={{ item.1.state }}
           grants={{ item.1.grants }}
           hostname={{ ansible_hostname }}
-          service_name={{ item.0.oracle_db_name }}
+          service_name={{ db_service_name }}
           user={{ db_user }}
           password={{ db_password_cdb}}
           mode={{ db_mode }}
@@ -48,7 +48,7 @@
           state={{ item.1.state }}
           grants={{ item.1.grants }}
           hostname={{ ansible_hostname }}
-          service_name={{ item.0.oracle_db_name }}
+          service_name={{ db_service_name }}
           user={{ db_user }}
           password={{ db_password_cdb}}
           mode={{ db_mode }}

--- a/roles/oradb-manage-parameters/defaults/main.yml
+++ b/roles/oradb-manage-parameters/defaults/main.yml
@@ -17,6 +17,9 @@ db_service_name: "{% if item.0 is defined %}
                     {%- endif %}
                   {%- endif %}"
 
+listener_port_template: "{% if item.0.listener_port is defined %}{{ item.0.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+listener_port: 1521
+
 oracle_env:
        ORACLE_HOME: "{{ oracle_home_db }}"
        LD_LIBRARY_PATH: "{{ oracle_home_db }}/lib"

--- a/roles/oradb-manage-parameters/defaults/main.yml
+++ b/roles/oradb-manage-parameters/defaults/main.yml
@@ -10,6 +10,13 @@ db_password_pdb: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is de
 
 db_mode: sysdba
 
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 oracle_env:
        ORACLE_HOME: "{{ oracle_home_db }}"
        LD_LIBRARY_PATH: "{{ oracle_home_db }}/lib"

--- a/roles/oradb-manage-parameters/tasks/main.yml
+++ b/roles/oradb-manage-parameters/tasks/main.yml
@@ -2,6 +2,7 @@
   oracle_parameter:
         hostname={{ ansible_hostname }}
         service_name={{ db_service_name }}
+        port={{ listener_port_template }}
         user={{ db_user }}
         password={{ db_password_cdb }}
         mode={{ db_mode }}
@@ -25,6 +26,7 @@
   oracle_parameter:
         hostname={{ ansible_hostname }}
         service_name={{ item.0.pdb_name }}
+        port={{ listener_port_template }}
         user={{ db_user }}
         password={{ db_password_pdb }}
         mode={{ db_mode }}

--- a/roles/oradb-manage-parameters/tasks/main.yml
+++ b/roles/oradb-manage-parameters/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Manage parameters (db/cdb)
   oracle_parameter:
         hostname={{ ansible_hostname }}
-        service_name={{ item.0.oracle_db_name }}
+        service_name={{ db_service_name }}
         user={{ db_user }}
         password={{ db_password_cdb }}
         mode={{ db_mode }}

--- a/roles/oradb-manage-pdb/defaults/main.yml
+++ b/roles/oradb-manage-pdb/defaults/main.yml
@@ -10,6 +10,9 @@ db_mode: sysdba
 pdbadmin_user: pdbadmin
 pdbadmin_password: "{% if dbpasswords is defined and dbpasswords[item[1].cdb] is defined and dbpasswords[item[1].cdb][item[1].pdb_name] is defined and dbpasswords[item[1].cdb][item[1].pdb_name][pdbadmin_user] is defined%}{{dbpasswords[item[1].cdb][item[1].pdb_name][pdbadmin_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 
+listener_port_template: "{% if item.0.listener_port is defined %}{{ item.0.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+listener_port: 1521
+
 oracle_env:
        ORACLE_HOME: "{{ oracle_home_db }}"
        LD_LIBRARY_PATH: "{{ oracle_home_db }}/lib"

--- a/roles/oradb-manage-pdb/tasks/main.yml
+++ b/roles/oradb-manage-pdb/tasks/main.yml
@@ -32,7 +32,9 @@
       username={{ db_user | default('sys') }}
       password={{ db_password_cdb }}
       mode={{ db_mode }}
-      service_name={{ item[1].cdb }}
+      service_name={{ item[0].oracle_db_unique_name | default(item[0].oracle_db_name) }}
+      port={{ listener_port_template }}
+listener_port
       state={{ item[1].state |default(omit) }}
   environment: "{{oracle_env}}"
   run_once: "{{ configure_cluster}}"

--- a/roles/oradb-manage-pdb/tasks/main.yml
+++ b/roles/oradb-manage-pdb/tasks/main.yml
@@ -34,7 +34,6 @@
       mode={{ db_mode }}
       service_name={{ item[0].oracle_db_unique_name | default(item[0].oracle_db_name) }}
       port={{ listener_port_template }}
-listener_port
       state={{ item[1].state |default(omit) }}
   environment: "{{oracle_env}}"
   run_once: "{{ configure_cluster}}"

--- a/roles/oradb-manage-redo/defaults/main.yml
+++ b/roles/oradb-manage-redo/defaults/main.yml
@@ -3,6 +3,14 @@ oracle_base: /u01/app/oracle
 oracle_home_db: "{% if dbh is defined %}{% if dbh.oracle_home is defined %}{{ dbh.oracle_home }}{% else %}{{ oracle_base}}/{{ dbh.oracle_version_db }}/{{ dbh.home }}{% endif %}{% elif item.0 is defined %}{% if item.0.oracle_home is defined %}{{ item.0.oracle_home}}{% else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}{% endif %}{% elif item is defined %}{% if item.oracle_home is defined %}{{ item.oracle_home}}{% else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}{% endif %}{% endif %}"
 db_user: system
 db_mode: normal
+
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 #db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.cdb] is defined and dbpasswords[item.cdb][db_user] is defined%}{{dbpasswords[item.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.oracle_db_name] is defined and dbpasswords[item.oracle_db_name][db_user] is defined%}{{dbpasswords[item.oracle_db_name][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-redo/defaults/main.yml
+++ b/roles/oradb-manage-redo/defaults/main.yml
@@ -11,6 +11,9 @@ db_service_name: "{% if item.0 is defined %}
                     {%- endif %}
                   {%- endif %}"
 
+listener_port_template: "{% if item.listener_port is defined %}{{ item.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+listener_port: 1521
+
 #db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.cdb] is defined and dbpasswords[item.cdb][db_user] is defined%}{{dbpasswords[item.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.oracle_db_name] is defined and dbpasswords[item.oracle_db_name][db_user] is defined%}{{dbpasswords[item.oracle_db_name][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-redo/tasks/main.yml
+++ b/roles/oradb-manage-redo/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Manage redologs
   oracle_redo:
         hostname={{ ansible_hostname }}
-        service_name={{ item.oracle_db_name }}
+        service_name={{ db_service_name }}
         user={{ db_user }}
         password={{ db_password_cdb }}
         mode={{ db_mode }}

--- a/roles/oradb-manage-redo/tasks/main.yml
+++ b/roles/oradb-manage-redo/tasks/main.yml
@@ -2,6 +2,7 @@
   oracle_redo:
         hostname={{ ansible_hostname }}
         service_name={{ db_service_name }}
+        port={{ listener_port_template }}
         user={{ db_user }}
         password={{ db_password_cdb }}
         mode={{ db_mode }}

--- a/roles/oradb-manage-roles/defaults/main.yml
+++ b/roles/oradb-manage-roles/defaults/main.yml
@@ -9,6 +9,13 @@ db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_
 db_password_pdb: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][db_user] is defined%}{{dbpasswords[item.0.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_mode: sysdba
 
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 user_cdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{dbpasswords[item.0.oracle_db_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 user_pdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] is defined%}{{dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-roles/defaults/main.yml
+++ b/roles/oradb-manage-roles/defaults/main.yml
@@ -16,6 +16,9 @@ db_service_name: "{% if item.0 is defined %}
                     {%- endif %}
                   {%- endif %}"
 
+listener_port_template: "{% if item.0.listener_port is defined %}{{ item.0.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+listener_port: 1521
+
 user_cdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{dbpasswords[item.0.oracle_db_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 user_pdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] is defined%}{{dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-roles/tasks/main.yml
+++ b/roles/oradb-manage-roles/tasks/main.yml
@@ -5,7 +5,7 @@
           role={{ item.1.name }}
           state={{ item.1.state }}
           hostname={{ ansible_hostname }}
-          service_name={{ item.0.oracle_db_name }}
+          service_name={{ db_service_name }}
           user={{ db_user }}
           password={{ db_password_cdb}}
           mode={{ db_mode }}

--- a/roles/oradb-manage-roles/tasks/main.yml
+++ b/roles/oradb-manage-roles/tasks/main.yml
@@ -5,6 +5,7 @@
           role={{ item.1.name }}
           state={{ item.1.state }}
           hostname={{ ansible_hostname }}
+          port={{ listener_port_template }}
           service_name={{ db_service_name }}
           user={{ db_user }}
           password={{ db_password_cdb}}
@@ -25,6 +26,7 @@
           role={{ item.1.name }}
           state={{ item.1.state }}
           hostname={{ ansible_hostname }}
+          port={{ listener_port_template }}
           service_name={{ item.0.pdb_name }}
           user={{ db_user }}
           password={{ db_password_pdb}}

--- a/roles/oradb-manage-services/defaults/main.yml
+++ b/roles/oradb-manage-services/defaults/main.yml
@@ -11,6 +11,13 @@ db_user: system
 db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][db_user] is defined%}{{dbpasswords[item.0.oracle_db_name][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_password_pdb: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][db_user] is defined%}{{dbpasswords[item.0.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 oracle_env:
        ORACLE_HOME: "{{ oracle_home_db }}"
        LD_LIBRARY_PATH: "{{ oracle_home_db }}/lib"

--- a/roles/oradb-manage-services/tasks/main.yml
+++ b/roles/oradb-manage-services/tasks/main.yml
@@ -11,7 +11,7 @@
         host={{ansible_hostname}}
         un={{ db_user }}
         pw={{ db_password_cdb }}
-        sn={{ item.0.oracle_db_name }}
+        sn={{ db_service_name }}
   environment: "{{oracle_env}}"
   run_once: "{{ configure_cluster }}"
   with_subelements:
@@ -57,7 +57,7 @@
          host={{ ansible_hostname }}
          un={{ db_user }}
          pw={{ db_password_cdb }}
-         sn={{ item.0.oracle_db_name }}
+         sn={{ db_service_name }}
   environment: "{{oracle_env}}"
   run_once: "{{ configure_cluster }}"
   with_subelements:
@@ -99,7 +99,7 @@
          host={{ ansible_hostname }}
          un={{ db_user }}
          pw={{ db_password_cdb }}
-         sn={{ item.0.oracle_db_name }}
+         sn={{ db_service_name }}
   environment: "{{oracle_env}}"
   run_once: "{{ configure_cluster }}"
   with_subelements:
@@ -141,7 +141,7 @@
          host={{ ansible_hostname }}
          un={{ db_user }}
          pw={{ db_password_cdb }}
-         sn={{ item.0.oracle_db_name }}
+         sn={{ db_service_name }}
   environment: "{{oracle_env}}"
   run_once: "{{ configure_cluster }}"
   with_subelements:

--- a/roles/oradb-manage-tablespace/defaults/main.yml
+++ b/roles/oradb-manage-tablespace/defaults/main.yml
@@ -6,6 +6,13 @@ db_user: system
 db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][db_user] is defined%}{{dbpasswords[item.0.oracle_db_name][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_password_pdb: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][db_user] is defined%}{{dbpasswords[item.0.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 oracle_env:
        ORACLE_HOME: "{{ oracle_home_db }}"
        LD_LIBRARY_PATH: "{{ oracle_home_db }}/lib"

--- a/roles/oradb-manage-tablespace/defaults/main.yml
+++ b/roles/oradb-manage-tablespace/defaults/main.yml
@@ -13,6 +13,9 @@ db_service_name: "{% if item.0 is defined %}
                     {%- endif %}
                   {%- endif %}"
 
+listener_port_template: "{% if item.0.listener_port is defined %}{{ item.0.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+listener_port: 1521
+
 oracle_env:
        ORACLE_HOME: "{{ oracle_home_db }}"
        LD_LIBRARY_PATH: "{{ oracle_home_db }}/lib"

--- a/roles/oradb-manage-tablespace/tasks/main.yml
+++ b/roles/oradb-manage-tablespace/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Manage tablespaces (db/cdb)
   oracle_tablespace:
         hostname={{ ansible_hostname }}
+        port={{ listener_port_template }}
         service_name={{ db_service_name }}
         user={{ db_user }}
         password={{ db_password_cdb}}
@@ -27,6 +28,7 @@
 - name: Manage tablespaces (pdb)
   oracle_tablespace:
         hostname={{ ansible_hostname }}
+        port={{ listener_port_template }}
         service_name={{ item.0.pdb_name }}
         user={{ db_user }}
         password={{ db_password_pdb}}

--- a/roles/oradb-manage-tablespace/tasks/main.yml
+++ b/roles/oradb-manage-tablespace/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Manage tablespaces (db/cdb)
   oracle_tablespace:
         hostname={{ ansible_hostname }}
-        service_name={{ item.0.oracle_db_name }}
+        service_name={{ db_service_name }}
         user={{ db_user }}
         password={{ db_password_cdb}}
         tablespace={{ item.1.name }}

--- a/roles/oradb-manage-users/defaults/main.yml
+++ b/roles/oradb-manage-users/defaults/main.yml
@@ -9,6 +9,13 @@ db_password_cdb: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_
 db_password_pdb: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][db_user] is defined%}{{dbpasswords[item.0.cdb][db_user]}}{% else %}{{ default_dbpass}}{% endif%}"
 db_mode: sysdba
 
+db_service_name: "{% if item.0 is defined %}
+                    {%- if item.0.oracle_db_unique_name is defined %}{{ item.0.oracle_db_unique_name }}
+                    {%- elif item.0.oracle_db_instance_name is defined %}{{ item.0.oracle_db_instance_name }}
+                    {%- else %}{{ item.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
 user_cdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{dbpasswords[item.0.oracle_db_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 user_pdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] is defined%}{{dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-users/defaults/main.yml
+++ b/roles/oradb-manage-users/defaults/main.yml
@@ -16,6 +16,9 @@ db_service_name: "{% if item.0 is defined %}
                     {%- endif %}
                   {%- endif %}"
 
+listener_port_template: "{% if item.0.listener_port is defined %}{{ item.0.listener_port }}{% else %}{{ listener_port }}{% endif %}"
+listener_port: 1521
+
 user_cdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name] is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{dbpasswords[item.0.oracle_db_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 user_pdb_password: "{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] is defined%}{{dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]}}{% else %}{{ default_dbpass}}{% endif%}"
 

--- a/roles/oradb-manage-users/tasks/main.yml
+++ b/roles/oradb-manage-users/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Manage users (db/cdb)
   oracle_user:
           hostname={{ ansible_hostname }}
-          service_name={{ item.0.oracle_db_name }}
+          service_name={{ db_service_name }}
           user={{ db_user }}
           password={{ db_password_cdb }}
           mode="{{ db_mode}}"

--- a/roles/oradb-manage-users/tasks/main.yml
+++ b/roles/oradb-manage-users/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Manage users (db/cdb)
   oracle_user:
           hostname={{ ansible_hostname }}
+          port={{ listener_port_template }}
           service_name={{ db_service_name }}
           user={{ db_user }}
           password={{ db_password_cdb }}
@@ -29,6 +30,7 @@
 - name: Manage users (pdb)
   oracle_user:
           hostname={{ ansible_hostname }}
+          port={{ listener_port_template }}
           service_name={{ item.0.pdb_name }}
           user={{ db_user }}
           password={{ db_password_pdb }}


### PR DESCRIPTION
db_unique_name is changing the default name for service during connectiong to the instance. A non default port for the listener is also usable whith listener_port in oracle_databases.

The listener_port is needed inside the pdb-configuration as well:

```
       oracle_pdbs:
         - pdb_name: orclpdb1
           listener_port: 1522
    ...
```
