### PR TITLE
oradb-datapatch: extended support for datapatch

### DIFF
--- a/roles/oradb-datapatch/defaults/main.yml
+++ b/roles/oradb-datapatch/defaults/main.yml
@@ -31,3 +31,12 @@ oracle_env_lsnrctl:
 
 autostartup_service: false
 fail_on_db_not_exist: False
+
+oracle_db_home:  "{%- if item is defined -%}
+                    {%- if db_homes_config[item.home]['oracle_home'] is defined  -%}
+                         {{db_homes_config[item.home]['oracle_home']}}
+                    {%- else -%}
+                         {{oracle_base}}/{{db_homes_config[item.home]['version']}}/{{db_homes_config[item.home]['home']}}
+                    {%- endif -%}
+                 {%- endif -%}"
+

--- a/roles/oradb-datapatch/defaults/main.yml
+++ b/roles/oradb-datapatch/defaults/main.yml
@@ -13,8 +13,21 @@ db_service_name: "{%- if item.oracle_db_unique_name is defined -%}
 listener_port_template: "{% if item.listener_port is defined %}{{ item.listener_port }}{% else %}{{ listener_port }}{% endif %}"
 listener_port: 1521
 
+listener_home: "{%- if lsnrinst is defined -%}
+                  {%- if db_homes_config[lsnrinst.home]['oracle_home'] is defined -%}{{db_homes_config[lsnrinst.home]['oracle_home']}}
+                  {%- else -%}{{oracle_base}}/{{db_homes_config[lsnrinst.home]['version']}}/{{db_homes_config[lsnrinst.home]['home']}}
+                  {%- endif -%}
+                {%- endif -%}"
+
 oracle_env:
       ORACLE_HOME: "{{ oracle_home_db}}"
       LD_LIBRARY_PATH: "{{ oracle_home_db}}/lib"
 
+oracle_env_lsnrctl:
+      ORACLE_BASE: "{{ oracle_base }}"
+      ORACLE_HOME: "{{ listener_home }}"
+      LD_LIBRARY_PATH: "{{ listener_home }}/lib"
+      PATH: "{{ listener_home}}/bin:$PATH:/usr/local/bin:/bin:/sbin:/usr/bin:/usr/sbin"
+
+autostartup_service: false
 fail_on_db_not_exist: False

--- a/roles/oradb-datapatch/tasks/main.yml
+++ b/roles/oradb-datapatch/tasks/main.yml
@@ -1,8 +1,34 @@
+- name: oradb-datapatch | Start listener
+  shell: "export PATH=${ORACLE_HOME}/bin:${PATH}; lsnrctl start {{ lsnrinst.listener_name }} /dev/null; exit 0"
+  environment: "{{ oracle_env_lsnrctl }}"
+  become_user: "{{ oracle_user }}"
+  with_items: "{{ listener_installed }}"
+  loop_control:
+     loop_var: lsnrinst
+     label: "LISTENER: {{ lsnrinst.listener_name }} ORACLE_HOME: {{ listener_home }}"
+  when: lsnrinst.state|lower == 'present'
+
+- name: oradb-datapatch | Start database (non GI)
+  oracle_db:
+     oracle_home={{ oracle_home_db}}
+     db_name={{ dbh.oracle_db_name }}
+     db_unique_name={{ dbh.oracle_db_unique_name |default(omit) }}
+     sid={{ dbh.oracle_db_instance_name |default(omit) }}
+     state=started
+  become_user: "{{ oracle_user }}"
+  with_items: "{{ oracle_databases }}"
+  when: dbh.oracle_db_type == 'SI'
+  loop_control:
+     loop_var: dbh
+     label: "home: {{ dbh.home }} db_name: {{ dbh.oracle_db_name }}"
+  tags: startdb
+
 - name: oradb-datapatch | Run datapatch
   oracle_datapatch:
         oracle_home={{ oracle_home_db }}
         db_name={{ item.oracle_db_name }}
