### PR TITLE
cxoracle: Support custom installation source

### DIFF
--- a/roles/cxoracle/tasks/main.yml
+++ b/roles/cxoracle/tasks/main.yml
@@ -2,11 +2,9 @@
 ---
 - name: Install cx_oracle
   pip:
-     name=cx_oracle<8.0
+     name="{{ cx_oracle_source | default('cx_oracle<8.0') }}"
      extra_args="{{ extra_args }}"
      umask={{ cx_oracle_umask | default (omit)}}
      state=present
-  #with_items: "{{oracle_databases}}"
   when: install_cx_oracle
   tags: cx_oracle
-  #environment: "{{oracle_env}}"


### PR DESCRIPTION
A new parameter has been added to support custom source definition for cx_Oracle.
This is needed when ansible-oracle is used in environments without public internet connectivity.

How to user?

Download cx_Oracle without installation:
    pip install --download /tmp 'cx_oracle<8.0'

Store the file in a directory availible from target host.

Set follwoing variable in inventory:

    cx_oracle_source="file:///tmp/cx_Oracle-7.3.0-cp27-cp27mu-manylinux1_x86_64.whl"