### PR TITLE
oradb-manage-db: Support for listener.ora, sqlnet.ora and tnsnames.ora with new inventory structure

### DIFF
--- a/roles/oradb-manage-db/LISTENER.md
+++ b/roles/oradb-manage-db/LISTENER.md
@@ -1,0 +1,55 @@
+
+# Information for listener configuration
+The following special configurations for
+listener are currently supported for
+installations without Oracle Restart or
+Grid Infraststructure.
+
+# Requirements
+
+- only supported with new home structure
+- 'listener_installed' and  'oracle_listeners_config'  are needed
+- multiple Hosts/Ports for each Listener
+- Extproc support
+- only Database in Filesystem without Restart/Grid Infrastructure is supported at the moment
+- Definition of listener_installed disables old functionality
+- listener_name in oracle_database for SID_LIST_ in listener.ora
+When listener_name in oracle_database is defined a static  entry for the instance is added to SID_LIST_ in Listener.
+- An Instance could only be part of 1 SID_LIST_ in the Listener
+- Don't forget local_listener in init.ora!
+- address in oracle_listeners_config need protocol for a host
+- listener_port in oracle_database is ignored!
+
+
+# Example Configuration
+```
+
+oracle_listeners_config:
+    LISTENER:
+        home: 18300-base
+        address:
+          - host: hwe2018
+            port: 1521
+            protocol: TCP
+    LISTENER1523:
+        home: 18300-base
+        address:
+          - host: hwe2018
+            port: 1523
+            protocol: TCP
+
+
+listener_installed:
+      - home: 18300-base
+        listener_name: LISTENER
+        state: present
+      - home: 18300-base
+        listener_name: LISTENER1523
+        state: present
+
+oracle_databases: 
+      - home: 18300-base
+        oracle_db_name: cdb183
+        listener_name: LISTENER
+		
+```

--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -57,6 +57,10 @@
                     {%- if db_homes_config[tnsinst.home]['oracle_home'] is defined -%}{{db_homes_config[tnsinst.home]['oracle_home']}}
                     {%- else -%}{{oracle_base}}/{{db_homes_config[tnsinst.home]['version']}}/{{db_homes_config[tnsinst.home]['home']}}
                     {%- endif -%}
+                  {%- elif sqlnetinst is defined -%}
+                    {%- if db_homes_config[sqlnetinst.home]['oracle_home'] is defined -%}{{db_homes_config[sqlnetinst.home]['oracle_home']}}
+                    {%- else -%}{{oracle_base}}/{{db_homes_config[sqlnetinst.home]['version']}}/{{db_homes_config[sqlnetinst.home]['home']}}
+                    {%- endif -%}
                   {%- endif -%}"
 
   oracle_env_lsnrctl:

--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -48,6 +48,17 @@
   listener_name: LISTENER
   listener_protocols: TCP
   listener_port: 1521
+  listener_home: "{%- if lsnrinst is defined -%}
+                    {%- if db_homes_config[lsnrinst.home]['oracle_home'] is defined -%}{{db_homes_config[lsnrinst.home]['oracle_home']}}
+                    {%- else -%}{{oracle_base}}/{{db_homes_config[lsnrinst.home]['version']}}/{{db_homes_config[lsnrinst.home]['home']}}
+                    {%- endif -%}
+                  {%- endif -%}"
+
+  oracle_env_lsnrctl:
+        ORACLE_BASE: "{{ oracle_base }}"
+        ORACLE_HOME: "{{ listener_home }}"
+        LD_LIBRARY_PATH: "{{ listener_home }}/lib"
+        PATH: "{{ listener_home}}/bin:$PATH:/usr/local/bin:/bin:/sbin:/usr/bin:/usr/sbin"
   autostartup_service: false
 
 

--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -48,9 +48,14 @@
   listener_name: LISTENER
   listener_protocols: TCP
   listener_port: 1521
+
   listener_home: "{%- if lsnrinst is defined -%}
                     {%- if db_homes_config[lsnrinst.home]['oracle_home'] is defined -%}{{db_homes_config[lsnrinst.home]['oracle_home']}}
                     {%- else -%}{{oracle_base}}/{{db_homes_config[lsnrinst.home]['version']}}/{{db_homes_config[lsnrinst.home]['home']}}
