### PR TITLE
Ignore ModuleNotFoundError when disabling selinux

### DIFF
--- a/changelogs/fragments/selinux-modulenotfound-fix.yml
+++ b/changelogs/fragments/selinux-modulenotfound-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "orahost: Ignore ModuleNotFoundError when disabling selinux"

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -67,6 +67,7 @@
   when: disable_selinux and ansible_os_family == 'RedHat'
   tags: selinux
   register: selinux
+  failed_when: selinux.msg | default('ok', True) is not search('(^ok$|libselinux-python|(SELinux state changed))')
 
 - name: Disable selinux (runtime)  # noqa command-instead-of-shell
   ansible.builtin.shell: setenforce 0


### PR DESCRIPTION
Apparently, disabling selinux can be picky. To reproduce, I used "Rendanic/oraclelinux-7.x" vagrant box. When applying the orahost role for the first time, no error is raised, but if you do it again, you'll get:

```
TASK [opitzconsulting.ansible_oracle.orahost : Disable selinux (permanently)] ***
Thursday 13 October 2022  13:51:12 +0300 (0:00:00.473)       0:00:15.256 ******
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'selinux'
fatal: [instance]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libselinux-python) on instance's Python /usr/bin/python3.6. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```

This is not good from an idempotence point of view, so this pull request is about implementing the fix recommended here: https://github.com/ansible/ansible/issues/62467.

I have also tested with "Rendanic/oraclelinux-8.x" and the "Disable selinux (permanently)" task is working as expected, so it seems that  just the OL-7.x version is affected. However, this change plays nicely with OL-8.x as well, so I don't think it's worthwhile to apply the "failed_when" clause just for the 7.x variant.
