### PR TITLE
oraswdb-install: added autostart support to multiple listeners for database in filesystems

### DIFF
--- a/roles/oraswdb-install/files/manage_oracle_rdbms_procs.sh
+++ b/roles/oraswdb-install/files/manage_oracle_rdbms_procs.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+#
+# Date: 10.11.2018
+#
+# Thorsten Bruhns (thorsten.bruhns@googlemail.com)
+#
+# The startup-scritp is bundeled with ansible-oracle
+# The .profile_<ORACLE_SID> files are needed for starting listeners
+#
+# Limitations:
+#  - 1 Listener per Instance
+#    An Instance can only start 1 Listener. Multieple Listeners inside
+#    an ORACLE_HOME are possible, when an Instance is existing for each
+#    Listener
+#
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+PROGNAME=`basename $0`
+PROGPATH=`echo $0 | sed -e 's,[\\/][^\\/][^\\/]*$,,'`
+
+function print_usage() {
+    echo "Usage:"
+    echo "  $PROGNAME -a <start|stop>"
+    echo "  $PROGNAME -m <abort|immediate>"
+    echo "  $PROGNAME -h"
+}
+
+function print_help() {
+    echo ""
+    print_usage
+    echo ""
+    echo "Start/Stop Oracle Listeners and Instances on Host"
+    echo ""
+    echo "-a/--action <start|stop> Start/Stop of all components"
+    echo "-m/--mode <abort|immediate> Shutdown Mode for all Databases"
+}
+
+setenv()
+{
+    SHORTOPTS="ha:m:"
+    LONGOPTS="help,action:mode:"
+
+    ARGS=$(getopt -s bash --options $SHORTOPTS  --longoptions $LONGOPTS --name $PROGNAME -- "$@" ) 
+    if [ ${?} -ne 0 ] ; then
+        exit
+    fi
+
+    eval set -- "$ARGS"
+
+    while true;
+    do
+        case "$1" in
+             -h|--help)
+                 print_help
+                 exit 0;;
+    
+              -a|--action)
+                  global_action=${2}
+                  export global_action
+                  shift 2;;
+
+              -m|--mode)
+                  global_dbmode=${2}
+                  export global_dbmode
+                  shift 2;;
+    
+              -s|--ORACLE_SID)
+                  ORACLE_SID=${2}
+                  export ORACLE_SID
+                  shift 2;;
+    
+              --)
+                  shift
+                  break;;
+        esac
+    done
+}
+
+function start_database() {
+
+    ORACLE_HOME=${1}
+    ORACLE_SID=${2}
+    ORA_STARTMODE=${3}
+    echo "########################################"
+    echo "ORACLE_HOME: "${ORACLE_HOME}
+    echo "ORACLE_SID : "${ORACLE_SID}
+
+    # Check for SPFile/PFile
+    test -f ${ORACLE_HOME}/dbs/spfile${ORACLE_SID}.ora || test -f ${ORACLE_HOME}/dbs/init${ORACLE_SID}.ora
+    if [ ${?} -ne 0 ] ; then
+        echo "no parameter file found."
+        echo "Skipping entry in oratab!"
+        return 1
+    fi
+
+    if [ ! -z "${global_dbmode}" ] ; then
+
+        DB_STARTMODE=${global_dbmode}
+        STARTDB=Y
+
+    elif [ ${ORA_STARTMODE} = 'Y' ] ; then
+
+        # 'Y' => Startup open
+        DB_STARTMODE=""
+        STARTDB=Y
+
+    elif [ ${ORA_STARTMODE} = 'M' ] ; then
+
+        DB_STARTMODE='MOUNT'
+        STARTDB=Y
+
+    fi
+
+    if [ ${STARTDB:-"N" = "Y" } ] ; then
+
+        # Using RMAN for startup
+        # => easy to switch from mount to open for running instance during execution
+        echo "startup ${DB_STARTMODE}" | ${ORACLE_HOME}/bin/rman  target /
+
+    else
+        echo "Skipping Oracle Instance: "${ORACLE_SID}" due to Startmode "${ORA_STARTMODE}
+    fi
+}
+
+function stop_database() {
+
+    ORACLE_HOME=${1}
+    ORACLE_SID=${2}
+    ORA_STOPMODE=${3}
+    echo "########################################"
+    # check for pmon
+    ps -C ora_pmon_${ORACLE_SID} > /dev/null 2>&1
+    if [ ${?} -ne 0 ] ; then
+        echo "Instance "${ORACLE_SID}" not running"
+        return
+    else
+        echo "Stopping Oracle Instance: "${ORACLE_SID}" with rman"
+
+        # Using RMAN for startup
+        # => easy to switch from mount to open for running instance during execution
+        echo "shutdown "${ORA_STOPMODE} | ${ORACLE_HOME}/bin/rman  target /
+
+    fi
+}
+
+function start_listener() {
+    ORACLE_HOME=${1}
+    LSNRNAME=${2}
+    echo "checking Listener: "${LSNRNAME}" in ORACLE_HOME: "${ORACLE_HOME}
+    ORACLE_BASE=$(${ORACLE_HOME}/bin/orabase)
+    ${ORACLE_HOME}/bin/lsnrctl status ${LSNRNAME} > /dev/null 2>&1
+    if [ ${?} -eq 0 ] ; then
+        echo "Listener still running"
+    else
+        ${ORACLE_HOME}/bin/lsnrctl start ${LSNRNAME}
+    fi
+}
+
+function stop_listener() {
+    ORACLE_HOME=${1}
+    LSNRNAME=${2}
+    echo "checking Listener: "${LSNRNAME}" in ORACLE_HOME: "${ORACLE_HOME}
+    ORACLE_BASE=$(${ORACLE_HOME}/bin/orabase)
+    ${ORACLE_HOME}/bin/lsnrctl status ${LSNRNAME} > /dev/null 2>&1
+    if [ ${?} -eq 0 ] ; then
+        ${ORACLE_HOME}/bin/lsnrctl stop ${LSNRNAME}
+    else
+        echo "Listener not running"
+    fi
+}
+
+function do_sidline() {
+    sidline=${1}
+
+    ORA_SID=$(echo $sidline | cut -d":" -f1)
+    ORA_HOME=$(echo $sidline | cut -d":" -f2)
+    ORA_STARTMODE=$(echo $sidline | cut -d":" -f3)
+    ORA_OWNER=$(stat -c '%U' ${ORA_HOME/bin/oracle})
+    PROFILE_FILE=$(getent passwd ${ORA_OWNER} | cut -d":" -f6)/.profile_${ORA_SID}
+
+    if [ ${ORA_OWNER:-"_"} != $(id -n -u) ] ; then
+        echo "Script started with wrong user."
+        echo "current user : "$(id -n -u)
+        echo "expected user: "${ORA_OWNER}
+        exit 50
+    fi
+
+    if [ ${global_action:-"unknown"} = "unknown" ] ; then
+
+        echo "no action found on command line."
+        print_usage
+        exit 99
+
+    elif [ ${global_action:-"unknown"} = "start" ] ; then
+
+        echo "########################################"
+        test -f ${PROFILE_FILE} && . ${PROFILE_FILE} > /dev/null
+        if [ ${?} -eq 0 ] ; then
+            echo "working on profile: "${PROFILE_FILE}
+            # listener need the LSNRNAME from .profile_!
+            start_listener ${ORA_HOME} ${LSNRNAME}
+        fi
+
+        start_database ${ORA_HOME} ${ORA_SID} ${ORA_STARTMODE}
+
+    elif [ ${global_action:-"unknown"} = "stop" ] ; then
+
+        echo "########################################"
+        echo "working on profile: "${PROFILE_FILE}
+        test -f ${PROFILE_FILE} && . ${PROFILE_FILE} > /dev/null
+        stop_database ${ORA_HOME} ${ORA_SID} ${global_dbmode:-"immediate"}
+
+        test -f ${PROFILE_FILE} && . ${PROFILE_FILE} > /dev/null
+        if [ ${?} -eq 0 ] ; then
+            echo "working on profile: "${PROFILE_FILE}
+            # listener need the LSNRNAME from .profile_!
+            stop_listener ${ORA_HOME} ${LSNRNAME}
+        fi
+
+
+    else
+
+        echo "wrong  action found on command line."
+        print_usage
+        exit 99
+
+    fi
+}
+
+
+setenv $*
+for sidline in $(cat /etc/oratab | grep -v "^#" ) ; do
+    do_sidline ${sidline}
+done

