### PR TITLE
cx_oracle: Limit installed Version to <8.0

### DIFF
--- a/roles/cxoracle/tasks/main.yml
+++ b/roles/cxoracle/tasks/main.yml
@@ -2,7 +2,7 @@
 ---
 - name: Install cx_oracle
   pip:
-     name=cx_oracle
+     name=cx_oracle<8.0
      extra_args="{{ extra_args }}"
      umask={{ cx_oracle_umask | default (omit)}}
      state=present


### PR DESCRIPTION
The newer versions of cx_oracle could not be installed with pip2
without Python3. The change to Python3 needs more tests in ansible-oracle-modules.

This is a quick fix to install cx_Oracle with pip2 for ansible-oracle.

This is a PR for #209 