### PR TITLE
oradb_manage_db: Bugfix listener.ora for multiple Instances on 1 host

### DIFF
--- a/changelogs/fragments/274-listener_details.yml
+++ b/changelogs/fragments/274-listener_details.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oradb_manage_db: Bugfix listener.ora for multiple Instances on 1 host (#275)"

--- a/roles/oradb_manage_db/templates/listener_details.j2
+++ b/roles/oradb_manage_db/templates/listener_details.j2
@@ -30,10 +30,10 @@
 {%- endif %}
 
 {# config_sid_list is used as a helper. jinja2 doesn't allow the exposing of variables from inside a loop to outside before version 2.10! #}
-{%- set config_sid_list = 0 %}
+{%- set config_sid_list = namespace(created = False) %}
 {# The following loop is executed only once for the header 'SID_LIST_... #}
-{%- for testsid in oracle_databases if testsid.listener_name is defined and testsid.listener_name == lsnrinst.listener_name and config_sid_list == 0 %}
-  {%- set config_sid_list =  1 %}
+{%- for testsid in oracle_databases if testsid.listener_name is defined and testsid.listener_name == lsnrinst.listener_name and not config_sid_list.created%}
+  {%- set config_sid_list.created =  True -%}
 
 SID_LIST_{{ lsnrinst.listener_name }} =
   (SID_LIST =


### PR DESCRIPTION
This fixes issue #152 .

Make sure to use Jinja 2.10 or newer for namespaces.