### PR TITLE
oradb-manage-db: Custom configuration of init_parameters for DBCA

### DIFF
--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -81,7 +81,9 @@
   # dbca_redolog: "{% if dbh.redolog_size_in_mb is defined %} -redoLogFileSize {{dbh.redolog_size_in_mb}}{% endif %}"
   init_params_list: "{%- if dbh.init_parameters is defined  -%}
                         {%- for p in  dbh.init_parameters -%}
-                           {{ p.name }}={{ p.value}}{%- if not loop.last -%},{%- endif -%}
+                          {%- if p.dbca | default(True) -%}
+                             {{ p.name }}={{ p.value}}{%- if not loop.last -%},{%- endif -%}
+                          {%- endif -%}
                         {%- endfor -%}
                      {%- endif -%}"
 


### PR DESCRIPTION
The init_parameters defines the parameers for init.ora during DBCA and
oradb-manage-parameters. Sometimes a parameter should not be sent to DBCA.

The parameter dbca could be used. The default is True when the parameter is missing.

oracle_databases:
  init_parameters:
    - {name: pga_aggregate_target, value: '200M', scope: both, state: present, dbca: False}