### PR TITLE
Support for read-only ORACLE_HOMEs

### DIFF
--- a/changelogs/fragments/273-readonly-homes.yml
+++ b/changelogs/fragments/273-readonly-homes.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Support of Read-Only ORACLE_HOMEs (#273)"

--- a/roles/oradb_manage_db/defaults/main.yml
+++ b/roles/oradb_manage_db/defaults/main.yml
@@ -66,6 +66,20 @@ listener_home: "{%- if lsnrinst is defined -%}\
                   {%- endif -%}\
                 {%- endif -%}"
 
+listener_home_config: "{%- if lsnrinst is defined -%}
+                  {%- if db_homes_config[lsnrinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[lsnrinst.home]['oracle_home_name'] }}
+                  {%- else -%}{{ listener_home }}
+                  {%- endif -%}
+                {%- elif tnsinst is defined -%}
+                  {%- if db_homes_config[tnsinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[tnsinst.home]['oracle_home_name'] }}
+                  {%- else -%}{{ listener_home }}
+                  {%- endif -%}
+                {%- elif sqlnetinst is defined -%}
+                  {%- if db_homes_config[sqlnetinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[sqlnetinst.home]['oracle_home_name'] }}
+                  {%- else -%}{{ listener_home }}
+                  {%- endif -%}
+                {%- endif -%}"
+
 oracle_env_lsnrctl:
   ORACLE_BASE: "{{ oracle_base }}"
   ORACLE_HOME: "{{ listener_home }}"

--- a/roles/oradb_manage_db/defaults/main.yml
+++ b/roles/oradb_manage_db/defaults/main.yml
@@ -66,18 +66,18 @@ listener_home: "{%- if lsnrinst is defined -%}\
                   {%- endif -%}\
                 {%- endif -%}"
 
-listener_home_config: "{%- if lsnrinst is defined -%}
-                  {%- if db_homes_config[lsnrinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[lsnrinst.home]['oracle_home_name'] }}
-                  {%- else -%}{{ listener_home }}
-                  {%- endif -%}
-                {%- elif tnsinst is defined -%}
-                  {%- if db_homes_config[tnsinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[tnsinst.home]['oracle_home_name'] }}
-                  {%- else -%}{{ listener_home }}
-                  {%- endif -%}
-                {%- elif sqlnetinst is defined -%}
-                  {%- if db_homes_config[sqlnetinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[sqlnetinst.home]['oracle_home_name'] }}
-                  {%- else -%}{{ listener_home }}
-                  {%- endif -%}
+listener_home_config: "{%- if lsnrinst is defined -%}\
+                  {%- if db_homes_config[lsnrinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[lsnrinst.home]['oracle_home_name'] }}\
+                  {%- else -%}{{ listener_home }}\
+                  {%- endif -%}\
+                {%- elif tnsinst is defined -%}\
+                  {%- if db_homes_config[tnsinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[tnsinst.home]['oracle_home_name'] }}\
+                  {%- else -%}{{ listener_home }}\
+                  {%- endif -%}\
+                {%- elif sqlnetinst is defined -%}\
+                  {%- if db_homes_config[sqlnetinst.home]['readonly_home'] | default(false) -%}{{ oracle_base }}/homes/{{ db_homes_config[sqlnetinst.home]['oracle_home_name'] }}\
+                  {%- else -%}{{ listener_home }}\
+                  {%- endif -%}\
                 {%- endif -%}"
 
 oracle_env_lsnrctl:

--- a/roles/oradb_manage_db/tasks/listener_details.yml
+++ b/roles/oradb_manage_db/tasks/listener_details.yml
@@ -1,10 +1,10 @@
 ---
-- ansible.builtin.debug: msg="ORACLE_HOME {{ listener_home }}"  # noqa unnamed-task
+- ansible.builtin.debug: msg="ORACLE_BASE_HOME {{ listener_home_config }}"  # noqa unnamed-task
   tags: listener2
 
 - name: listener | create custom configuration in listener.ora
   ansible.builtin.blockinfile:
-    path: "{{ listener_home }}/network/admin/listener.ora"
+    path: "{{ listener_home_config }}/network/admin/listener.ora"
     backup: true
     create: true
     mode: 0644

--- a/roles/oradb_manage_db/tasks/sqlnet.yml
+++ b/roles/oradb_manage_db/tasks/sqlnet.yml
@@ -1,13 +1,13 @@
 ---
-- ansible.builtin.debug: msg="sqlnet in ORACLE_HOME {{ listener_home }}"  # noqa unnamed-task
+- ansible.builtin.debug: msg="ORACLE_BASE_HOME {{ listener_home_config }}"  # noqa unnamed-task
   tags: sqlnet2
 
 - name: sqlnet.ora | create IFILE entry in sqlnet.ora
   ansible.builtin.lineinfile:
-    line: "IFILE={{ listener_home }}/network/admin/sqlnet_ansible.ora"
+    line: "IFILE={{ listener_home_config }}/network/admin/sqlnet_ansible.ora"
     regexp: "^IFILE=/"
     insertbefore: BOF
-    path: "{{ listener_home }}/network/admin/sqlnet.ora"
+    path: "{{ listener_home_config }}/network/admin/sqlnet.ora"
     backup: true
     create: true
     group: "{{ oracle_group }}"
@@ -18,7 +18,7 @@
 
 - name: sqlnet.ora | create custom configuration in sqlnet_ansible.ora
   ansible.builtin.lineinfile:
-    path: "{{ listener_home }}/network/admin/sqlnet_ansible.ora"
+    path: "{{ listener_home_config }}/network/admin/sqlnet_ansible.ora"
     line: "{{ item.name }}={{ item.value }}"
     regexp: "^{{ item.name }}="
     backup: true

--- a/roles/oradb_manage_db/tasks/tnsnames.yml
+++ b/roles/oradb_manage_db/tasks/tnsnames.yml
@@ -1,5 +1,5 @@
 ---
-- ansible.builtin.debug: msg="ORACLE_HOME {{ listener_home }}"  # noqa unnamed-task
+- ansible.builtin.debug: msg="ORACLE_BASE_HOME {{ listener_home_config }}"  # noqa unnamed-task
   tags: tnsnames
 
 - name: tnsnames.ora | create IFILE entry in tnsnames.ora
@@ -7,7 +7,7 @@
     line: "IFILE={{ listener_home }}/network/admin/tnsnames_ansible.ora"
     regexp: "^IFILE=/"
     insertbefore: BOF
-    path: "{{ listener_home }}/network/admin/tnsnames.ora"
+    path: "{{ listener_home_config }}/network/admin/tnsnames.ora"
     backup: true
     create: true
     group: "{{ oracle_group }}"
@@ -18,7 +18,7 @@
 
 - name: tnsnames.ora | create custom configuration in tnsnames_ansible.ora
   ansible.builtin.blockinfile:
-    path: "{{ listener_home }}/network/admin/tnsnames_ansible.ora"
+    path: "{{ listener_home_config }}/network/admin/tnsnames_ansible.ora"
     backup: true
     create: true
     group: "{{ oracle_group }}"

--- a/roles/oraswdb_install/defaults/main.yml
+++ b/roles/oraswdb_install/defaults/main.yml
@@ -22,40 +22,8 @@ oracle_sw_extract_path: "{%- if '18' in db_version -%}\
                               {{ oracle_stage }}/{{ item[0].version }}\
                           {%- endif -%}"
 
-# oracle_home_db: "{% if dbh is defined %}
-#                    {%- if dbh.oracle_home is defined %}{{ dbh.oracle_home }}
-#                    {%- else %}{{ oracle_base}}/{{ dbh.oracle_version_db }}/{{ dbh.home }}
-#                    {%- endif %}
-#                  {%- elif item.0 is defined %}
-#                    {%- if item.0.oracle_home is defined %}{{ item.0.oracle_home}}
-#                    {%- else %}{{ oracle_base }}/{{ item.0.oracle_version_db }}/{{ item.0.home }}
-#                    {%- endif %}
-#                  {%- elif item is defined %}
-#                    {%- if item.oracle_home is defined %}{{ item.oracle_home}}
-#                    {%- else %}{{ oracle_base }}/{{ item.oracle_version_db }}/{{ item.home }}
-#                    {%- endif %}
-#                  {%- endif %}"
-
-
 oracle_profile_name: ".profile_{{ dbh.home }}"
 
-# "{%- if item is defined -%}
-#                          {%- if item.oracle_home is defined -%}
-#                             .profile_{{ item.oracle_home |basename}}_{{ item.oracle_version_db}}
-#                          {%- elif item.home is defined -%}
-#                             .profile_{{ item.home }}_{{item.oracle_version_db}}
-#                          {%- elif item.oracle_home is defined -%}
-#                             .profile_{{item.oracle_home |basename}}_{{item.oracle_version_db}}
-#                          {%- endif- %}
-#                       {% else %}
-#                          {%- if dbh.oracle_home is defined -%}
-#                             .profile_{{ dbh.oracle_home |basename}}_{{ dbh.oracle_version_db}}
-#                          {%- elif dbh.home is defined -%}
-#                             .profile_{{ dbh.home }}_{{dbh.oracle_version_db}}
-#                          {%- else -%}
-#                             .profile_{{dbh.home}}_{{dbh.oracle_db_name}}
-#                          {%- endif -%}
-#                       {%- endif -%}"    # Name of profile-file. Sets up the environment for that ORACLE_HOME
 oracle_hostname: "{{ ansible_fqdn }}"                            # Full (FQDN) name of the host
 www_download_bin: curl                              # curl (shell module) or get_url module
 

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,7 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.shell: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion"
-  # noqa command-instead-of-shell
+  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion"
   become: true
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster }}"

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,6 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion"
+  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
   become: true
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster }}"
@@ -18,3 +18,5 @@
   tags:
     - oradbinstall
   ignore_errors: true
