### PR TITLE
orahost: only install ASMLib Packages with defined Diskgroups

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -311,26 +311,26 @@
   - name: Asmlib | Add configuration
     template: src=oracleasm.j2 dest=/etc/sysconfig/oracleasm-_dev_oracleasm
     register: asmlibconfig
-    when: device_persistence|lower == 'asmlib'
+    when: device_persistence|lower == 'asmlib' and asm_diskgroups is defined
     tags:
       - asmlibconfig
 
   - name: Asmlib | Add configuration (link)
     file: src=/etc/sysconfig/oracleasm-_dev_oracleasm dest=/etc/sysconfig/oracleasm state=link force=yes
     register: asmlibconfig
-    when: device_persistence|lower == 'asmlib'
+    when: device_persistence|lower == 'asmlib' and asm_diskgroups is defined
     tags:
       - asmlibconfig
 
   - name: Asmlib | Enable and start Oracle Asmlib
     service: name=oracleasm  state=started  enabled=yes
-    when: device_persistence == 'asmlib'
+    when: device_persistence == 'asmlib' and asm_diskgroups is defined
     tags:
       - asmlibconfig
 
   - name: Asmlib | Restart Asmlib
     service: name=oracleasm  state=restarted
-    when: device_persistence == 'asmlib' and asmlibconfig.changed
+    when: asm_diskgroups is defined and device_persistence == 'asmlib' and asmlibconfig.changed
     tags:
       - asmlibconfig
 

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -30,13 +30,13 @@
        state: installed
        enablerepo: "{{ extrarepos_enabled |default (omit) }}"
        disablerepo: "{{ extrarepos_disabled |default (omit) }}"
-    when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'RedHat'
+    when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'RedHat' and asm_diskgroups is defined
     tags: os_packages, oscheck
 
   - name: Install packages required by Oracle for ASMlib on SLES
     zypper: name={{ item }} state=installed
     with_items: "{{ oracle_asm_packages_sles }}"
-    when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'Suse'
+    when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'Suse' and asm_diskgroups is defined
     tags: os_packages, oscheck, asm1
 
   - name: Check if firewall is installed


### PR DESCRIPTION
The commit leads to an installation of ASMlib tools when no
ASM-Diskgroups were defined:
 orahost: Make device_persistence consistent against other roles

This has beend fixed. The RPMs are only installed when the
variable asm_diskgroups is defined.