### PR TITLE
oradb-manage-users: Added support for profiles

### DIFF
--- a/roles/oradb-manage-users/tasks/main.yml
+++ b/roles/oradb-manage-users/tasks/main.yml
@@ -11,6 +11,7 @@
           mode="{{ db_mode}}"
           schema={{ item.1.schema }}
           schema_password={{ user_cdb_password }}
+          profile={{ item.1.profile |default (omit) }}
           state={{ item.1.state }}
           default_tablespace={{ item.1.default_tablespace |default (omit)}}
           container={{ item.1.container |default(omit) }}
@@ -39,6 +40,7 @@
           mode="{{ db_mode}}"
           schema={{ item.1.schema }}
           schema_password={{ user_pdb_password }}
+          profile={{ item.1.profile |default (omit) }}
           state={{ item.1.state }}
           default_tablespace={{ item.1.default_tablespace |default (omit)}}
           update_password={{ item.1.update_password | default('on_create') }}


### PR DESCRIPTION
The parameter profile was missind in users.

Example:
oracle_databases:
  - home: 12201-latest
    oracle_db_name: testdb

    users:
      - schema: c##check_mk
        profile: c##check_mk_profile