### PR TITLE
Add option to set the path of the dbca template

### DIFF
--- a/changelogs/fragments/dbca_templatepath.yml
+++ b/changelogs/fragments/dbca_templatepath.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oradb_manage_db: Add option to set the path of the dbca template"

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -25,7 +25,7 @@
 # without executing a template task before.
 - name: manage_db | Copy custom dbca Templates for Database to ORACLE_HOME/assistants/dbca/templates
   ansible.builtin.template:
-    src: "{{ dbh.dbca_templatename }}"
+    src: "{{ (dbh.dbca_templatepath | default(''), dbh.dbca_templatename) | path_join }}"
     dest: "{{ oracle_home_db }}/assistants/dbca/templates/{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"


### PR DESCRIPTION
Currently `dbca_templatename` can't refer to a file outside of the `./templates` sub-directory. This is a problem if you maintain a location with various dbca template files, outside of the role/playbook structure. So, it should be possible to provide the source path of the dbca template as well. I know that you can set `dbca_copy_template` to `false` and copy the template file yourself, but I feel that `oradb_manage_db` role should be smart enough to handle this simple scenario by its own. Another way to address this would be to specify the full path as part of the `dbca_templatename` property and apply a `basename` filter here and there, but I think it is more complicated and it doesn't pay off the trouble.
