### PR TITLE
orahost: Bugfix for Ansible Issue #46517

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -13,8 +13,8 @@
     yum:
        name: "{{ oracle_packages }}"
        state: installed
-       enablerepo: "{{ extrarepos_enabled |default (omit) }}"
-       disablerepo: "{{ extrarepos_disabled |default (omit) }}"
+       enablerepo: "{{ extrarepos_enabled |default (omit, True) }}"
+       disablerepo: "{{ extrarepos_disabled |default (omit, True) }}"
     when: install_os_packages and ansible_os_family == 'RedHat'
     tags: os_packages, oscheck
 
@@ -28,8 +28,8 @@
     yum:
        name: "{{ oracle_asm_packages }}"
        state: installed
-       enablerepo: "{{ extrarepos_enabled |default (omit) }}"
-       disablerepo: "{{ extrarepos_disabled |default (omit) }}"
+       enablerepo: "{{ extrarepos_enabled |default (omit, True) }}"
+       disablerepo: "{{ extrarepos_disabled |default (omit, True) }}"
     when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'RedHat' and asm_diskgroups is defined
     tags: os_packages, oscheck
 


### PR DESCRIPTION
'repository not found' if passing empty string to yum 'enablerepo' parameter #46517

This problem has been introduced in Ansible 2.7.0. This
fix hopefully prevent future problems.