-        oracle_db_unique_name={{ item.oracle_db_unique_name |default(omit)}}
+        db_unique_name={{ item.oracle_db_unique_name |default(omit)}}
+        sid={{ item.oracle_db_instance_name |default(omit) }}
         output=verbose
         fail_on_db_not_exist={{ fail_on_db_not_exist }}
         user={{ db_user }}
@@ -14,4 +40,6 @@
   when: item.state|lower == 'present'
   become: True
   become_user: "{{ oracle_user }}"
+  loop_control:
+     label: "home: {{ item.home }} db_name: {{ item.oracle_db_name }}"
   tags: datapatch

--- a/roles/oradb-datapatch/tasks/main.yml
+++ b/roles/oradb-datapatch/tasks/main.yml
@@ -10,22 +10,22 @@
 
 - name: oradb-datapatch | Start database (non GI)
   oracle_db:
-     oracle_home={{ oracle_home_db}}
-     db_name={{ dbh.oracle_db_name }}
-     db_unique_name={{ dbh.oracle_db_unique_name |default(omit) }}
-     sid={{ dbh.oracle_db_instance_name |default(omit) }}
+#     oracle_home={{ oracle_home_db}}
+     oracle_home={{ oracle_db_home}}
+     db_name={{ item.oracle_db_name }}
+     db_unique_name={{ item.oracle_db_unique_name |default(omit) }}
+     sid={{ item.oracle_db_instance_name |default(omit) }}
      state=started
   become_user: "{{ oracle_user }}"
   with_items: "{{ oracle_databases }}"
-  when: dbh.oracle_db_type == 'SI'
+  when: item.oracle_db_type == 'SI'
   loop_control:
-     loop_var: dbh
-     label: "home: {{ dbh.home }} db_name: {{ dbh.oracle_db_name }}"
+     label: "home: {{ item.home }} db_name: {{ item.oracle_db_name }}"
   tags: startdb
 
 - name: oradb-datapatch | Run datapatch
   oracle_datapatch:
-        oracle_home={{ oracle_home_db }}
+        oracle_home={{ oracle_db_home }}
         db_name={{ item.oracle_db_name }}
         db_unique_name={{ item.oracle_db_unique_name |default(omit)}}
         sid={{ item.oracle_db_instance_name |default(omit) }}

--- a/roles/oradb-datapatch/tasks/main.yml
+++ b/roles/oradb-datapatch/tasks/main.yml
@@ -6,9 +6,9 @@
   loop_control:
      loop_var: lsnrinst
      label: "LISTENER: {{ lsnrinst.listener_name }} ORACLE_HOME: {{ listener_home }}"
-  when: lsnrinst.state|lower == 'present'
+  when: listener_installed is defined and lsnrinst.state|lower == 'present'
 
-- name: oradb-datapatch | Start database (non GI)
+- name: oradb-datapatch | Start database
   oracle_db:
 #     oracle_home={{ oracle_home_db}}
      oracle_home={{ oracle_db_home}}
@@ -18,7 +18,6 @@
      state=started
   become_user: "{{ oracle_user }}"
   with_items: "{{ oracle_databases }}"
-  when: item.oracle_db_type == 'SI'
   loop_control:
      label: "home: {{ item.home }} db_name: {{ item.oracle_db_name }}"
   tags: startdb


### PR DESCRIPTION
The role has been rewritten for Single-Instance configurations.
This role can be used to install PSU/RU for 12.1.0.2+ databases.

The following roles can be used to install a new PSU:
- oraswdb-manage-patches
- oradb-datapatch

The role starts listener and instances in SI configurations, because
oraswdb-manage-patches is stopping the listener and instances for the
ORACLE_HOME.

Don't forget the updates in ansible-oracle-modules for this commit.
- oravirt/ansible-oracle-modules#92
- oravirt/ansible-oracle-modules#98