### PR TITLE
oraswdb-install: Configure license option in Oracle Executables

### DIFF
--- a/roles/oraswdb-install/defaults/main.yml
+++ b/roles/oraswdb-install/defaults/main.yml
@@ -79,11 +79,11 @@
                    {%- else %}{% if ansible_service_mgr is defined %}{{ ansible_service_mgr }}{% else %}init{% endif %}{% endif %}"
 
   disable_EE_options: True
-  oracle_EE_options: "{%- if db_homes_config[dbh.home]['version'] in ('12.2.0.1') %}{{ oracle_EE_options_122 }}
+  oracle_EE_options: "{%- if   db_homes_config[dbh.home]['version'] in ('18.3.0.0') %}{{ oracle_EE_options_183 }}
+                      {%- elif db_homes_config[dbh.home]['version'] in ('12.2.0.1') %}{{ oracle_EE_options_122 }}
                       {%- elif db_homes_config[dbh.home]['version'] in ('12.1.0.1', '12.1.0.2') %}{{oracle_EE_options_121}}
                       {%- elif db_homes_config[dbh.home]['version'] == '11.2.0.4' %}{{oracle_EE_options_112}}
                       {%- endif %}"
-  oracle_EE_option_state: "{% if item.state is defined and item.state %}enable{% else %}disable{% endif %}"
 
   # disable all options who requires extra licences
   oracle_EE_options_112:
@@ -106,6 +106,11 @@
     - {option: partitioning , state: false }
     - {option: rat          , state: false }
 
+  oracle_EE_options_183:
+    - {option: oaa          , state: false }
+    - {option: olap         , state: false }
+    - {option: partitioning , state: false }
+    - {option: rat          , state: false }
 
   oracle_directories:
           - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775 }

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -40,25 +40,26 @@
   tags: responsefileswdb
 
 - include_tasks: "{{ db_version }}.yml"
+
 # oracle_EE_options = '' => Nothing to do
 # licence options in 11.2+ must be changed by chopt
 # => use this method for all >= 11.2 (Doc ID 948061.1)
 # test -f => reduce number of executions when > 1 database in oracle_databases for same ORACLE_HOME
-# - name: install-home-db | Change Database options with chopt
-#   shell: "test -f {{ oracle_home_db }}/install/{{oracle_EE_option_state}}_{{item.option}}.log || {{ oracle_home_db }}/bin/chopt {{oracle_EE_option_state}} {{item.option}}"
-#   #debugger: on_failed
-#   with_items:
-#     - "{{oracle_EE_options}}"
-#   become: yes
-#   become_user: "{{ oracle_user }}"
-#   register: choptout
-#   changed_when: '"Writing" in choptout.stdout'
-#   when: db_homes_config[dbh.home]['edition'] == 'EE' and oracle_EE_options is defined and disable_EE_options
-#   loop_control:
-#     label: "{{ oracle_home_db }} {{oracle_EE_option_state}} {{item.option}}"
-#   tags:
-#     - dbchopt
-#
+# we cannot use default/main.yml here. => complicated structure for 'enabled' 'disabled'...
+- name: install-home-db | Change Database options with chopt
+  shell: "test -f {{ oracle_home_db }}/install/{{ item.state | replace(true, 'enable') | replace(false, 'disable') }}_{{item.option}}.log || {{ oracle_home_db }}/bin/chopt {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}}"
+  with_items:
+    - "{{oracle_EE_options}}"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: choptout
+  changed_when: '"Writing" in choptout.stdout'
+  when: db_homes_config[dbh.home]['edition'] == 'EE' and oracle_EE_options is defined and disable_EE_options
+  loop_control:
+    label: "{{ oracle_home_db }} {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}}"
+  tags:
+    - dbchopt
+
 - name: install-home-db | Run root script after installation
   shell: "{{ oracle_home_db }}/root.sh"
   run_once: "{{ configure_cluster}}"

--- a/roles/oraswdb-install/tasks/main.yml
+++ b/roles/oraswdb-install/tasks/main.yml
@@ -86,7 +86,7 @@
     loop_control:
       loop_var: dbh
     when: db_homes_installed is defined and dbh.state|lower == 'present'
-    tags: oradbinstall
+    tags: oradbinstall,dbchopt
 
   - name: install-home-db | Unmount nfs share with installation media
     mount: src="{{ nfs_server_sw }}:{{ nfs_server_sw_path }}" name={{ oracle_stage_remote }} fstype=nfs state=absent


### PR DESCRIPTION
This feauture was removed during the change to the new inventory
structure.

The task only changes an option, if a file for
$ORACLE_HOME/install/<enable|disable>_.log is not existing!

The licensed options in the Oracle binaries are configurable.
All options are disabled by default!

To activate an option set state to 'True'.
More details could be found in Doc ID 948061.1

The following variable could be used to change the default:

      oracle_EE_options_112:
        - {option: dm           , state: false }
        - {option: dv           , state: false }
        - {option: lbac         , state: false }
        - {option: olap         , state: false }
        - {option: partitioning , state: false }
        - {option: rat          , state: false }

      oracle_EE_options_121:
        - {option: dm           , state: false }
        - {option: olap         , state: false }
        - {option: partitioning , state: false }
        - {option: rat          , state: false }

      oracle_EE_options_122:
        - {option: oaa          , state: false }
        - {option: olap         , state: false }
        - {option: partitioning , state: false }
        - {option: rat          , state: false }

      oracle_EE_options_183:
        - {option: oaa          , state: false }
        - {option: olap         , state: false }
        - {option: partitioning , state: false }
        - {option: rat          , state: false }