+                    {%- endif -%}
+                  {%- elif tnsinst is defined -%}
+                    {%- if db_homes_config[tnsinst.home]['oracle_home'] is defined -%}{{db_homes_config[tnsinst.home]['oracle_home']}}
+                    {%- else -%}{{oracle_base}}/{{db_homes_config[tnsinst.home]['version']}}/{{db_homes_config[tnsinst.home]['home']}}
                     {%- endif -%}
                   {%- endif -%}"
 

--- a/roles/oradb-manage-db/tasks/listener.yml
+++ b/roles/oradb-manage-db/tasks/listener.yml
@@ -5,7 +5,7 @@
   when: create_listener
   tags: responsefile_netca, listener_install
 
-- name: listener | Create listener
+- name: listener | Create listener with netca
   shell: "{{ oracle_home_db }}/bin/netca -responseFile {{ oracle_rsp_stage }}/{{ oracle_netca_rsp }} -silent"
   args:
       creates: "{{ oracle_home_db }}/network/admin/listener.ora"

--- a/roles/oradb-manage-db/tasks/listener_details.yml
+++ b/roles/oradb-manage-db/tasks/listener_details.yml
@@ -1,0 +1,23 @@
+- debug: msg="ORACLE_HOME {{listener_home}}"
+  tags: listener2
+
+- name: listener | create custom configuration in listener.ora
+  blockinfile:
+    path: "{{ listener_home }}/network/admin/listener.ora"
+    backup: True
+    create: True
+    group: "{{ oracle_group }}"
+    owner: "{{ oracle_user }}"
+    state: present
+    insertafter: "EOF"
+    marker: "# {mark} Ansible managed for  {{ lsnrinst.listener_name }}"
+    block: "{{ lookup('template', 'listener_details.j2') }}"
+  tags: listener2
+
+# Don't try to stop the listener at this point
+# => Restart of role will fail at create/manage database due to TNS-12514
+- name: listener | Reload Listener
+  shell: "{{ listener_home }}/bin/lsnrctl start {{ lsnrinst.listener_name }}; {{ listener_home }}/bin/lsnrctl reload {{ lsnrinst.listener_name }}"
+  environment: "{{ oracle_env_lsnrctl }}"
+  become_user: "{{ oracle_user }}"
+  tags: listener2

--- a/roles/oradb-manage-db/tasks/listener_details.yml
+++ b/roles/oradb-manage-db/tasks/listener_details.yml
@@ -16,8 +16,14 @@
 
 # Don't try to stop the listener at this point
 # => Restart of role will fail at create/manage database due to TNS-12514
+- name: listener | Start Listener - ignore errors for running Listener
+  shell: "export PATH=${ORACLE_HOME}/bin:${PATH}; lsnrctl start {{ lsnrinst.listener_name }} /dev/null; exit 0"
+  environment: "{{ oracle_env_lsnrctl }}"
+  become_user: "{{ oracle_user }}"
+  tags: listener2
+
 - name: listener | Reload Listener
-  shell: "{{ listener_home }}/bin/lsnrctl start {{ lsnrinst.listener_name }}; {{ listener_home }}/bin/lsnrctl reload {{ lsnrinst.listener_name }}"
+  shell: "export PATH=${ORACLE_HOME}/bin:${PATH}; lsnrctl reload {{ lsnrinst.listener_name }}"
   environment: "{{ oracle_env_lsnrctl }}"
   become_user: "{{ oracle_user }}"
   tags: listener2

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -9,12 +9,20 @@
      loop_var: dbh
   tags: set_fact
 
+- include_tasks: listener_details.yml
+  with_items:
+    - "{{ listener_installed }}"
+  loop_control:
+     loop_var: lsnrinst
+  when: create_listener and listener_installed is defined
+  tags: listener2
+
 - include_tasks: listener.yml
   with_items:
       - "{{ oracle_databases }}"
   loop_control:
     loop_var: dbh
-  when: create_listener and oracle_databases is defined
+  when: create_listener and oracle_databases is defined and listener_installed is not defined
   tags: listener
 
 - name: manage-db | Add change-pdb script

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -14,7 +14,7 @@
     - "{{ listener_installed }}"
   loop_control:
      loop_var: lsnrinst
-  when: create_listener and listener_installed is defined
+  when: listener_installed is defined
   tags: listener2
 
 - include_tasks: listener.yml

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for manage-db
 
