### PR TITLE
Use byte streams for sqlplus process communication

### DIFF
--- a/changelogs/fragments/sqlplus-pipe-byte-streams-fix.yml
+++ b/changelogs/fragments/sqlplus-pipe-byte-streams-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oracle_sqldba module: Use byte streams for sqlplus process communication."

--- a/plugins/modules/oracle_sqldba
+++ b/plugins/modules/oracle_sqldba
@@ -245,7 +245,7 @@ def run_sql(sql, username, password, pdb):
         if timeout > 0:
             t = Timer(timeout, kill_process)
             t.start()
-        [sout, serr] = sql_process.communicate(input = sql_cmd)
+        [sout, serr] = sql_process.communicate(input = sql_cmd.encode())
     except Exception as e:
         err_msg += 'Could not call sqlplus. %s. called: %s.' % (to_native(e), " ".join(sqlplus()))
         return "[ERR]"
@@ -256,13 +256,13 @@ def run_sql(sql, username, password, pdb):
         err_msg += "called: %s\nreturncode: %d\nresult: %s. stderr = %s." % (sql_cmd, sql_process.returncode, sout, serr)
         return "[ERR]"
     sqlerr_pat = re.compile("^(ORA|TNS|SP2)-[0-9]+", re.MULTILINE)
-    sqlplus_err = sqlerr_pat.search(sout)
+    sqlplus_err = sqlerr_pat.search(sout.decode())
     if sqlplus_err:
         err_msg += "[ERR] sqlplus: %s\nERR Code: %s.\n" % (sql_cmd, sqlplus_err.group())
         return "[ERR]\n%s\n" % sout.strip()
 
     changed = True
-    return sout.strip()
+    return sout.decode().strip()
 
 
 def check_creates_sql(sql, scope):

--- a/plugins/modules/oracle_sqldba
+++ b/plugins/modules/oracle_sqldba
@@ -266,8 +266,9 @@ def run_sql(sql, username, password, pdb):
 
 
 def check_creates_sql(sql, scope):
-    global pdb_list
+    global pdb_list, err_msg
 
+    err_msg = ""
     if not sql.endswith(";"):
         sql += ";"
     if scope == 'cdb':


### PR DESCRIPTION
When using oracle_sqldba module with a rhel8 box with python3 I get the following error:

```
TASK [Shutdown the database.] **************************************************
Tuesday 18 October 2022  13:47:52 +0300 (0:00:01.854)       0:00:01.882 *******
fatal: [instance]: FAILED! => {"changed": false, "msg": "[ERR]\nCould not call sqlplus. memoryview: a bytes-like object is required, not 'str'. called: /opt/oracle/product/19c/bin/sqlplus -l -s /nolog."}
```

It can be reproduced with a task like the following:

```
tasks:
  - name: Shutdown the database.
    oracle_sqldba:
      sql: "shutdown immediate"
      scope: db
      oracle_home: /opt/oracle/product/19c
      oracle_db_name: MOLDB01
    become_user: oracle
```
