### PR TITLE
Make some of the j2 templates source configurable

### DIFF
--- a/changelogs/fragments/custom_template_path.yml
+++ b/changelogs/fragments/custom_template_path.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "common, orahost, oraswdb_install: Make some of the j2 templates source configurable"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -23,6 +23,7 @@ install_os_packages: true
 configure_epel_repo: true
 configure_public_yum_repo: true
 configure_motd: true
+motd_template: motd.j2
 configure_ntp: true
 ntp_type: "{% if ansible_distribution_major_version | int >= 8 %}chrony\
              {%- else %}ntp\

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -72,7 +72,7 @@
 
 - name: Add motd
   ansible.builtin.template:
-    src: motd.j2
+    src: "{{ motd_template }}"
     dest: /etc/motd
     mode: 0644
   tags: motd

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -36,6 +36,7 @@ oracle_user: oracle                        # User that will own the Oracle Insta
 grid_user: grid
 grid_install_user: "{% if role_separation %}{{ grid_user }}{% else %}{{ oracle_user }}{% endif %}"
 configure_oracle_sudo: false
+sudoers_template: sudoers.j2
 etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_all_ipv4_addresses[1] }}{% else %}{{ ansible_default_ipv4.address }}{% endif %}"
 oracle_inventory_loc: /u01/app/oraInventory
 

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -165,7 +165,7 @@
 
 - name: User | Add Oracle user to sudoers
   ansible.builtin.template:
-    src: sudoers.j2
+    src: "{{ sudoers_template }}"
     dest: "/etc/sudoers.d/{{ item.username }}"
     owner: root
     mode: 0440
@@ -177,7 +177,7 @@
 
 - name: User | Add Grid user to sudoers
   ansible.builtin.template:
-    src: sudoers.j2
+    src: "{{ sudoers_template }}"
     dest: "/etc/sudoers.d/{{ item.username }}"
     owner: root
     mode: 0440

--- a/roles/oraswdb_install/defaults/main.yml
+++ b/roles/oraswdb_install/defaults/main.yml
@@ -22,7 +22,9 @@ oracle_sw_extract_path: "{%- if '18' in db_version -%}\
                               {{ oracle_stage }}/{{ item[0].version }}\
                           {%- endif -%}"
 
+configure_oracle_profile: true
 oracle_profile_name: ".profile_{{ dbh.home }}"
+oracle_profile_template: dotprofile-home.j2
 
 oracle_hostname: "{{ ansible_fqdn }}"                            # Full (FQDN) name of the host
 www_download_bin: curl                              # curl (shell module) or get_url module

--- a/roles/oraswdb_install/tasks/install-home-db.yml
+++ b/roles/oraswdb_install/tasks/install-home-db.yml
@@ -22,12 +22,13 @@
 
 - name: install_home_db | add dotprofile
   ansible.builtin.template:
-    src: dotprofile-home.j2
+    src: "{{ oracle_profile_template }}"
     dest: "{{ oracle_user_home }}/{{ oracle_profile_name }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: 0660
   # when: oracle_home_db not in existing_dbhome.stdout_lines
+  when: configure_oracle_profile
   tags: create_db,dotprofile_db
 
 - name: install_home_db | Setup response file for install (DB)


### PR DESCRIPTION
For some custom/advanced setups it would be nice if we could customize some of the default provided templates. It is the case of `motd.j2` template from the common role, `sudoers.j2` from the orahost role (if for example I don't want NOPASSWD for sudo or I'd like access to a few commands only) and `dotprofile-home.j2` from oraswdb-install role. With the proposed changes I can create for example my own `dotprofile-home.j2`, place it in my templates/ folder in the root of my playbook directory and set `oracle_profile_template` to `"{{ playbook_dir }}/templates/dotprofile-home.j2"`. I can do all these manually through some post_tasks, of course, but it would unnecessarily complicate the playbook. Not to mention that generating dotprofile file can't be currently disabled. This patch adds also a new `configure_oracle_profile` variable to control whether the profile file should be generated.