### PR TITLE
Support for OL8 and RHEL8

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -20,6 +20,9 @@
   configure_public_yum_repo: true
   configure_motd: true
   configure_ntp: true
+  ntp_type: "{%- if ansible_distribution_major_version|int>=8 %}chrony
+             {%- else %}ntp
+             {%- endif %}"
   common_packages: "{%- if ansible_distribution_major_version|int==6%}{{ common_packages_el6 }}
                     {%- elif ansible_distribution_major_version|int==7 %}{{ common_packages_el7 }}
                     {%- elif ansible_distribution_major_version|int==8 %}{{ common_packages_el8 }}
@@ -174,7 +177,7 @@
 #      - collectl
 #      - rlwrap
 #      - tigervnc-server
-      - ntp
+      - chrony
       - expect
 #      - git
       - lvm2

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,12 +1,18 @@
 # Lab playbook - sets up the host specific shit
 ---
 
-  epel_rpm: "{% if ansible_distribution_major_version|int==6%}{{ epel6_rpm }}{%elif ansible_distribution_major_version|int==7 %}{{ epel7_rpm }}{% else %}None{% endif %}"
+  epel_rpm: "{%- if ansible_distribution_major_version|int==6 %}{{ epel6_rpm }}
+             {%- elif ansible_distribution_major_version|int==7 %}{{ epel7_rpm }}
+             {%- elif ansible_distribution_major_version|int==8 %}{{ epel8_rpm }}
+             {%- else %}None
+             {%- endif %}"
+  epel8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
   epel7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   epel6_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   ol_repo_file: "{% if ansible_distribution_major_version|int==6%}{{ ol6_repo_file }}{%elif ansible_distribution_major_version|int==7 %}{{ ol7_repo_file }}{% else %}None{% endif %}"
   ol6_repo_file: public-yum-ol6.repo
   ol7_repo_file: public-yum-ol7.repo
+  ol8_repo_file: public-yum-ol8.repo
   repo_dir: /etc/yum.repos.d/
 #  default_user: ansible
   install_os_packages: true
@@ -14,7 +20,10 @@
   configure_public_yum_repo: true
   configure_motd: true
   configure_ntp: true
-  common_packages: "{% if ansible_distribution_major_version|int==6%}{{ common_packages_el6 }}{%elif ansible_distribution_major_version|int==7 %}{{ common_packages_el7 }}{% else %}None{% endif %}"
+  common_packages: "{%- if ansible_distribution_major_version|int==6%}{{ common_packages_el6 }}
+                    {%- elif ansible_distribution_major_version|int==7 %}{{ common_packages_el7 }}
+                    {%- elif ansible_distribution_major_version|int==8 %}{{ common_packages_el8 }}
+                    {%- else %}None{% endif %}"
   common_packages_el6:
       - screen
       - facter
@@ -94,7 +103,58 @@
       - btrfs-progs
       - procps
       - psmisc
-      
+
+  common_packages_el8:
+      - screen
+      - facter
+      - procps
+      - module-init-tools
+      - ethtool
+      - lsof
+      - bc
+      - binutils
+      - elfutils-libelf
+      - elfutils-libelf-devel
+      - fontconfig-devel
+      - glibc
+      - glibc-devel
+      - ksh
+      - libaio
+      - libaio-devel
+      - libXrender
+      - libX11
+      - libXau
+      - libXi
+      - libXtst
+      - libgcc
+      - libnsl
+      - librdmacm
+      - libstdc++
+      - libstdc++-devel
+      - libxcb
+      - libibverbs
+      - make
+      - smartmontools
+      - sysstat 
+      - nc
+      - bind-utils
+      - nfs-utils
+      - unzip
+      - openssh-clients
+      - rlwrap
+      - tigervnc-server
+      - expect
+      - git
+      - lvm2
+      - xfsprogs
+      - autofs
+      - parted
+      - mlocate
+      - ksh
+      - lvm2
+      - xfsprogs
+      - psmisc
+
   common_packages_sles:
       - screen
 #      - facter

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -54,8 +54,8 @@
     tags:
       - commonpackages
 
-  - name: Start and enable NTP
-    service: name=ntpd  state=started  enabled=yes
+  - name: Start and enable ntp or chrony
+    service: name={{ ntp_type }}d  state=started  enabled=yes
     when: configure_ntp
 
   - name: Add motd

--- a/roles/orahost/tasks/RedHat-8.yml
+++ b/roles/orahost/tasks/RedHat-8.yml
@@ -1,0 +1,17 @@
+- name: Disable Transparent Hugepages (runtime)
+  shell: if test -f {{ item.path }}; then {{ item.disable }} {{ item.path }}; fi;
+  with_items:
+      - "{{ transparent_hugepage_disable }}"
+  tags: tphnuma
+
+- name: Disable Transparent Hugepages (permanently)
+  lineinfile: dest={{ item.rclocal}} line="{{ item.disable }} {{ item.path }}" state=present
+  with_items:
+      - "{{ transparent_hugepage_disable }}"
+  tags: tphnuma
+
+- name: Fix permissions on /etc/rc.d/rc.local
+  file: path={{ item.rclocal}} mode=755
+  with_items:
+      - "{{ transparent_hugepage_disable }}"
+  tags: tphnuma

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -9,13 +9,17 @@
     tags:
      - oscheck
 
-  - name: Install packages required by Oracle on OL/RHEL
+  # OL8/RHEL8 has all needed RPMs in orahost role!
+  - name: Install packages required by Oracle on OL/RHEL version 6 and 7
     yum:
        name: "{{ oracle_packages }}"
        state: installed
        enablerepo: "{{ extrarepos_enabled |default (omit, True) }}"
        disablerepo: "{{ extrarepos_disabled |default (omit, True) }}"
-    when: install_os_packages and ansible_os_family == 'RedHat'
+    when: 
+      - install_os_packages
+      - ansible_os_family == 'RedHat'
+      - "facter_os.release.major is version('7', '<=')"
     tags: os_packages, oscheck
 
   - name: Install packages required by Oracle on SLES


### PR DESCRIPTION
This PR adds support for OL8 and RHEL8 as OS.

Important Note:
Oracle 19.3 is not detecting OL8/RHEL8 as a valid OS. Please use a previous created GoldenImage as image for dsw-install.