### PR TITLE
oradb-manage-db: custom parameter for listener.ora

### DIFF
--- a/roles/oradb-manage-db/templates/listener_details.j2
+++ b/roles/oradb-manage-db/templates/listener_details.j2
@@ -1,6 +1,14 @@
 
 # do not edit the configuration manually.
 # The execution of ansible-oracle automatically replace all manual changes!
+{% if oracle_listeners_config[lsnrinst.listener_name]['parameter'] is defined %}
+  {%- for item in  oracle_listeners_config[lsnrinst.listener_name]['parameter'] %}
+
+{{item.param | upper() }}_{{ lsnrinst.listener_name }}={{item.value}}
+  {%- endfor %}
+
+{% endif %}
+
 {{ lsnrinst.listener_name }} =
   (DESCRIPTION =
 {% if oracle_listeners_config[lsnrinst.listener_name]['address'] is defined %}


### PR DESCRIPTION
Addional parameters could be configured for non GI/Restart
installations:

```
oracle_listeners_config:
  LISTENER1522:
    home: 12102-latest
    parameter:
      - param: "INBOUND_CONNECT_TIMEOUT"
        value: 0
      - param: "USE_SID_AS_SERVICE"
        value: "ON"
```

listener.ora:
```
INBOUND_CONNECT_TIMEOUT_LISTENER1522=0
USE_SID_AS_SERVICE_LISTENER1522=ON
```