### PR TITLE
oraswgi-manage-patches: added Support for non rolling apply in GI

### DIFF
--- a/roles/oraswgi-manage-patches/tasks/main.yml
+++ b/roles/oraswgi-manage-patches/tasks/main.yml
@@ -85,6 +85,7 @@
         patch_id={{item.patchid}}
         patch_version={{ item.patchversion |default(omit)}}
         opatchauto=True
+        rolling={{item.rolling | default(True)}}
         conflict_check=True
         ocm_response_file={{ ocm_response_file | default(omit)}}
         output=verbose


### PR DESCRIPTION
The parameter rolling has beend added to support non rolling
installations for opatchauto.
The default for rolling is True

gi_patches:
  18.3.0.0:
    opatchauto:
      - patchid: 29301682
        rolling: False

This PR needs 2 other PRs 
- oravirt/ansible-oracle-modules#100
- #159 