### PR TITLE
Summary of fixes from ansible-oracle-modules for ansible-oracle

### DIFF
--- a/library/oracle_db
+++ b/library/oracle_db
@@ -594,10 +594,14 @@ def ensure_db_state (module,msg,oracle_home,db_name,db_unique_name,sid, archivel
 
 	change_restart_sql = []
 	change_db_sql = []
-	supp_log_check_sql = 'select SUPPLEMENTAL_LOG_DATA_MIN,SUPPLEMENTAL_LOG_DATA_PL,SUPPLEMENTAL_LOG_DATA_SR,SUPPLEMENTAL_LOG_DATA_PK,SUPPLEMENTAL_LOG_DATA_UI from v$database'
 	log_check_sql = 'select log_mode,force_logging, flashback_on from v$database'
-	supp_log_check_ = execute_sql_get(module,msg,cursor,supp_log_check_sql)
 	log_check_ = execute_sql_get(module,msg,cursor,log_check_sql)
+
+	if major_version >= '19.0':
+		supp_log_check_sql = 'select SUPPLEMENTAL_LOG_DATA_MIN,SUPPLEMENTAL_LOG_DATA_PL,SUPPLEMENTAL_LOG_DATA_SR,SUPPLEMENTAL_LOG_DATA_PK,SUPPLEMENTAL_LOG_DATA_UI from v$database'
+		supp_log_check_ = execute_sql_get(module,msg,cursor,supp_log_check_sql)
+		if supp_log_check_[0][0] != slcomp:
+			change_db_sql.append(slsql)
 
 	if israc_[0][0] == 'NO':
 		israc = False
@@ -656,9 +660,6 @@ def ensure_db_state (module,msg,oracle_home,db_name,db_unique_name,sid, archivel
 
 	if log_check_[0][2] != fbcomp:
 		change_db_sql.append(fbsql)
-
-	if supp_log_check_[0][0] != slcomp:
-		change_db_sql.append(slsql)
 
 	if len(change_db_sql) > 0 or len(change_restart_sql) > 0:
 

--- a/library/oracle_db
+++ b/library/oracle_db
@@ -601,6 +601,14 @@ def ensure_db_state (module,msg,oracle_home,db_name,db_unique_name,sid, archivel
 		supp_log_check_sql = 'select SUPPLEMENTAL_LOG_DATA_MIN,SUPPLEMENTAL_LOG_DATA_PL,SUPPLEMENTAL_LOG_DATA_SR,SUPPLEMENTAL_LOG_DATA_PK,SUPPLEMENTAL_LOG_DATA_UI from v$database'
 		supp_log_check_ = execute_sql_get(module,msg,cursor,supp_log_check_sql)
 		if supp_log_check_[0][0] != slcomp:
+
+			if supplemental_logging == True:
+				slcomp = 'YES'
+				slsql = alterdb_sql + ' add supplemental log data'
+			else:
+				slcomp = 'NO'
+				slsql = alterdb_sql +  ' drop supplemental log data'
+
 			change_db_sql.append(slsql)
 
 	if israc_[0][0] == 'NO':
@@ -628,13 +636,6 @@ def ensure_db_state (module,msg,oracle_home,db_name,db_unique_name,sid, archivel
 	else:
 		fbcomp = 'NO'
 		fbsql = alterdb_sql +  ' flashback off'
-
-	if supplemental_logging == True:
-		slcomp = 'YES'
-		slsql = alterdb_sql + ' add supplemental log data'
-	else:
-		slcomp = 'NO'
-		slsql = alterdb_sql +  ' drop supplemental log data'
 
 	if def_tbs_type[0] != default_tablespace_type:
 		deftbstypesql = 'alter database set default %s tablespace ' % (default_tablespace_type)

--- a/library/oracle_db
+++ b/library/oracle_db
@@ -703,7 +703,8 @@ def apply_restart_changes(module,msg,oracle_home,db_name,db_unique_name,sid,inst
 			for sql in change_restart_sql:
 				execute_sql(module,msg,cursor,sql)
 				if stop_db(module,msg,oracle_home,db_name,db_unique_name,sid):
-					if start_db(module,msg,oracle_home,db_name,db_unique_name, sid):
+					start_db_state = start_db(module,msg,oracle_home,db_name,db_unique_name, sid)
+					if start_db_state in ('ok', 'changed'):
 						if newdb:
 							msg = 'Database %s successfully created (%s) ' % (db_name, archcomp)
 							if output == 'verbose':
@@ -762,13 +763,25 @@ def start_db (module,msg, oracle_home, db_name, db_unique_name, sid):
 	if gimanaged:
 		if db_unique_name is not None:
 			db_name = db_unique_name
-		command = '%s/bin/srvctl start database -d %s' % (oracle_home,db_name)
+		command = '%s/bin/srvctl status database -d %s' % (oracle_home,db_name)
 		(rc, stdout, stderr) = module.run_command(command)
 		if rc != 0:
 			msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
 			module.fail_json(msg=msg, changed=False)
+		elif 'Database is running' in stdout:
+			return 'ok'
+		elif 'Database is not running' in stdout:
+
+			command = '%s/bin/srvctl start database -d %s' % (oracle_home,db_name)
+			(rc, stdout, stderr) = module.run_command(command)
+			if rc != 0:
+				msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+				module.fail_json(msg=msg, changed=False)
+			else:
+				return 'changed'
 		else:
-			return True
+			msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+			module.fail_json(msg=msg, changed=False)
 	else:
 		if sid is not None:
 			os.environ['ORACLE_SID'] = sid
@@ -789,7 +802,7 @@ def start_db (module,msg, oracle_home, db_name, db_unique_name, sid):
 			msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, startup_sql)
 			module.fail_json(msg=msg, changed=False)
 		else:
-			return True
+			return 'changed'
 
 
 def start_instance (module,msg, oracle_home, db_name, db_unique_name,sid, open_mode, instance_name, host_name, israc):
@@ -1033,9 +1046,13 @@ def main():
 			msg = "Database not found. %s" % msg
 			module.fail_json(msg=msg, changed=False)
 		else:
-			if start_db (module, msg, oracle_home, db_name, db_unique_name, sid):
+			start_db_state = start_db (module, msg, oracle_home, db_name, db_unique_name, sid)
+                        if start_db_state == 'changed':
 				msg = "Database started."
 				module.exit_json(msg=msg, changed=True)
+                        if start_db_state == 'ok':
+				msg = "Database already running."
+				module.exit_json(msg=msg, changed=False)
 			else:
 				msg = "Startup failed. %s" % msg
 				module.fail_json(msg=msg, changed=False)

--- a/library/oracle_db
+++ b/library/oracle_db
@@ -1047,12 +1047,12 @@ def main():
 			module.fail_json(msg=msg, changed=False)
 		else:
 			start_db_state = start_db (module, msg, oracle_home, db_name, db_unique_name, sid)
-                        if start_db_state == 'changed':
+			if start_db_state == 'changed':
 				msg = "Database started."
 				module.exit_json(msg=msg, changed=True)
-                        if start_db_state == 'ok':
-				msg = "Database already running."
-				module.exit_json(msg=msg, changed=False)
+			elif start_db_state == 'ok':
+					msg = "Database already running."
+					module.exit_json(msg=msg, changed=False)
 			else:
 				msg = "Startup failed. %s" % msg
 				module.fail_json(msg=msg, changed=False)

--- a/library/oracle_db
+++ b/library/oracle_db
@@ -377,7 +377,7 @@ def create_db (module, msg, oracle_home, sys_password, system_password, dbsnmp_p
 			initparam += 'db_name=%s,db_unique_name=%s,' % (db_name,db_unique_name)
 
 		if domain is not None:
-			initparam += 'db_domain=%s' % domain
+			initparam += 'db_domain=%s,' % domain
 
 		if initparams is not None:
 			paramslist = ",".join(initparams)

--- a/library/oracle_opatch
+++ b/library/oracle_opatch
@@ -301,7 +301,7 @@ def stop_process(module, oracle_home):
                    p_status = p.wait()
 
                    if output:
-                       for lline in output.split('\n'):
+                       for lline in output.decode('utf-8').split('\n'):
 
                            proclen = len("%s/bin/tnslsnr " % (oracle_home))
 

--- a/library/oracle_parameter
+++ b/library/oracle_parameter
@@ -106,7 +106,7 @@ def check_parameter_exists(module, mode, msg, cursor, name):
             msg = error.message+ 'sql: ' + sql
             return False
 
-    if result > 0:
+    if result:
         return True
     else:
         msg = 'The parameter (%s) doesn\'t exist' % name

--- a/library/oracle_profile
+++ b/library/oracle_profile
@@ -181,7 +181,7 @@ def ensure_profile_state(cursor, module, msg, name, state, attribute_name, attri
             current_attributes = get_current_attributes (cursor, module, msg, name, attribute_names_)
 
             # Convert to dict and compare current with wanted
-            if cmp(dict(current_attributes),dict(wanted_attributes)) is not 0:
+            if dict(current_attributes) != dict(wanted_attributes):
                 for i in wanted_attributes:
                     total_sql.append("alter profile %s limit %s %s " % (name, i[0], i[1]))
 


### PR DESCRIPTION
The following commits are picked fromPRs:
- oravirt/ansible-oracle-modules#176
a37c1a9 oracle_opatch: Bugfix for Python3
- oravirt/ansible-oracle-modules#175
e86e95e oracle_profile: Bugfix for Python3
- oravirt/ansible-oracle-modules#174
612a9ee oracle_parameter: Support for Python3
- oravirt/ansible-oracle-modules#168
7ec00e7 fixed db_domain handling
- oravirt/ansible-oracle-modules#147
47fc3e9 oracle_db: Bugfix for empty slsql
dc3a32b oracle_db: fixed ORA-00904: invalid identifier sql: select SUPPLEMENTAL_LOG_DATA_MIN
- oravirt/ansible-oracle-modules#98
429aaae oracle_db: Bugfix for start_db in Oracle Restart
860d9ee oracle_db: fixed wrong identation

