### PR TITLE
Make it possible to install Oracle 19.3 on RedHat 8

### DIFF
--- a/changelogs/fragments/284-ol8-fix.yml
+++ b/changelogs/fragments/284-ol8-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oraswdb_install: Make it possible to install Oracle 19.3 on RedHat 8 (#284)"

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,6 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.command: "{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
+  ansible.builtin.shell: "CV_ASSUME_DISTID=OL7 {{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
   become: true
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster }}"

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,6 +1,7 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.shell: "CV_ASSUME_DISTID=OL7 {{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
+  ansible.builtin.shell: "{% if ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 8 and db_homes_config[dbh.home]['imagename'] is not defined %}CV_ASSUME_DISTID=OL7 {% endif %}{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
+  # noqa command-instead-of-shell
   become: true
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster }}"


### PR DESCRIPTION
Installing Oracle 19.3 on a RedHat 8 box will raise:

`TASK [opitzconsulting.ansible_oracle.oraswdb_install : install_home_db | Install Oracle Database Server] ***
Sunday 09 October 2022  10:01:22 +0200 (0:00:00.164)       0:03:56.251 ********
fatal: [molecule-install_orahome-default]: FAILED! => {"changed": true, "cmd": ["/opt/oracle/product/19c/runInstaller", "-responseFile", "/opt/oracle/stage/rsp/19c_molecule-installorahome-default.rsp", "-ignorePrereq", "-silent", "-waitforcompletion"], "delta": "0:00:02.106271", "end": "2022-10-09 10:01:25.339855", "failed_when_result": true, "msg": "non-zero return code", "rc": 255, "start": "2022-10-09 10:01:23.233584", "stderr": "", "stderr_lines": [], "stdout": "Launching Oracle Database Setup Wizard...\n\n[WARNING] [INS-08101] Unexpected error while executing the action at state: 'supportedOSCheck'\n   CAUSE: No additional information available.\n   ACTION: Contact Oracle Support Services or refer to the software manual.\n   SUMMARY:\n       - java.lang.NullPointerException", "stdout_lines": ["Launching Oracle Database Setup Wizard...", "", "[WARNING] [INS-08101] Unexpected error while executing the action at state: 'supportedOSCheck'", "   CAUSE: No additional information available.", "   ACTION: Contact Oracle Support Services or refer to the software manual.", "   SUMMARY:", "       - java.lang.NullPointerException"]}`

This pull request is about implementing the workaround recommended by the following Oracle support note:

[Requirements for Installing Oracle Database/Client 19c on OL8 or RHEL8 64-bit (x86-64) (Doc ID 2668780.1)](https://support.oracle.com/epmos/faces/SearchDocDisplay?_adf.ctrl-state=1cojc1xj2c_308&_afrLoop=14550049654793#aref_section39)



