### PR TITLE
oradb-manage-db: new handling of custom dbca-templates

### DIFF
--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -97,6 +97,7 @@
      - "dbh='cd $ORACLE_HOME'"
      - "dbb='cd $ORACLE_BASE'"
      - "talert='tail -500f $ORACLE_BASE/diag/rdbms/$ORA_DB_UNQ_NAME/$ORACLE_SID/trace/alert_$ORACLE_SID.log'"
+     - "lalert='less $ORACLE_BASE/diag/rdbms/$ORA_DB_UNQ_NAME/$ORACLE_SID/trace/alert_$ORACLE_SID.log'"
 
   # db_homes_config:
   #   12201-base:

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -25,26 +25,13 @@
          group: "{{ oracle_group }}"
   tags: sql_script
 
-- name: manage-db | Copy custom dbca Templates to ORACLE_HOME/assistants/dbca/templates
-  template:
-         src={{ item.dbca_templatename }}
-         dest={{ oracle_home_db }}/assistants/dbca/templates/{{ item.dbca_templatename }}
-         owner={{ oracle_user }}
-         group={{ oracle_group }}
-         mode=640
-  with_items:
-     - "{{oracle_databases}}"
-  when: item.dbca_templatename is defined and item.dbca_templatename not in('New_Database.dbt','General_Purpose.dbc')
-  tags:
-    - customdbcatemplate
-
 - include_tasks: manage-db.yml
   with_items:
       - "{{ oracle_databases }}"
   loop_control:
     loop_var: dbh
   when: oracle_databases is defined
-  tags: create_db,dbca
+  tags: create_db,dbca,customdbcatemplate
 
 
 - name: manage-db | Check if database is running

--- a/roles/oradb-manage-db/tasks/main.yml
+++ b/roles/oradb-manage-db/tasks/main.yml
@@ -31,7 +31,7 @@
   loop_control:
     loop_var: dbh
   when: oracle_databases is defined
-  tags: create_db,dbca,customdbcatemplate
+  tags: create_db,dbca,customdbcatemplate,dotprofile_db
 
 
 - name: manage-db | Check if database is running

--- a/roles/oradb-manage-db/tasks/manage-db.yml
+++ b/roles/oradb-manage-db/tasks/manage-db.yml
@@ -49,6 +49,18 @@
   when: dbh.state|lower == 'present'
   tags: create_db,dotprofile_db
 
+- name: manage-db | Copy custom dbca Templates for Database to ORACLE_HOME/assistants/dbca/templates
+  template:
+         src={{ dbh.dbca_templatename }}
+         dest={{ oracle_home_db }}/assistants/dbca/templates/{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}
+         owner={{ oracle_user }}
+         group={{ oracle_group }}
+         mode=640
+  when: dbh.state|lower == 'present' and dbh.dbca_templatename is defined and dbh.dbca_templatename not in('New_Database.dbt','General_Purpose.dbc')
+  tags:
+    - customdbcatemplate
+    - dbcatemplate
+
 - name: manage-db | Prepare installation template
   template:
     src: "dbca-create-db.rsp.{{ db_version}}.j2"

--- a/roles/oradb-manage-db/templates/dbca-create-db.rsp.11.2.0.3.j2
+++ b/roles/oradb-manage-db/templates/dbca-create-db.rsp.11.2.0.3.j2
@@ -205,7 +205,7 @@ NODELIST={% for host in groups[hostgroup] -%} {{host}} {%- if not loop.last -%} 
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 {% if dbh.dbca_templatename is defined %}
-TEMPLATENAME = "{{dbh.dbca_templatename}}"
+TEMPLATENAME = "{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
 {% else %}
 TEMPLATENAME = "{{dbca_templatename}}"
 {% endif %}

--- a/roles/oradb-manage-db/templates/dbca-create-db.rsp.11.2.0.4.j2
+++ b/roles/oradb-manage-db/templates/dbca-create-db.rsp.11.2.0.4.j2
@@ -206,7 +206,7 @@ NODELIST={% for host in groups[hostgroup] -%} {{host}} {%- if not loop.last -%} 
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 {% if dbh.dbca_templatename is defined %}
-TEMPLATENAME = "{{dbh.dbca_templatename}}"
+TEMPLATENAME = "{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
 {% else %}
 TEMPLATENAME = "{{dbca_templatename}}"
 {% endif %}