+
+- include_tasks: roohctl.yml

--- a/roles/oraswdb_install/tasks/21.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/21.3.0.0.yml
@@ -1,7 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.shell: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion"
-  # noqa command-instead-of-shell
+  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion"
   become: true
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster }}"

--- a/roles/oraswdb_install/tasks/21.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/21.3.0.0.yml
@@ -1,6 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion"
+  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
   become: true
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster }}"
@@ -18,3 +18,5 @@
   tags:
     - oradbinstall
   ignore_errors: true
+
+- include_tasks: roohctl.yml

--- a/roles/oraswdb_install/tasks/roohctl.yml
+++ b/roles/oraswdb_install/tasks/roohctl.yml
@@ -1,0 +1,31 @@
+---
+# we need a known value for ORACLE_HOME_NAME for later usage in ansible-oracle
+- name: install_home_db | Check Inventory for enabled readonly home
+  ansible.builtin.assert:
+    fail_msg: Missing oracle_home_name key in db_homes_config for enabled readonly_home
+    that:
+      - db_homes_config[dbh.home]['oracle_home_name'] is defined
+  when:
+    - db_homes_config[dbh.home]['readonly_home'] | default(false)
+
+- name: install_home_db | Configure Read Only Oracle Home
+  ansible.builtin.command: "{{ oracle_home_db }}/bin/roohctl {% if db_homes_config[dbh.home]['readonly_home'] | default(false) %}-enable{% else %}-disable{% endif %}"
+  become: true
+  become_user: "{{ oracle_user }}"
+  run_once: "{{ configure_cluster }}"
+  when:
+    - oracle_home_db not in existing_dbhome.stdout_lines
+  tags:
+    - roohctl
+  register: roohctl
+  failed_when: roohctl.rc not in [0]
+
+- ansible.builtin.debug: var=roohctl.stdout_lines
+  # noqa unnamed-task ignore-errors
+  run_once: "{{ configure_cluster }}"
+  when:
+    - oracle_home_db not in existing_dbhome.stdout_lines
+    - roohctl.changed
+  tags:
+    - roohctl
+  ignore_errors: true


### PR DESCRIPTION
This PR introduce the ability to use read-only ORACLE_HOMEs for Database-Homes.

Add the following  to oracle_homes

```
db_homes_config:
  db19-si-ee:
    oracle_home_name: db19_si_ee
    readonly_home: true
```

The default for `readonly_home` is `false`. If it is `true`, the parameter `oracle_home_name` must be set as well.
Important: Onlly alphanumeric, numbers and underscore characters are allowed for `oracle_home_name`.

The mode for an ORALCE_HOME is only set during the initial runInstaller execution.
**Do not change `readonly_home` after installation, because that creates some problems for existing Listeners and Database Instances.**
