### PR TITLE
ansible-lint: Move to  v6.6.1

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,12 @@
 ---
-
 use_default_rules: true
+
+skip_list:
+  - name[casing]
+  - name[play]
+  - key-order[task]
+  - jinja[spacing]
+  - yaml[comments-indentation]
 
 exclude_paths:
   - .github

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -19,8 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Lint roles
-        # Use custom action repo due to open PRs 43 and 48
-        uses: ansible-community/ansible-lint-action@v6.5.2
+        uses: ansible-community/ansible-lint-action@v6.6.1
         with:
           targets: |
             inventory/*

--- a/changelogs/fragments/277-ansible-lint.yml
+++ b/changelogs/fragments/277-ansible-lint.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "ansible-lint: Move to  v6.6.1 (#277)"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,10 @@
 FROM docker.io/library/python:3.10-slim-buster
 
 ARG ansible_version
+ARG ansible_lint_version
+
+ENV ansible_version=5.8.0
+ENV ansible_lint_version=6.6.1
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
@@ -27,7 +31,7 @@ RUN apt-get update -y &&\
 
 RUN python3 -m pip install --upgrade pip
 
-RUN pip3 install ansible===${ansible_version} && \
+RUN pip3 install ansible===${ansible_version} ansible-lint===${ansible_lint_version} && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/ && \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        ansible_lint_version: 6.6.1
         ansible_version: 5.8.0
     #     ansible_version: 2.9.26
     # container_name: ansible-oracle-2.9.26


### PR DESCRIPTION
Update ansible-lint to 6.6.1.

Added ansible-lint to Dockerfile. ansible-lint could be used with ansible in Docker Container together.