### PR TITLE
Support for dNFS

### DIFF
--- a/roles/orahost-storage/defaults/main.yml
+++ b/roles/orahost-storage/defaults/main.yml
@@ -17,6 +17,8 @@
   partition_suffix: "{% if multipath |lower == 'dm-multipath' and ansible_distribution_major_version|int == 6  %}p1{% else %}1{% endif%}"
   asmlib_binary: "{% if ansible_distribution_major_version|int == 7 %}oracleasm{% elif ansible_distribution_major_version|int == 6  %}/etc/init.d/oracleasm{% else %}/etc/init.d/oracleasm{% endif%}"
 
+  dnfstaboptions: "{%- if item.1.fstaboptions is defined %}{{ item.1.fstaboptions }}
+                   {%- else %}rw,bg,hard,nointr,tcp,vers=3,timeo=600,rsize=32768,wsize=32768{% endif %}"
 
   #asm_diskgroups:
   #  - diskgroup: crs

--- a/roles/orahost-storage/defaults/main.yml
+++ b/roles/orahost-storage/defaults/main.yml
@@ -47,3 +47,14 @@
   #      - {name: compatible.asm, value: 12.1.0.2.0}
   #    disk:
   #      - {device: /dev/sdg, asmlabel: fra01}
+
+  #oradnfs:
+  #  - server: nfsserver
+  #    ips:
+  #      - local: dbserver
+  #        path: nfsserver
+  #    exports:
+  #      - export: /nfs/oradata
+  #        mount: /u02/oradata2
+  #      - export: /nfs/oradata2
+  #        mount: /u02/oradata

--- a/roles/orahost-storage/tasks/main.yml
+++ b/roles/orahost-storage/tasks/main.yml
@@ -33,7 +33,7 @@
       path: "{{ item.1.mount }}"
       fstype: "nfs"
       opts: "{{ dnfstaboptions }}"
-      state: present
+      state: mounted
     with_subelements:
         - "{{ oradnfs }}"
         - exports

--- a/roles/orahost-storage/tasks/main.yml
+++ b/roles/orahost-storage/tasks/main.yml
@@ -15,3 +15,41 @@
     when: multipath == 'dm-multipath' and partition_devices and asm_diskgroups is defined
 
   - include: "{{ device_persistence }}.yml"
+
+  - name: dNFS-storage | Prepare mountpoints
+    file:
+      path: "{{ item.1.mount }}"
+      state: "directory"
+      owner: "root"
+      group: "root"
+    with_subelements:
+        - "{{ oradnfs }}"
+        - exports
+    when: oradnfs is defined
+
+  - name: dNFS-storage | Configure /etc/fstab and mount
+    mount:
+      src: "{{ item.0.server }}:{{ item.1.export }}"
+      path: "{{ item.1.mount }}"
+      fstype: "nfs"
+      opts: "{{ dnfstaboptions }}"
+      state: present
+    with_subelements:
+        - "{{ oradnfs }}"
+        - exports
+    when: oradnfs is defined
+
+  - name: dNFS-storage | Create /etc/oranfstab for dNFS
+    blockinfile:
+      path: /etc/oranfstab
+      state: present
+      create: True
+      owner: root
+      group: root
+      mode: 0644
+      insertafter: "EOF"
+      marker: "# {mark} Ansible managed for NFS-Server: {{ item.server }}"
+      block: "{{ lookup('template', 'oranfstab.j2') }}"
+    with_items:
+        - "{{ oradnfs }}"
+    when: oradnfs is defined

--- a/roles/orahost-storage/templates/oranfstab.j2
+++ b/roles/orahost-storage/templates/oranfstab.j2
@@ -1,0 +1,19 @@
+{#
+server:  nfsserver
+ local: 198.51.100.02
+ path: 10.0.0.0
+ local: 198.51.100.03
+ path: 10.0.0.3
+ export: /private/oracle1/logs  mount: C:\APP\ORACLE\ORADATA\logs  security: krb5
+ export: /private/oracle1/data  mount: C:\APP\ORACLE\ORADATA\data  security: krb5p
+ export: /private/oracle1/archive mount: C:\APP\ORACLE\ORADATA\archive security: sys
+ export: /private/oracle1/data1 mount: C:\APP\ORACLE\ORADATA\data1
+#}
+server: {{ item.server }}
+{% for ips in item.ips %}
+ local: {{ ips.local }}
+ path: {{ ips.path }}
+{% endfor %}
+{% for exp in item.exports %}
+ export: {{ exp.export }} mount: {{ exp.mount }}
+{% endfor %}


### PR DESCRIPTION
The following variable is needed to configure dNFS for Oracle.
The fstab and /etc/oranfstab are automaically configured.
Multiple exports and networks are possible.

There is no removal option at the moment.

Configuration:
  oradnfs:
    - server: nfsserver
      ips:
        - local: dbserver
          path: nfsserver
     exports:
        - export: /nfs/oradata
          mount: /u02/oradata