### PR TITLE
oradb-rman: rman_tns_admin depends on oracle_base

### DIFF
--- a/roles/oradb-rman/defaults/main.yml
+++ b/roles/oradb-rman/defaults/main.yml
@@ -9,7 +9,7 @@
   rman_script_dir: "{% if item is defined and item.0.rman_script_dir is defined %}{{item.0.rman_script_dir}}{% else %}{{oracle_base}}/rman/{% endif %}"
   rman_log_dir: "{% if item is defined and item.0.rman_log_dir is defined %}{{item.0.rman_log_dir}}{% else %}{{oracle_base}}/rman/log/{% endif %}"
 
-  rman_tns_admin: /u01/app/oracle/rman/network/admin
+  rman_tns_admin: "{{oracle_base}}/rman/network/admin"
   rman_wallet_loc: "{{oracle_base}}/rman/network/wallet"
   rman_wallet_password: "oracleWallet1"
 


### PR DESCRIPTION
The variable rman_tns_admin is dependent on oracle_base
instead of /u01/app/oracle/rman/network/admin