### PR TITLE
oraswdb-install: Install 19c from Golden Image

### DIFF
--- a/roles/oraswdb-install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb-install/tasks/19.3.0.0.yml
@@ -1,7 +1,7 @@
 
 - name: install-home-db | Extract files
   unarchive:
-      src={{ oracle_stage }}/{{ item[0].filename }}
+      src={{ oracle_stage }}/{{ oracle_sw_source_local }}/{{ db_homes_config[item[1].home].imagename | default(item[0].filename) }}
       dest={{ oracle_home_db }}
       copy=no
       creates="{{ oracle_home_db }}/{{ item[0].creates}}"
@@ -17,13 +17,15 @@
 
 - name: install-home-db | Extract files (from remote location)
   unarchive:
-      src={{ oracle_stage_remote }}/{{ item[0].filename }}
+      src={{ oracle_stage_remote }}/{{ db_homes_config[item[1].home].imagename | default(item[0].filename) }}
       dest={{ oracle_home_db }}
       copy=no
       creates="{{ oracle_home_db }}/{{ item[0].creates}}"
   with_nested:
     - "{{oracle_sw_image_db}}"
     - "{{db_homes_installed}}"
+  loop_control:
+    label: "{{ oracle_stage_remote }}/{{ db_homes_config[item[1].home].imagename | default(item[0].filename) | default('')}}"
   become: yes
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster}}"

--- a/roles/oraswdb-install/tasks/main.yml
+++ b/roles/oraswdb-install/tasks/main.yml
@@ -36,7 +36,11 @@
     when: not is_sw_source_local and oracle_sw_copy
 
   - name: install-home-db | Transfer oracle installfiles to server (local)
-    copy: src={{ oracle_sw_source_local }}/{{ item[0].filename }} dest={{ oracle_stage }} mode=775 force=no
+    copy: 
+      src: "{{ oracle_sw_source_local }}/{{ db_homes_config[item[1].home].imagename | default(item[0].filename) }}"
+      dest: "{{ oracle_stage }}" 
+      mode: 775
+      force: no
     with_nested:
       - "{{oracle_sw_image_db}}"
       - "{{db_homes_installed}}"


### PR DESCRIPTION
The name for the installation archive in 19c could be defined in oracle_db_homes.

Example:
db_homes_config:
  db198:
    home: db198
    version: 19.3.0.0
    # imagename => use File as GoldenImage
    imagename: db_home_19.8.zip

The imagename defines the used filename for the archive to unzip.
Please create the archive with oui before:

    $ORACLE_HOME/runInstaller -createGoldImage -silent -destinationLocation "${ORACLE_BASE}/db_golden_image