### PR TITLE
oradb-manage-users: added support for update_password

### DIFF
--- a/roles/oradb-manage-users/tasks/main.yml
+++ b/roles/oradb-manage-users/tasks/main.yml
@@ -14,7 +14,7 @@
           state={{ item.1.state }}
           default_tablespace={{ item.1.default_tablespace |default (omit)}}
           container={{ item.1.container |default(omit) }}
-          update_password=on_create
+          update_password={{ item.1.update_password | default('on_create') }}
           grants={{ item.1.grants |default (omit) }}
   with_subelements:
       - "{{ oracle_databases }}"
@@ -39,7 +39,7 @@
           schema_password={{ user_pdb_password }}
           state={{ item.1.state }}
           default_tablespace={{ item.1.default_tablespace |default (omit)}}
-          update_password=on_create
+          update_password={{ item.1.update_password | default('on_create') }}
           grants={{ item.1.grants |default (omit) }}
   with_subelements:
       - "{{ oracle_pdbs }}"


### PR DESCRIPTION
The password of existing users could be changed with:
        users:
          - schema: dbsnmp
            update_password: always
            state: unlocked

This is needed for existing accounts. By default only new
created accounts will get the password, because the role
will always set the password for the user when update_password
is set to 'always'!