### PR TITLE
fixed a problem with thsnames ignoring state in tnsnames_installed

### DIFF
--- a/roles/oradb-manage-db/tasks/tnsnames.yml
+++ b/roles/oradb-manage-db/tasks/tnsnames.yml
@@ -22,7 +22,7 @@
     create: True
     group: "{{ oracle_group }}"
     owner: "{{ oracle_user }}"
-    state: present
+    state: "{{ tnsinst.state | default('present') }}"
     mode: 0644
     insertafter: "EOF"
     marker: "# {mark} Ansible managed for  {{ tnsinst.tnsname }}"


### PR DESCRIPTION
Currently having conditional state in tnsnames_installed is ignored and all entries found there are created. It does not even respect state: absent for removing tnsnames.ora entries.

With this change this gets fixed and tnsnames entry will only then exist, when state is defined to present in tnsnames_installed.