### PR TITLE
Make the deployment of ocenv configurable

### DIFF
--- a/changelogs/fragments/285-ocenv-deploy-fix.yml
+++ b/changelogs/fragments/285-ocenv-deploy-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oradb-manage-db: Make the deployment of ocenv configurable (#285)"

--- a/roles/oradb_manage_db/defaults/main.yml
+++ b/roles/oradb_manage_db/defaults/main.yml
@@ -142,3 +142,5 @@ shell_aliases:
   - "lsnrstop='lsnrctl stop $LSNRNAME'"
   - "lsnrstatus='lsnrctl status $LSNRNAME'"
   - "lsnrservice='lsnrctl services $LSNRNAME'"
+
+deploy_ocenv: true  # deploy ocenv scripts

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -13,6 +13,7 @@
                     {%- endif -%}"
 
 - include_tasks: ocenv.yml
+  when: deploy_ocenv
   tags:
     - always
 


### PR DESCRIPTION
While I can understand the utility of the ocenv script, it should be possible to decide if you want it deployed or not.