--- a/roles/oraswdb-install/tasks/init.yml
+++ b/roles/oraswdb-install/tasks/init.yml
@@ -1,8 +1,7 @@
 - name: install-home-db | Configure DB instances auto-startup service (init.d)
   template: src=dbora.j2 dest=/etc/init.d/dbora owner=root mode=750
   become: true
-  with_items: "{{db_homes_installed}}"
-  when: autostartup_service and hostinitdaemon == "init" and item.state|lower == 'present'
+  when: autostartup_service and hostinitdaemon == "init"
   tags: autostartup_service
 
 - name: install-home-db | Register dbora service (init.d)

--- a/roles/oraswdb-install/tasks/main.yml
+++ b/roles/oraswdb-install/tasks/main.yml
@@ -94,6 +94,14 @@
     tags:
       - nfsunmountdb
 
-  - include_tasks: "{{ hostinitdaemon }}.yml"
+  - name: install-home-db | copy start/stop script for autostart
+    copy: 
+      dest: /usr/local/bin
+      src: manage_oracle_rdbms_procs.sh
+      mode: 0755
+    tags: autostartup_service
+
+#  - include_tasks: "{{ hostinitdaemon }}.yml"
+  - include_tasks: "init.yml"
     when: autostartup_service
     tags: autostartup_service

