### PR TITLE
Release: ansible-oracle v3.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v3.2.0
+======
+
+Bugfixes
+--------
+
+- oracle_sqldba module: Use byte streams for sqlplus process communication.
+- oradb-manage-db: Make the deployment of ocenv configurable (#285)
+- oraswdb_install: Make it possible to install Oracle 19.3 on RedHat 8 (#284)
+
 v3.1.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -14,4 +14,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 3.1.0
+version: 3.2.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -160,3 +160,14 @@ releases:
     - 282-sles_hugepages.yml
     - 282-sles_packages.yml
     release_date: '2022-10-03'
+  3.2.0:
+    changes:
+      bugfixes:
+      - 'oracle_sqldba module: Use byte streams for sqlplus process communication.'
+      - 'oradb-manage-db: Make the deployment of ocenv configurable (#285)'
+      - 'oraswdb_install: Make it possible to install Oracle 19.3 on RedHat 8 (#284)'
+    fragments:
+    - 284-ol8-fix.yml
+    - 285-ocenv-deploy-fix.yml
+    - sqlplus-pipe-byte-streams-fix.yml
+    release_date: '2022-10-30'

--- a/changelogs/fragments/284-ol8-fix.yml
+++ b/changelogs/fragments/284-ol8-fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_install: Make it possible to install Oracle 19.3 on RedHat 8 (#284)"

--- a/changelogs/fragments/285-ocenv-deploy-fix.yml
+++ b/changelogs/fragments/285-ocenv-deploy-fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oradb-manage-db: Make the deployment of ocenv configurable (#285)"

--- a/changelogs/fragments/sqlplus-pipe-byte-streams-fix.yml
+++ b/changelogs/fragments/sqlplus-pipe-byte-streams-fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oracle_sqldba module: Use byte streams for sqlplus process communication."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from Branch oc on https://github.com/opitzconsulting/ansible-oracle"
-version: 3.1.0
+version: 3.2.0
 repository: https://github.com/opitzconsulting/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v3.2.0
======

Bugfixes
--------

- oracle_sqldba module: Use byte streams for sqlplus process communication.
- oradb-manage-db: Make the deployment of ocenv configurable (#285)
- oraswdb_install: Make it possible to install Oracle 19.3 on RedHat 8 (#284)