--- a/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.1.0.1.j2
+++ b/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.1.0.1.j2
@@ -278,7 +278,7 @@ NODELIST={% for host in groups[hostgroup] -%} {{host}} {%- if not loop.last -%} 
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 {% if dbh.dbca_templatename is defined %}
-TEMPLATENAME = "{{dbh.dbca_templatename}}"
+TEMPLATENAME = "{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
 {% else %}
 TEMPLATENAME = "{{dbca_templatename}}"
 {% endif %}

--- a/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.1.0.2.j2
+++ b/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.1.0.2.j2
@@ -278,7 +278,7 @@ NODELIST={% for host in groups[hostgroup] -%} {{host}} {%- if not loop.last -%} 
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 {% if dbh.dbca_templatename is defined %}
-TEMPLATENAME = "{{dbh.dbca_templatename}}"
+TEMPLATENAME = "{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
 {% else %}
 TEMPLATENAME = "{{dbca_templatename}}"
 {% endif %}

--- a/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.2.0.1.j2
+++ b/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.2.0.1.j2
@@ -234,7 +234,7 @@ nodelist={% for host in groups[hostgroup] -%} {{host}} {%- if not loop.last -%} 
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 {% if dbh.dbca_templatename is defined %}
-templateName={{dbh.dbca_templatename}}
+templateName="{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
 {% else %}
 templateName={{dbca_templatename}}
 {% endif %}

--- a/roles/oradb-manage-db/templates/dotprofile-db.j2
+++ b/roles/oradb-manage-db/templates/dotprofile-db.j2
@@ -4,7 +4,7 @@
 {% if shell_ps1 is defined %}
 export PS1={{ shell_ps1 }}
 {% endif %}
-
+get_sid=$(ps -ef | grep "ora_pmon_$ORACLE_DBNAME" |grep -v grep | sed 's/^.*pmon_//g')
 
 
 # Set up the Oracle environment variables
@@ -27,12 +27,18 @@ export PS1={{ shell_ps1 }}
         get_sid=$(ps -ef | grep "ora_pmon_$ORACLE_DBNAME" |grep -v grep | sed 's/^.*pmon_//g')
         export ORACLE_SID=${get_sid:-$ORACLE_DBNAME}
         export ORA_DB_UNQ_NAME={% if dbh.oracle_db_unique_name is defined %}{{ dbh.oracle_db_unique_name }}{% else %}{{ dbh.oracle_db_name }}{% endif %}
-        
         export NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'
 
 
+{# create environemt variables when rman is configured in oracle_databases #}
+{% if dbh.rman_jobs is defined %}        
+# setup some variables for oradb-rman
+        export RMANTNS_ADMIN={{ rman_tns_admin  | default(dbh.rman_tns_admin  | default(oracle_base + '/rman/network/admin')) }}
+        export RMANLOGDIR={{ rman_log_dir       | default(dbh.rman_log_dir    | default(oracle_base + '/rman/log/')) }}
+        export RMANSCRIPTDIR={{ rman_script_dir | default(dbh.rman_script_dir | default(oracle_base + '/rman/script')) }}
+{% endif %}
 
-export PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch:$PATH:$SQLPATH:$GG_HOME/
+export PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch:$PATH:$SQLPATH:$GG_HOME/:$ORACLE_BASE/bin
 
 # Set Up Aliases:
 {% if shell_aliases is defined %}


### PR DESCRIPTION
The usage of dbca_templatename in oracle_database has been changed.
The template is copied to $ORACLE_HOME/assistant/dbca/templates for
each database as <db_name>_customexample.dbt. This allow the usage
of jinja2 in the template for each database.

Be aware:
The jinja2 variable 'item' has been changed to 'dbh' in the template
files.

oracle_databases:
   dbca_templatename: customexample.dbt