### PR TITLE
oraswdb-install: Fixed autostart for 11.2 databases

### DIFF
--- a/roles/oraswdb-install/files/manage_oracle_rdbms_procs.sh
+++ b/roles/oraswdb-install/files/manage_oracle_rdbms_procs.sh
@@ -143,7 +143,7 @@ function stop_database() {
     ORA_STOPMODE=${3}
     echo "########################################"
     # check for pmon
-    ps -C ora_pmon_${ORACLE_SID} > /dev/null 2>&1
+    ps ax | grep "[0-9] ora_pmon_${ORACLE_SID}$" > /dev/null 2>&1
     if [ ${?} -ne 0 ] ; then
         echo "Instance "${ORACLE_SID}" not running"
         return


### PR DESCRIPTION
Oracle changed the presentation of process names with 12.1.
The used 'ps -C' was not able to find the pmon on the
process list.
This is the fix for #140.