### PR TITLE
Remove unwanted or conflicting patches from DB

### DIFF
--- a/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
+++ b/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
@@ -38,6 +38,30 @@
   tags:
     - ocmconfig
 
+- name: db-opatch | Remove unwanted patches from DB
+  oracle_opatch:
+      oracle_home={{ oracle_home_db }}
+      patch_base={{ oracle_patch_install }}/{{ db_version}}/{{ item.path | default (item.patchid)}}/
+      patch_id={{item.patchid}}
+      patch_version={{ item.patchversion |default(omit)}}
+      opatchauto=False
+      conflict_check=True
+      stop_processes={{item.stop_processes |default(False)}}
+      ocm_response_file={{ ocm_response_file | default(omit)}}
+      output=verbose
+      state={{ item.state}}
+  with_items:
+      - "{{db_homes_config[dbh.home]['opatch']}}"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags:
+    - apply_patch_db
+  when:
+    - apply_patches_db|bool
+    - db_homes_config[dbh.home]['opatch'] is defined
+    - item.state == "absent"
+  register: psuapplym
+
 - name: db-opatch | Manage opatchauto patches for DB (non-gi)
   oracle_opatch:
       oracle_home={{ oracle_home_db }}


### PR DESCRIPTION
Conflicting one-off patches have to be removed before applying opatchauto.

- Situation:

  - DB 12.1.0.2 EE
  - PSU Jan 19
  - One Off Patch 18633374 (among others)

- Objective:

  - PSU Apr 19

- Problem:

  - conflicting patch 18633374 has to be removed before installing PSU Apr 19

- Suggested solution:

  - Copy (duplicate) task "db-opatch | Manage patches for DB"
    - new name: "db-opatch | Remove unwanted patches from DB"
    - insert just before "db-opatch | Manage opatchauto patches for DB (non-gi)"
  - when clause extended by 'item.state == "absent"'
  - (sideshow: removing 18633374 requires https://github.com/oravirt/ansible-oracle-modules/pull/110

==> Is there a different solution for the problem of conflicting patches?
