### PR TITLE
orasw-meta: moved variables from oraswdb-install to orasw-meta

### DIFF
--- a/roles/orasw-meta/defaults/main.yml
+++ b/roles/orasw-meta/defaults/main.yml
@@ -1,3 +1,16 @@
+---
+oracle_user: oracle                        # User that will own the Oracle Installations.
+grid_user: grid
+grid_install_user: "{% if role_separation %}{{ grid_user }}{% else %}{{ oracle_user }}{% endif %}"
+oracle_user_home: "/home/{{ oracle_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
+grid_user_home: "/home/{{ grid_install_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
+oracle_group: oinstall                          # Primary group for oracle_user.
+oper_group: oper
+dba_group: dba                          # Primary group for oracle_user.
+asmoper_group: asmoper
+asmdba_group: asmdba                          # Primary group for oracle_user.
+asmadmin_group: asmadmin                          # Primary group for oracle_user.
+
 db_homes_config:
   18300-base:
     home: db1-base

--- a/roles/oraswdb-install/defaults/main.yml
+++ b/roles/oraswdb-install/defaults/main.yml
@@ -1,17 +1,5 @@
   #master_node: true
 
-  oracle_user: oracle                        # User that will own the Oracle Installations.
-  grid_user: grid
-  grid_install_user: "{% if role_separation %}{{ grid_user }}{% else %}{{ oracle_user }}{% endif %}"
-  oracle_user_home: "/home/{{ oracle_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
-  grid_user_home: "/home/{{ grid_install_user }}" # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
-  oracle_group: oinstall                          # Primary group for oracle_user.
-  oper_group: oper
-  dba_group: dba                          # Primary group for oracle_user.
-  asmoper_group: asmoper
-  asmdba_group: asmdba                          # Primary group for oracle_user.
-  asmadmin_group: asmadmin                          # Primary group for oracle_user.
-
   hostgroup: "{{ group_names[0] }}"
   hostgroup_hub: "{{ hostgroup }}-hub"
   hostgroup_leaf: "{{ hostgroup }}-leaf"


### PR DESCRIPTION
Moving some variables into the meta role to reduce duplicate
deffinitions in defaults/main.yml.