### PR TITLE
chopt: new strategy for change chopt options

### DIFF
--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -184,6 +184,7 @@
       - elfutils-libelf-devel.i686
       - elfutils-libelf-devel
       - cpp
+      - lsof
 
   oracle_packages_sles:
       - ksh
@@ -206,6 +207,7 @@
       - libstdc++-devel-32bit
       - libgcc_s1
       - libgcc_s1-32bit
+      - lsof
       - make
       - sysstat
       - xorg-x11-driver-video

--- a/roles/oraswdb-install/defaults/main.yml
+++ b/roles/oraswdb-install/defaults/main.yml
@@ -78,6 +78,10 @@
                    {%- elif ansible_os_family == 'Suse'   and ansible_distribution_major_version | int >= 12 %}systemd
                    {%- else %}{% if ansible_service_mgr is defined %}{{ ansible_service_mgr }}{% else %}init{% endif %}{% endif %}"
 
+  forcechopt: false
+  # choptcheck is a dummy for 'creates' during chopt-task to force an execution
+  choptcheck: "{% if forcechopt | bool %}dochopt{% endif %}"
+
   disable_EE_options: True
   oracle_EE_options: "{%- if   db_homes_config[dbh.home]['version'] in ('18.3.0.0') %}{{ oracle_EE_options_183 }}
                       {%- elif db_homes_config[dbh.home]['version'] in ('19.3.0.0') %}{{ oracle_EE_options_193 }}

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -46,12 +46,24 @@
 # => use this method for all >= 11.2 (Doc ID 948061.1)
 # touch a statefile instead checking the logfile from chopt
 # we cannot use default/main.yml here. => complicated structure for 'enabled' 'disabled'...
+# check for running processes on $ORACLE_HOME/bin/oracle
+# 1st check for installed lsof, because systems could miss it...
 - name: install-home-db | Change Database options with chopt
   shell: |
+    set -eu
+    if lsof > /dev/null  2>&1 ; then
+      if lsof {{ oracle_home_db }}/bin/oracle > /dev/null 2>&1 ; then
+        echo "running Oracle processes found. Aborting chopt!"
+        exit 10
+      fi
+    else
+      echo "Please install lsof"
+      exit 9
+    fi
     {{ oracle_home_db }}/bin/chopt {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}} \
     && touch {{ oracle_home_db }}/install/chopt_{{item.option}}_{{ item.state }}.state
   args: 
-    creates: "{{ oracle_home_db }}/install/chopt_{{item.option}}_{{ item.state }}.state"
+    creates: "{{ oracle_home_db }}/install/chopt_{{item.option}}_{{ item.state }}.state{{ choptcheck }}"
   with_items:
     - "{{oracle_EE_options}}"
   become: yes

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -44,10 +44,14 @@
 # oracle_EE_options = '' => Nothing to do
 # licence options in 11.2+ must be changed by chopt
 # => use this method for all >= 11.2 (Doc ID 948061.1)
-# test -f => reduce number of executions when > 1 database in oracle_databases for same ORACLE_HOME
+# touch a statefile instead checking the logfile from chopt
 # we cannot use default/main.yml here. => complicated structure for 'enabled' 'disabled'...
 - name: install-home-db | Change Database options with chopt
-  shell: "test -f {{ oracle_home_db }}/install/{{ item.state | replace(true, 'enable') | replace(false, 'disable') }}_{{item.option}}.log || {{ oracle_home_db }}/bin/chopt {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}}"
+  shell: |
+    {{ oracle_home_db }}/bin/chopt {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}} \
+    && touch {{ oracle_home_db }}/install/chopt_{{item.option}}_{{ item.state }}.state
+  args: 
+    creates: "{{ oracle_home_db }}/install/chopt_{{item.option}}_{{ item.state }}.state"
   with_items:
     - "{{oracle_EE_options}}"
   become: yes


### PR DESCRIPTION
Oracle changed the logfile for chopt in 19c. This leads to problems with the old
impletation, due to recompiles of oracle binary for each execution of the task.
The new solution is not dependent on the logfile anymore.

Warning!
This change will recompile the binaries during the 1st execution, because
the statefile was not created with the old solution.

this PR fixes #219 