+- include_tasks: tnsnames.yml
+  with_items:
+    - "{{ tnsnames_installed }}"
+  loop_control:
+     loop_var: tnsinst
+  when: tnsnames_installed is defined
+  tags: tnsnames2
+
 - name: manage-db | set fact for Listener
   set_fact:
       create_listener: "{{ create_listener }}"

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -17,6 +17,14 @@
      loop_var: dbh
   tags: set_fact
 
+- include_tasks: sqlnet.yml
+  with_items:
+    - "{{ sqlnet_installed }}"
+  loop_control:
+     loop_var: sqlnetinst
+  when: sqlnet_installed is defined
+  tags: sqlnet2
+
 - include_tasks: listener_details.yml
   with_items:
     - "{{ listener_installed }}"

--- a/roles/oradb-manage-db/tasks/sqlnet.yml
+++ b/roles/oradb-manage-db/tasks/sqlnet.yml
@@ -1,0 +1,31 @@
+- debug: msg="sqlnet in ORACLE_HOME {{listener_home}}"
+  tags: sqlnet2
+
+- name: sqlnet.ora | create IFILE entry in sqlnet.ora
+  lineinfile:
+    line: "IFILE={{ listener_home }}/network/admin/sqlnet_ansible.ora"
+    regexp: "^IFILE=/"
+    insertbefore: BOF
+    path: "{{ listener_home }}/network/admin/sqlnet.ora"
+    backup: True
+    create: True
+    group: "{{ oracle_group }}"
+    owner: "{{ oracle_user }}"
+    state: present
+    mode: 0644
+  tags: sqlnet2
+
+- name: sqlnet.ora | create custom configuration in sqlnet_ansible.ora
+  lineinfile:
+    path: "{{ listener_home }}/network/admin/sqlnet_ansible.ora"
+    line: "{{ item.name}}={{item.value }}"
+    regexp: "^{{ item.name }}="
+    backup: True
+    create: True
+    group: "{{ oracle_group }}"
+    owner: "{{ oracle_user }}"
+    state: present
+    mode: 0644
+  with_items:
+    - "{{ sqlnet_config[sqlnetinst.sqlnet] }}"
+  tags: sqlnet2

--- a/roles/oradb-manage-db/tasks/tnsnames.yml
+++ b/roles/oradb-manage-db/tasks/tnsnames.yml
@@ -1,9 +1,23 @@
 - debug: msg="ORACLE_HOME {{listener_home}}"
   tags: tnsnames
 
-- name: tnsnames.ora | create custom configuration in tnsnames.ora
-  blockinfile:
+- name: tnsnames.ora | create IFILE entry in tnsnames.ora
+  lineinfile:
+    line: "IFILE={{ listener_home }}/network/admin/tnsnames_ansible.ora"
+    regexp: "^IFILE=/"
+    insertbefore: BOF
     path: "{{ listener_home }}/network/admin/tnsnames.ora"
+    backup: True
+    create: True
+    group: "{{ oracle_group }}"
+    owner: "{{ oracle_user }}"
+    state: present
+    mode: 0644
+  tags: tnsnames
+
+- name: tnsnames.ora | create custom configuration in tnsnames_ansible.ora
+  blockinfile:
+    path: "{{ listener_home }}/network/admin/tnsnames_ansible.ora"
     backup: True
     create: True
     group: "{{ oracle_group }}"

--- a/roles/oradb-manage-db/tasks/tnsnames.yml
+++ b/roles/oradb-manage-db/tasks/tnsnames.yml
@@ -1,0 +1,16 @@
+- debug: msg="ORACLE_HOME {{listener_home}}"
+  tags: tnsnames
+
+- name: tnsnames.ora | create custom configuration in tnsnames.ora
+  blockinfile:
+    path: "{{ listener_home }}/network/admin/tnsnames.ora"
+    backup: True
+    create: True
+    group: "{{ oracle_group }}"
+    owner: "{{ oracle_user }}"
+    state: present
+    mode: 0644
+    insertafter: "EOF"
+    marker: "# {mark} Ansible managed for  {{ tnsinst.tnsname }}"
+    block: "{{ lookup('template', 'tnsnames' + oracle_tnsnames_config[tnsinst.tnsname]['tnstemplate'] | default('') + '.ora.j2') }}"
+  tags: tnsnames

