### PR TITLE
oraswgi-install: Install from Golden-Image

### DIFF
--- a/roles/oraswgi-install/defaults/main.yml
+++ b/roles/oraswgi-install/defaults/main.yml
@@ -98,6 +98,12 @@
 
   opatcharchive: "{{ oracle_stage_install }}/{{ oracle_install_version_gi }}/{% for opatchfile in oracle_opatch_patch if  opatchfile['version']==oracle_install_version_gi %}{{ opatchfile['filename'] }}{% endfor %}"
 
+  oracle_gi_image: "{%- if oracle_sw_copy %}{{ oracle_stage }}
+                  {%- else %}{{ oracle_stage_remote }}
+                  {%- endif %}
+                  {%- if oracle_install_image_gi is defined %}/{{ oracle_install_image_gi }}
+                  {%- else %}//{{ item.filename }}
+                  {%- endif %}"
 
   oracle_sw_image_gi:                                              # Files containing the installation media for Grid Infrastructure
        - { filename: LINUX.X64_193000_grid_home.zip, version: 19.3.0.0, creates: 'install/.img.bin' }

--- a/roles/oraswgi-install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/19.3.0.0.yml
@@ -3,6 +3,8 @@
   - name: install-home-gi | Extract files to ORACLE_HOME (gi)
     unarchive: src={{ oracle_gi_image }}  dest={{ oracle_home_gi }} copy=no
     with_items: "{{oracle_sw_image_gi}}"
+    loop_control:
+      label: "{{ oracle_gi_image | default ('') }}"
     args:
         creates: "{{ oracle_home_gi }}/root.sh"
     become: yes
@@ -12,7 +14,6 @@
     when: 
       - oracle_home_gi not in checkgiinstall.stdout 
       - oracle_install_version_gi == item.version
-      - oracle_sw_unpack
 
   # Check for an existing GRID_HOME before reinstallation of OPatch
   - name: install-home-gi | Check for file GridSetup.sh

--- a/roles/oraswgi-install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/19.3.0.0.yml
@@ -1,7 +1,7 @@
 ---
 
   - name: install-home-gi | Extract files to ORACLE_HOME (gi)
-    unarchive: src={{ oracle_stage }}/{{ item.filename }}  dest={{ oracle_home_gi }} copy=no
+    unarchive: src={{ oracle_gi_image }}  dest={{ oracle_home_gi }} copy=no
     with_items: "{{oracle_sw_image_gi}}"
     args:
         creates: "{{ oracle_home_gi }}/root.sh"
@@ -12,7 +12,7 @@
     when: oracle_home_gi not in checkgiinstall.stdout and oracle_install_version_gi == item.version and oracle_sw_copy and oracle_sw_unpack
 
   - name: install-home-gi | Extract files to ORACLE_HOME (gi) (from remote location)
-    unarchive: src={{ oracle_stage_remote }}/{{ item.filename }}  dest={{ oracle_home_gi }} copy=no
+    unarchive: src={{ oracle_gi_image }}  dest={{ oracle_home_gi }} copy=no
     with_items: "{{oracle_sw_image_gi}}"
     args:
         creates: "{{ oracle_home_gi }}/root.sh"

--- a/roles/oraswgi-install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/19.3.0.0.yml
@@ -9,18 +9,10 @@
     become_user: "{{ grid_install_user }}"
     tags:
       - oragridswunpack
-    when: oracle_home_gi not in checkgiinstall.stdout and oracle_install_version_gi == item.version and oracle_sw_copy and oracle_sw_unpack
-
-  - name: install-home-gi | Extract files to ORACLE_HOME (gi) (from remote location)
-    unarchive: src={{ oracle_gi_image }}  dest={{ oracle_home_gi }} copy=no
-    with_items: "{{oracle_sw_image_gi}}"
-    args:
-        creates: "{{ oracle_home_gi }}/root.sh"
-    become: yes
-    become_user: "{{ grid_install_user }}"
-    tags:
-    - oragridswunpack
-    when: oracle_home_gi not in checkgiinstall.stdout and oracle_install_version_gi == item.version and not oracle_sw_copy
+    when: 
+      - oracle_home_gi not in checkgiinstall.stdout 
+      - oracle_install_version_gi == item.version
+      - oracle_sw_unpack
 
   # Check for an existing GRID_HOME before reinstallation of OPatch
   - name: install-home-gi | Check for file GridSetup.sh


### PR DESCRIPTION
The following variable has been added to support GI/Restart
installations from Golden-Images.

   oracle_install_image_gi: grid_home_19.11.zip

Restrictions:
This is only supported for 19c at the moment.
Creating a Golden-Images for Oracle Restart requires a running installation of Oracle Restart.