--- a/roles/oraswdb-install/tasks/main.yml
+++ b/roles/oraswdb-install/tasks/main.yml
@@ -101,7 +101,6 @@
       mode: 0755
     tags: autostartup_service
 
-#  - include_tasks: "{{ hostinitdaemon }}.yml"
-  - include_tasks: "init.yml"
+  - include_tasks: "{{ hostinitdaemon }}.yml"
     when: autostartup_service
     tags: autostartup_service

--- a/roles/oraswdb-install/templates/dbora.j2
+++ b/roles/oraswdb-install/templates/dbora.j2
@@ -12,35 +12,28 @@
 #  chkconfig --add dbora
 #  chkconfig dbora on
 
-# Note: Change the value of ORACLE_HOME to specify the correct Oracle home
-# directory for your installation.
-# ORACLE_HOME=/u01/app/oracle/product/11.1.0/db_1
-ORACLE_HOME={{ oracle_home_db }}
-
 #
 # Note: Change the value of ORACLE to the login name of the oracle owner
 ORACLE={{ oracle_user }}
 
-PATH=${PATH}:$ORACLE_HOME/bin
 HOST=`hostname`
 PLATFORM=`uname`
-export ORACLE_HOME PATH
 
 case $1 in
 'start')
         echo -n $"Starting Oracle: "
-        su $ORACLE -c "$ORACLE_HOME/bin/dbstart $ORACLE_HOME"
+        su $ORACLE -c "/usr/local/bin/manage_oracle_rdbms_procs.sh -a start"
         ;;
 'stop')
         echo -n $"Shutting down Oracle: "
-        su $ORACLE -c "$ORACLE_HOME/bin/dbshut $ORACLE_HOME"
+        su $ORACLE -c "/usr/local/bin/manage_oracle_rdbms_procs.sh -a stop"
         ;;
 'restart')
         echo -n $"Shutting down Oracle: "
-        su $ORACLE -c "$ORACLE_HOME/bin/dbshut $ORACLE_HOME"
+        su $ORACLE -c "/usr/local/bin/manage_oracle_rdbms_procs.sh -a stop"
         sleep 5
         echo -n $"Starting Oracle: "
-        su $ORACLE -c "$ORACLE_HOME/bin/dbstart $ORACLE_HOME"
+        su $ORACLE -c "/usr/local/bin/manage_oracle_rdbms_procs.sh -a start"
         ;;
 *)
         echo "usage: $0 {start|stop|restart}"

--- a/roles/oraswdb-install/templates/oracle-rdbms-service.j2
+++ b/roles/oraswdb-install/templates/oracle-rdbms-service.j2
@@ -9,8 +9,8 @@ Requires=network.target
 [Service]
 Type=forking
 Restart=no
-ExecStart={{ oracle_home_db }}/bin/dbstart {{ oracle_home_db }}
-ExecStop={{ oracle_home_db }}/bin/dbshut {{ oracle_home_db }}
+ExecStart=/usr/local/bin/manage_oracle_rdbms_procs.sh -a start
+ExecStop=/usr/local/bin/manage_oracle_rdbms_procs.sh -a stop
 User={{ oracle_user }}
 
 [Install]


### PR DESCRIPTION
The stupid dbstart and dbstop has been replaced by a completly new designed script manage_oracle_rdbms_procs.sh.
The script is placed in /usr/local/bin and must be executed as the owner of the Oracle software. Instances are started when the state in oratab is 'Y' or 'M' for only 'startup mount' which is important in data-guards to protect against accidently using the active data-guard option.
All listeners are started when 'listener_name' is defined in oracle_databases for the instance.