--- a/roles/oradb-manage-db/templates/listener_details.j2
+++ b/roles/oradb-manage-db/templates/listener_details.j2
@@ -30,6 +30,8 @@
 SID_LIST_{{ lsnrinst.listener_name }} =
 {# loop over oracle_database when testsid.listener_name was found for lsnrinst.listener_name #}
   {%- for sid in oracle_databases if sid.listener_name is defined and sid.listener_name == lsnrinst.listener_name %}
+{%- set sid_name = sid.oracle_db_instance_name | default(sid.oracle_db_name) %}
+{%- set sid_name_dgmgrl = sid.oracle_db_unique_name | default(sid.oracle_db_name) %}
   (SID_LIST =
     (SID_DESC =
     {% if db_homes_config[sid.home]['oracle_home'] is defined %}
@@ -37,7 +39,7 @@ SID_LIST_{{ lsnrinst.listener_name }} =
     {% else %}
   (ORACLE_HOME = {{oracle_base}}/{{db_homes_config[sid.home]['version']}}/{{db_homes_config[sid.home]['home']}})
     {% endif %}
-  (SID_NAME = {{ sid.oracle_db_name }})
+  (SID_NAME = {{ sid_name }})
     )
 {# added for compatibility against Oracle 11.2#}
     (SID_DESC =
@@ -46,8 +48,8 @@ SID_LIST_{{ lsnrinst.listener_name }} =
     {% else %}
   (ORACLE_HOME = {{oracle_base}}/{{db_homes_config[sid.home]['version']}}/{{db_homes_config[sid.home]['home']}})
     {% endif %}
-  (SID_NAME = {{ sid.oracle_db_name }})
-      (GLOBAL_DBNAME = {{ sid.oracle_db_name }}_DGMGRL)
+  (SID_NAME = {{ sid_name }})
+      (GLOBAL_DBNAME = {{ sid_name_dgmgrl }}_DGMGRL)
     )
   {% endfor %}
 )

--- a/roles/oradb-manage-db/templates/listener_details.j2
+++ b/roles/oradb-manage-db/templates/listener_details.j2
@@ -1,0 +1,54 @@
+
+# do not edit the configuration manually.
+# The execution of ansible-oracle automatically replace all manual changes!
+{{ lsnrinst.listener_name }} =
+  (DESCRIPTION =
+{% if oracle_listeners_config[lsnrinst.listener_name]['address'] is defined %}
+    (ADDRESS_LIST=
+  {%- for item in  oracle_listeners_config[lsnrinst.listener_name]['address'] %}
+    {%- if item.host is defined %}
+
+      (ADDRESS = (PROTOCOL = {{ item.protocol | default('TCP') }})(HOST = {{item.host}})(PORT = {{item.port | default(listener_port) }}))
+    {%- elif item.key is defined %}
+      (ADDRESS = (PROTOCOL = {{ item.protocol | default('IPC') }})(KEY = {{ item.key }}))
+    {%- endif %}
+  {%- endfor %}
+
+    )
+  )
+{%- else %}
+    (ADDRESS = (PROTOCOL = TCP)(HOST = {{ ansible_host }})(PORT = {{ item.host}})(PORT = {{item.port | default(listener_port) }}))
+  )
+{%- endif %}
+
+{# config_sid_list is used as a helper. jinja2 doesn't allow the exposing of variables from inside a loop to outside before version 2.10! #}
+{%- set config_sid_list = 0 %}
+{# The following loop is executed only once for the header 'SID_LIST_... #}
+{%- for testsid in oracle_databases if testsid.listener_name is defined and testsid.listener_name == lsnrinst.listener_name and config_sid_list == 0 %}
+  {%- set config_sid_list =  1 %}
+
+SID_LIST_{{ lsnrinst.listener_name }} =
+{# loop over oracle_database when testsid.listener_name was found for lsnrinst.listener_name #}
+  {%- for sid in oracle_databases if sid.listener_name is defined and sid.listener_name == lsnrinst.listener_name %}
+  (SID_LIST =
+    (SID_DESC =
+    {% if db_homes_config[sid.home]['oracle_home'] is defined %}
+  (ORACLE_HOME = {{db_homes_config[sid.home]['oracle_home']}})
+    {% else %}
+  (ORACLE_HOME = {{oracle_base}}/{{db_homes_config[sid.home]['version']}}/{{db_homes_config[sid.home]['home']}})
+    {% endif %}
+  (SID_NAME = {{ sid.oracle_db_name }})
+    )
+{# added for compatibility against Oracle 11.2#}
+    (SID_DESC =
+    {% if db_homes_config[sid.home]['oracle_home'] is defined %}
+  (ORACLE_HOME = {{db_homes_config[sid.home]['oracle_home']}})
+    {% else %}
+  (ORACLE_HOME = {{oracle_base}}/{{db_homes_config[sid.home]['version']}}/{{db_homes_config[sid.home]['home']}})
+    {% endif %}
+  (SID_NAME = {{ sid.oracle_db_name }})
+      (GLOBAL_DBNAME = {{ sid.oracle_db_name }}_DGMGRL)
+    )
+  {% endfor %}
+)
+{% endfor %}

--- a/roles/oradb-manage-db/templates/tnsnames.ora.j2
+++ b/roles/oradb-manage-db/templates/tnsnames.ora.j2
@@ -16,7 +16,7 @@ SALES=
 
 # do not edit the configuration manually.
 # The execution of ansible-oracle automatically replace all manual changes!
-{{ tnsinst.tnsname }} =
+{{ tnsinst.tnsname | upper }} =
  (DESCRIPTION =
    (FAILOVER={{ oracle_tnsnames_config[tnsinst.tnsname]['failover'] | default('yes')}})
    (CONNECT_TIMEOUT={{ oracle_tnsnames_config[tnsinst.tnsname]['connect_timeout'] | default('5')}})
@@ -39,5 +39,6 @@ SALES=
   {%- endif %}
 {%- endif %}
 
+     (SERVER =  {{oracle_tnsnames_config[tnsinst.tnsname]['connect']['SERVER']| default ('DEDICATED')}})
    )
  )

--- a/roles/oradb-manage-db/templates/tnsnames.ora.j2
+++ b/roles/oradb-manage-db/templates/tnsnames.ora.j2
@@ -1,0 +1,43 @@
+{#
+
+https://www.oracle.com/technetwork/database/availability/client-failover-2280805.pdf
+SALES=
+  (DESCRIPTION=
+    (FAILOVER=on)
+    (CONNECT_TIMEOUT=5)(TRANSPORT_CONNECT_TIMEOUT=3)(RETRY_COUNT=3)
+    (ADDRESS_LIST=
+      (LOAD_BALANCE=on)
+      (ADDRESS=(PROTOCOL=TCP)(HOST=prmy-scan)(PORT=1521))
+      (ADDRESS=(PROTOCOL=TCP)(HOST=stby-scan)(PORT=1521))
+    )
+    (CONNECT_DATA=(SERVICE_NAME=oltpworkload))
+  )
+#}
+
+# do not edit the configuration manually.
+# The execution of ansible-oracle automatically replace all manual changes!
+{{ tnsinst.tnsname }} =
+ (DESCRIPTION =
+   (FAILOVER={{ oracle_tnsnames_config[tnsinst.tnsname]['failover'] | default('yes')}})
+   (CONNECT_TIMEOUT={{ oracle_tnsnames_config[tnsinst.tnsname]['connect_timeout'] | default('5')}})
+   (TRANSPORT_CONNECT_TIMEOUT={{ oracle_tnsnames_config[tnsinst.tnsname]['transport_connect_timeout'] | default('3')}})
+   (RETRY_COUNT={{ oracle_tnsnames_config[tnsinst.tnsname]['retry_count'] | default('3')}})
+   (ADDRESS_LIST =
+     (LOAD_BALANCE={{ oracle_tnsnames_config[tnsinst.tnsname]['load_balance'] | default('on')}})
+{% for addr in  oracle_tnsnames_config[tnsinst.tnsname]['address']  %}
+     (ADDRESS = (PROTOCOL = {{addr.tcp | default ('TCP')}})(Host = {{addr.host}})(Port = {{addr.port | default(listener_port) }}))
+{% endfor %}
+   )
+   (CONNECT_DATA =
+{%- if oracle_tnsnames_config[tnsinst.tnsname]['connect'] is defined %}
+  {%- if oracle_tnsnames_config[tnsinst.tnsname]['connect']['service_name'] is defined %}
+
+     (SERVICE_NAME = {{oracle_tnsnames_config[tnsinst.tnsname]['connect']['service_name']}})
+  {%- elif oracle_tnsnames_config[tnsinst.tnsname]['connect']['sid_name'] is defined %}
+
+     (SID = {{oracle_tnsnames_config[tnsinst.tnsname]['connect']['sid_name']}})
+  {%- endif %}
+{%- endif %}
+
+   )
+ )

--- a/roles/oradb-manage-db/templates/tnsnamesdgfailover2.ora.j2
+++ b/roles/oradb-manage-db/templates/tnsnamesdgfailover2.ora.j2
@@ -31,7 +31,7 @@ SALES=
 
 # do not edit the configuration manually.
 # The execution of ansible-oracle automatically replace all manual changes!
-{{ tnsinst.tnsname }} =
+{{ tnsinst.tnsname | upper }} =
  (DESCRIPTION_LIST=
    (LOAD_BALANCE={{ oracle_tnsnames_config[tnsinst.tnsname]['load_balance'] | default('off')}})
    (FAILOVER={{ oracle_tnsnames_config[tnsinst.tnsname]['failover'] | default('yes')}})
@@ -46,6 +46,7 @@ SALES=
      )
      (CONNECT_DATA =
        (SERVICE_NAME = {{oracle_tnsnames_config[tnsinst.tnsname]['connect']['service_name']}})
+       (SERVER =  {{oracle_tnsnames_config[tnsinst.tnsname]['connect']['SERVER']| default ('DEDICATED')}})
      )
    )
 {% endfor %}

--- a/roles/oradb-manage-db/templates/tnsnamesdgfailover2.ora.j2
+++ b/roles/oradb-manage-db/templates/tnsnamesdgfailover2.ora.j2
@@ -1,0 +1,52 @@
+{#
+
+https://www.oracle.com/technetwork/database/availability/client-failover-2280805.pdf
+
+SALES=
+  (DESCRIPTION_LIST=
+    (LOAD_BALANCE=off)
+    (FAILOVER=on)
+    (DESCRIPTION=
+      (CONNECT_TIMEOUT=5)
+      (TRANSPORT_CONNECT_TIMEOUT=3)
+      (RETRY_COUNT=3)
+      (ADDRESS_LIST=
+        (LOAD_BALANCE=on)
+        (ADDRESS=(PROTOCOL=TCP)(HOST=prmy-scan)(PORT=1521))
+      )
+      (CONNECT_DATA=(SERVICE_NAME=oltpworkload))
+    )
+    (DESCRIPTION=
+      (CONNECT_TIMEOUT=5)
+      (TRANSPORT_CONNECT_TIMEOUT=3)
+      (RETRY_COUNT=3)
+      (ADDRESS_LIST=
+        (LOAD_BALANCE=on)
+        (ADDRESS=(PROTOCOL=TCP)(HOST=stby-scan)(PORT=1521))
+      )
+      (CONNECT_DATA=(SERVICE_NAME=oltpworkload))
+    )
+  )
+#}
+
+# do not edit the configuration manually.
+# The execution of ansible-oracle automatically replace all manual changes!
+{{ tnsinst.tnsname }} =
+ (DESCRIPTION_LIST=
+   (LOAD_BALANCE={{ oracle_tnsnames_config[tnsinst.tnsname]['load_balance'] | default('off')}})
+   (FAILOVER={{ oracle_tnsnames_config[tnsinst.tnsname]['failover'] | default('yes')}})
+{% for addr in  oracle_tnsnames_config[tnsinst.tnsname]['address']  %}
+   (DESCRIPTION=
+   (CONNECT_TIMEOUT={{ oracle_tnsnames_config[tnsinst.tnsname]['connect_timeout'] | default('5')}})
+   (TRANSPORT_CONNECT_TIMEOUT={{ oracle_tnsnames_config[tnsinst.tnsname]['transport_connect_timeout'] | default('3')}})
+   (RETRY_COUNT={{ oracle_tnsnames_config[tnsinst.tnsname]['retry_count'] | default('3')}})
+     (ADDRESS_LIST=
+       (LOAD_BALANCE={{ oracle_tnsnames_config[tnsinst.tnsname]['load_balance'] | default('on')}})
+       (ADDRESS = (PROTOCOL = {{addr.tcp | default ('TCP')}})(Host = {{addr.host}})(Port = {{addr.port | default(listener_port) }}))
+     )
+     (CONNECT_DATA =
+       (SERVICE_NAME = {{oracle_tnsnames_config[tnsinst.tnsname]['connect']['service_name']}})
+     )
+   )
+{% endfor %}
+ )


### PR DESCRIPTION
This PR includes all changes for creating tnsnames.ora and listener.ora with new inventory structure.
It is very flexible and a mandatory requiement for the future Data-Guard role.