### PR TITLE
Fix oracle export environment variables

### DIFF
--- a/changelogs/fragments/manage_oracle_rdbms_procs.yml
+++ b/changelogs/fragments/manage_oracle_rdbms_procs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oraswdb_install: Fix oracle export environment variables"

--- a/roles/oraswdb_install/files/manage_oracle_rdbms_procs.sh
+++ b/roles/oraswdb_install/files/manage_oracle_rdbms_procs.sh
@@ -91,8 +91,8 @@ setenv()
 
 function start_database() {
 
-    ORACLE_HOME=${1}
-    ORACLE_SID=${2}
+    export ORACLE_HOME=${1}
+    export ORACLE_SID=${2}
     ORA_STARTMODE=${3}
     echo "########################################"
     echo "ORACLE_HOME: "${ORACLE_HOME}
@@ -137,8 +137,8 @@ function start_database() {
 
 function stop_database() {
 
-    ORACLE_HOME=${1}
-    ORACLE_SID=${2}
+    export ORACLE_HOME=${1}
+    export ORACLE_SID=${2}
     ORA_STOPMODE=${3}
     echo "########################################"
     # check for pmon
@@ -157,7 +157,7 @@ function stop_database() {
 }
 
 function start_listener() {
-    ORACLE_HOME=${1}
+    export ORACLE_HOME=${1}
     LSNRNAME=${2}
     echo "checking Listener: "${LSNRNAME}" in ORACLE_HOME: "${ORACLE_HOME}
     ORACLE_BASE=$(${ORACLE_HOME}/bin/orabase)
@@ -170,7 +170,7 @@ function start_listener() {
 }
 
 function stop_listener() {
-    ORACLE_HOME=${1}
+    export ORACLE_HOME=${1}
     LSNRNAME=${2}
     echo "checking Listener: "${LSNRNAME}" in ORACLE_HOME: "${ORACLE_HOME}
     ORACLE_BASE=$(${ORACLE_HOME}/bin/orabase)


### PR DESCRIPTION
The script invoked by systemd to start/stop databases is not working properly.

```
root@molecule--default ~ # systemctl start oracle-rdbms
Job for oracle-rdbms.service failed because the control process exited with error code.
See "systemctl status oracle-rdbms.service" and "journalctl -xe" for details.

root@molecule--default ~ # journalctl -xe
...
Nov 13 09:50:28 molecule--default systemd[1]: Starting Oracle Database(s) and Listener...
-- Subject: Unit oracle-rdbms.service has begun start-up
-- Defined-By: systemd
-- Support: https://access.redhat.com/support
--
-- Unit oracle-rdbms.service has begun starting up.
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336423]: for MOLDB:/opt/oracle/product/19c:Y
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336423]: ########################################
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336423]: ########################################
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336423]: ORACLE_HOME: /opt/oracle/product/19c
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336423]: ORACLE_SID : MOLDB
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336448]: Message file RMAN<lang>.msb not found
Nov 13 09:50:28 molecule--default manage_oracle_rdbms_procs.sh[336448]: Verify that ORACLE_HOME is set properly
Nov 13 09:50:28 molecule--default systemd[1]: oracle-rdbms.service: Control process exited, code=exited status=1
Nov 13 09:50:28 molecule--default systemd[1]: oracle-rdbms.service: Failed with result 'exit-code'.
-- Subject: Unit failed
-- Defined-By: systemd
-- Support: https://access.redhat.com/support
--
-- The unit oracle-rdbms.service has entered the 'failed' state with result 'exit-code'.
Nov 13 09:50:28 molecule--default systemd[1]: Failed to start Oracle Database(s) and Listener.
-- Subject: Unit oracle-rdbms.service has failed
-- Defined-By: systemd
-- Support: https://access.redhat.com/support
--
-- Unit oracle-rdbms.service has failed.
--
-- The result is failed.

oracle@molecule--default ~ $ env | grep ORA
```

It could be related to #265, but I'm not sure. For now, this pull request provides a quick fix for this issue.