### PR TITLE
oraswdb-manage-patches: Added option to stop processes before install…

### DIFF
--- a/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
+++ b/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
@@ -90,6 +90,7 @@
       patch_version={{ item.patchversion |default(omit)}}
       opatchauto=False
       conflict_check=True
+      stop_processes={{item.stop_processes |default(False)}}
       ocm_response_file={{ ocm_response_file | default(omit)}}
       output=verbose
       state={{ item.state}}


### PR DESCRIPTION
…ation

Added parameter stop_processes for automatic stop of
Insances and Listeber during opatch apply. This is
only valid for non opatchauto.
The processes are not stopped by default.

Add the following parameter to stop the processes:
12201-latest:
  home: db122-latest
  version: 12.2.0.1
  opatch:
    - patchid: 28822515
      path: 28828733/28822515
      stop_processes: True
      state: present