### PR TITLE
oraswgi_install: experimental support for ASMFD (Filter Driver)

### DIFF
--- a/changelogs/fragments/1-asmfd.yml
+++ b/changelogs/fragments/1-asmfd.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "experimental support for ASMFD (Filter Driver) ()"

--- a/changelogs/fragments/1-asmfd.yml
+++ b/changelogs/fragments/1-asmfd.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "experimental support for ASMFD (Filter Driver) ()"

--- a/changelogs/fragments/297-asmfd.yml
+++ b/changelogs/fragments/297-asmfd.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "experimental support for ASMFD (Filter Driver) (#297)"

--- a/roles/orahost_storage/tasks/main.yml
+++ b/roles/orahost_storage/tasks/main.yml
@@ -19,6 +19,8 @@
   when: multipath == 'dm-multipath' and partition_devices and asm_diskgroups is defined
 
 - include: "{{ device_persistence }}.yml"  # noqa name[missing] fqcn[action-core] deprecated-module
+  when:
+    - device_persistence in ('asmlib', 'udev')
 
 - name: dNFS-storage | Prepare mountpoints
   ansible.builtin.file:

--- a/roles/oraswgi_install/defaults/main.yml
+++ b/roles/oraswgi_install/defaults/main.yml
@@ -41,6 +41,7 @@ oracle_base: /u01/app/oracle
 oracle_rsp_stage: "{{ oracle_stage }}/rsp"
 oracle_inventory_loc: /u01/app/oraInventory
 
+init_dg_exists: "{% for dg in asm_diskgroups if oracle_asm_init_dg == dg.diskgroup %}true{% endfor %}"
 oracle_directories:
   - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_rsp_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}

--- a/roles/oraswgi_install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi_install/tasks/19.3.0.0.yml
@@ -44,13 +44,15 @@
     path: "{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}"
   register: statcvuqdisk
   run_once: true
-  when: configure_cluster
   tags: cvuqdisk
 
+# Oracle Restart + ASMFD
+# => cvuqdisk is mandatory
 - name: When configure_cluster
   when:
-    - configure_cluster
-    - hostvars[cluster_master]['statcvuqdisk']['stat']['exists']
+    - (configure_cluster and hostvars[cluster_master]['statcvuqdisk']['stat']['exists'])
+      or
+      (not configure_cluster and device_persistence == 'asmfd')
   tags: cvuqdisk
   block:
 
@@ -107,8 +109,15 @@
         - force_runcluvfy | default(false) or oracle_home_gi not in checkgiinstall.stdout
       tags: always
 
-    - ansible.builtin.debug:  # noqa name[missing]
-        msg: "install_home_gi | Start Install Grid Infrastructure"
+    - name: ASM Filter Driver
+      ansible.builtin.include_tasks: asmfd.yml
+      when:
+        - device_persistence == 'asmfd'
+      tags:
+        - asmfd
+
+    - ansible.builtin.debug:
+        msg: "install_home_gi | Start Install Grid Infrastructure"  # noqa name[missing]
       run_once: true
 
     - name: install_home_gi | Install Grid Infrastructure
@@ -127,7 +136,7 @@
       tags:
         - oragridinstall
       register: giinstall
-      failed_when: giinstall.rc = not in [0, 6]
+      failed_when: giinstall.rc not in [0, 6]
 
     - ansible.builtin.debug:  # noqa name[missing]
         var: giinstall.stdout_lines

--- a/roles/oraswgi_install/tasks/21.3.0.0.yml
+++ b/roles/oraswgi_install/tasks/21.3.0.0.yml
@@ -44,13 +44,15 @@
     path: "{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}"
   register: statcvuqdisk
   run_once: true
-  when: configure_cluster
   tags: cvuqdisk
 
-- name: install_home_gi
+# Oracle Restart + ASMFD
+# => cvuqdisk is mandatory
+- name: When configure_cluster
   when:
-    - configure_cluster
-    - hostvars[cluster_master]['statcvuqdisk']['stat']['exists']
+    - (configure_cluster and hostvars[cluster_master]['statcvuqdisk']['stat']['exists'])
+      or
+      (not configure_cluster and device_persistence == 'asmfd')
   tags: cvuqdisk
   block:
 
@@ -106,6 +108,13 @@
       when:
         - force_runcluvfy | default(false) or oracle_home_gi not in checkgiinstall.stdout
       tags: always
+
+    - name: ASM Filter Driver
+      ansible.builtin.include_tasks: asmfd.yml
+      when:
+        - device_persistence == 'asmfd'
+      tags:
+        - asmfd
 
     - ansible.builtin.debug:  # noqa name[missing]
         msg: "install_home_gi | Start Install Grid Infrastructure"

--- a/roles/oraswgi_install/tasks/asmcmd_dsset.yml
+++ b/roles/oraswgi_install/tasks/asmcmd_dsset.yml
@@ -1,0 +1,28 @@
+---
+# Setting the asm_diskstring after installation for ASMfd
+# => Installer sets wrong asm_diskstring ...
+- name: Set asmcmd dsset for ASMfd
+  when:
+    - device_persistence == "asmfd"
+  tags:
+    - dsset
+  block:
+    - name: Execute asmcmd dsset
+      ansible.builtin.command:  # noqa no-changed-when
+        argv:
+          - "{{ oracle_home_gi }}/bin/asmcmd"
+          - dsset
+          - "{{ oracle_asm_disk_string }}"
+      become: true
+      become_user: "{{ grid_install_user }}"
+      register: asmcmddsset
+      run_once: true
+      environment:
+        ORACLE_BASE: "{{ oracle_base }}"
+        ORACLE_HOME: "{{ oracle_home_gi }}"
+        ORACLE_SID: "+ASM{% if configure_cluster %}1{% endif %}"
+
+    - name: Output asmcmd dsset
+      ansible.builtin.debug:
+        msg: "{{ asmcmddsset.stdout_lines }}"
+      run_once: true

--- a/roles/oraswgi_install/tasks/asmfd.yml
+++ b/roles/oraswgi_install/tasks/asmfd.yml
@@ -1,0 +1,137 @@
+---
+- name: assert for ASMFD
+  ansible.builtin.assert:
+    that:
+      - oracle_asmfd_disk_string is defined
+  when:
+    - device_persistence == "asmfd"
+
+- name: Check for installed ASMlib
+  when:
+    - check_installed_asmlib | default(true)
+  block:
+    - name: Gather the package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: assert that ASMlib is not installed
+      ansible.builtin.assert:
+        that:
+          - "'oracleasmlib' not in ansible_facts.packages"
+
+- name: Check ASMFD Support
+  tags:
+    - asmfd
+  environment:
+    ORACLE_BASE: "/tmp"  # asmcmd is executed as root => Permission issues with ADR structure
+    ORACLE_HOME: "{{ oracle_home_gi }}"
+  block:
+    - name: Check ASMFD Support
+      ansible.builtin.command:
+        argv:
+          - "{{ oracle_home_gi }}/bin/afddriverstate"
+          - supported
+      changed_when: "asmfdcheck.stdout == 'AFD-9200: Supported'"
+      failed_when: "asmfdcheck.stdout != 'AFD-9200: Supported'"
+      register: asmfdcheck
+
+    - name: Output Check ASMFD failed
+      ansible.builtin.debug:
+        msg: "{{ asmfdcheck.stdout_lines }}"
+
+  rescue:
+    - name: Check ASMFD failed
+      ansible.builtin.debug:
+        msg: "{{ asmfdcheck.stdout_lines }}"
+
+    - name: Check ASMFD failed
+      ansible.builtin.fail:
+        msg: "ASMFD not supported on Node"
+
+- name: Get Current State of ASMFD
+  ansible.builtin.command:
+    argv:
+      - "{{ oracle_home_gi }}/bin/afddriverstate"
+      - loaded
+  register: asmfdstate
+  changed_when: "'AFD-9206:' is in asmfdstate.stdout"
+  failed_when: asmfdstate.rc not in [0, 1]
+  tags:
+    - asmfd
+  environment:
+    ORACLE_BASE: "/tmp"  # asmcmd is executed as root => Permission issues with ADR structure
+    ORACLE_HOME: "{{ oracle_home_gi }}"
+
+- name: Install ASMFD Driver  # noqa no-handler
+  when: asmfdstate.changed
+  tags:
+    - asmfd
+  environment:
+    ORACLE_BASE: "/tmp"  # asmcmd is executed as root => Permission issues with ADR structure
+    ORACLE_HOME: "{{ oracle_home_gi }}"
+  block:
+    - name: Output Get Current State of ASMFD
+      ansible.builtin.debug:
+        var: asmfdstate.stdout_lines
+
+    # asmcmd afd_configure has no result after 1 execution
+    # => retry it for a 2nd time before failing
+    - name: Configure ASMFD with asmcmd  # noqa no-changed-when
+      ansible.builtin.command:
+        argv:
+          - "{{ oracle_home_gi }}/bin/asmcmd"
+          - afd_configure
+          - "-e"
+      become: true
+      become_user: root
+      register: asmfdconfigure
+      until: "asmfdconfigure.stdout_lines | length > 0"
+      retries: 2
+      delay: 1
+
+    - name: Output Configure ASMFD with asmcmd
+      ansible.builtin.debug:
+        msg: "{{ asmfdconfigure.stdout_lines }}"
+
+- name: Get current List of ASMFD Labels
+  environment:
+    ORACLE_BASE: "/tmp"  # asmcmd is executed as root => Permission issues with ADR structure
+    ORACLE_HOME: "{{ oracle_home_gi }}"
+  ansible.builtin.command:  # noqa no-changed-when
+    argv:
+      - "{{ oracle_home_gi }}/bin/asmcmd"
+      - afd_lslbl
+  become: true
+  register: asmfdlsdsk
+  tags:
+    - asmfd
+
+- name: List existing ASMFD Labels
+  ansible.builtin.debug:
+    var: asmfdlsdsk.stdout_lines
+  tags:
+    - asmfd
+
+- name: Label ASMFD Disks
+  tags:
+    - asmfd
+  when:
+    - item.1.asmlabel is defined
+    - asmfdlsdsk.stdout_lines is defined
+    - not asmfdlsdsk.stdout_lines | regex_search(item.1.asmlabel | upper)
+  ansible.builtin.include_tasks: asmfd_disks.yml
+  with_subelements:
+    - "{{ asm_diskgroups }}"
+    - disk
+  loop_control:
+    label: "Diskgroup {{ item.0.diskgroup | default('') }} Disk {{ item.1.asmlabel | default('') }}"
+
+# just for safety, when a root proces created the ADR in ORACLE_BASE
+- name: Fix ownership of ADR
+  ansible.builtin.file:
+    path: "{{ oracle_base }}/diag"
+    recurse: true
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+    state: directory
+    mode: '0755'

--- a/roles/oraswgi_install/tasks/asmfd_disks.yml
+++ b/roles/oraswgi_install/tasks/asmfd_disks.yml
@@ -1,0 +1,35 @@
+---
+- name: Label ASMFD Disk
+  tags:
+    - always
+  environment:
+    ORACLE_BASE: "/tmp"  # asmcmd is executed as root => Permission issues with ADR structure
+    ORACLE_HOME: "{{ oracle_home_gi }}"
+  block:
+
+    - name: Label ASMFD Disk Label {{ item.1.asmlabel | default('') }} Device {{ item.1.device | default('') }}
+      # noqa name[template]
+      ansible.builtin.command:
+        argv:
+          - "{{ oracle_home_gi }}/bin/asmcmd"
+          - afd_label
+          - "{{ item.1.asmlabel }}"
+          - "{{ item.1.device }}1"
+          # - "--init"
+      register: asmfdlabel
+      become: true
+      become_user: root
+      changed_when: "asmfdlabel.stdout_lines | length == 0"
+
+    - name: Output Label ASMFD Disk
+      ansible.builtin.debug:
+        msg: "{{ asmfdlabel.stdout_lines }}"
+
+  rescue:
+    - name: Output Label ASMFD Disk failed
+      ansible.builtin.debug:
+        msg: "{{ asmfdlabel.stdout_lines }}"
+
+    - name: Output Label ASMFD Disk failed
+      ansible.builtin.fail:
+        msg: "asmcmd afd_label failed"

--- a/roles/oraswgi_install/tasks/main.yml
+++ b/roles/oraswgi_install/tasks/main.yml
@@ -13,6 +13,16 @@
     path: /etc/oracle/olr.loc
   register: olrloc
 
+- name: Assert inventory
+  when:
+    - not olrloc.stat.exists
+  block:
+    - name: assert oracle_asm_init_dg in asm_diskgroups
+      ansible.builtin.assert:
+        that:
+          - oracle_asm_init_dg is defined
+          - init_dg_exists
+
 - name: install_home_gi | set fact for patch_before_rootsh
   ansible.builtin.set_fact:
     patch_before_rootsh: false
@@ -95,6 +105,10 @@
 
 - name: include_tasks {{ oracle_install_version_gi }}
   ansible.builtin.include_tasks: "{{ oracle_install_version_gi }}.yml"
+  tags: always
+
+- name: include_tasks asmcmd_dsset.yml
+  ansible.builtin.include_tasks: asmcmd_dsset.yml
   tags: always
 
 - name: install_home_gi | Check if stuff is running

--- a/roles/oraswgi_install/templates/grid-install.rsp.19.3.0.0.j2
+++ b/roles/oraswgi_install/templates/grid-install.rsp.19.3.0.0.j2
@@ -272,7 +272,7 @@ oracle.install.crs.config.clusterNodes=
       :HUB
     {%- endif -%}
     {%- if not loop.last -%},
-    {%- endif -%} 
+    {%- endif -%}
   {%- endfor %}
 {%- endif %}
 
@@ -454,6 +454,7 @@ oracle.install.asm.diskGroup.disksWithFailureGroupNames=
 #-------------------------------------------------------------------------------
 oracle.install.asm.diskGroup.disks={%- for disk in  item.disk %}
   {%- if device_persistence=='udev' -%}{{ disk.device }}
+  {%- elif device_persistence=='asmfd' -%}AFD:{{ disk.asmlabel | upper }}
   {%- else -%}
     {%- if oracle_asm_disk_string.endswith('*') %}{{ oracle_asm_disk_string[:-1] }}
     {%- else -%}{{ oracle_asm_disk_string }}
@@ -477,7 +478,8 @@ oracle.install.asm.diskGroup.quorumFailureGroupNames=
 #     oracle.install.asm.diskGroup.diskDiscoveryString=\\.\ORCLDISK*
 #
 #-------------------------------------------------------------------------------
-oracle.install.asm.diskGroup.diskDiscoveryString={{ oracle_asm_disk_string }}
+# todo: asm_diskstring includes the afd_diskstring which is wrong as well, but installation will not work, with afd_diskstring here...
+oracle.install.asm.diskGroup.diskDiscoveryString={% if device_persistence=='asmfd' %}{{ oracle_asmfd_disk_string }}{% else %}{{ oracle_asm_disk_string }}{% endif %}
 
 #-------------------------------------------------------------------------------
 # Password for ASMSNMP account
@@ -566,7 +568,8 @@ oracle.install.asm.gimrDG.quorumFailureGroupNames=
 # Applicable only for FLEX_ASM_STORAGE option
 # Specify 'true' if you want to configure AFD, else specify 'false'
 #-------------------------------------------------------------------------------
-oracle.install.asm.configureAFD=
+oracle.install.asm.configureAFD={% if device_persistence | default('udev') == 'asmfd' %}true{% endif %}
+
 #-------------------------------------------------------------------------------
 # Configure RHPS - Rapid Home Provisioning Service
 # Applicable only for DOMAIN cluster configuration

--- a/roles/oraswgi_install/templates/grid-install.rsp.21.3.0.0.j2
+++ b/roles/oraswgi_install/templates/grid-install.rsp.21.3.0.0.j2
@@ -41,7 +41,7 @@
 ###############################################################################
 
 #------------------------------------------------------------------------------
-# Do not change the following system generated value. 
+# Do not change the following system generated value.
 #------------------------------------------------------------------------------
 oracle.install.responseFileVersion=/oracle/install/rspfmt_crsinstall_response_schema_v21.0.0
 
@@ -54,7 +54,7 @@ oracle.install.responseFileVersion=/oracle/install/rspfmt_crsinstall_response_sc
 
 #-------------------------------------------------------------------------------
 # Specify the location which holds the inventory files.
-# This is an optional parameter if installing on  
+# This is an optional parameter if installing on
 # Windows based Operating System.
 #-------------------------------------------------------------------------------
 INVENTORY_LOCATION={{ oracle_inventory_loc }}
@@ -65,9 +65,9 @@ INVENTORY_LOCATION={{ oracle_inventory_loc }}
 #   - CRS_CONFIG  : To register home and configure Grid Infrastructure for cluster
 #   - HA_CONFIG   : To register home and configure Grid Infrastructure for stand alone server
 #   - UPGRADE     : To register home and upgrade clusterware software of earlier release
-#   - CRS_SWONLY  : To register Grid Infrastructure Software home (can be configured for cluster 
+#   - CRS_SWONLY  : To register Grid Infrastructure Software home (can be configured for cluster
 #                   or stand alone server later)
-#   - HA_SWONLY   : To register Grid Infrastructure Software home (can be configured for stand 
+#   - HA_SWONLY   : To register Grid Infrastructure Software home (can be configured for stand
 #                   alone server later. This is only supported on Windows.)
 #   - CRS_ADDNODE : To add more nodes to the cluster
 #   - CRS_DELETE_NODE : To delete nodes to the cluster
@@ -167,7 +167,7 @@ oracle.install.crs.config.configureAsExtendedCluster=false
 #-------------------------------------------------------------------------------
 # Specify a name for the Cluster you are creating.
 #
-# The maximum length allowed for clustername is 63 characters. The name can be 
+# The maximum length allowed for clustername is 63 characters. The name can be
 # any combination of lower and uppercase alphabets (A - Z), (0 - 9) and hyphens (-).
 #
 # Applicable only for STANDALONE and DOMAIN cluster configuration
@@ -202,7 +202,7 @@ oracle.install.crs.config.gpnp.gnsOption=CREATE_NEW_GNS
 oracle.install.crs.config.gpnp.gnsClientDataFile=
 
 #-------------------------------------------------------------------------------
-# Applicable only for STANDALONE and DOMAIN cluster configuration if you choose to 
+# Applicable only for STANDALONE and DOMAIN cluster configuration if you choose to
 # configure GNS for this cluster oracle.install.crs.config.gpnp.gnsOption=CREATE_NEW_GNS
 # Specify the GNS subdomain and an unused virtual hostname for GNS service
 #-------------------------------------------------------------------------------
@@ -228,7 +228,7 @@ oracle.install.crs.config.sites=
 # - 2 fields if configuring a Flex Cluster
 # - 2 fields if adding more nodes to the configured cluster, or
 # - 3 fields if configuring an Extended Cluster
-# 
+#
 # The fields should be ordered as follows:
 # 1. The first field should be the public node name.
 # 2. The second field should be the virtual host name
@@ -262,7 +262,7 @@ oracle.install.crs.config.clusterNodes=
       :HUB
     {%- endif -%}
     {%- if not loop.last -%},
-    {%- endif -%} 
+    {%- endif -%}
   {%- endfor %}
 {%- endif %}
 
@@ -317,10 +317,10 @@ oracle.install.crs.config.storageOption={{ oracle_asm_storage_option|upper }}
 {% endif %}
 
 #-------------------------------------------------------------------------------
-# These properties are applicable only if FILE_SYSTEM_STORAGE is chosen for 
+# These properties are applicable only if FILE_SYSTEM_STORAGE is chosen for
 # storing OCR and voting disk
 # Specify the location(s) for OCR and voting disks
-# Three(3) or one(1) location(s) should be specified for OCR and voting disk, 
+# Three(3) or one(1) location(s) should be specified for OCR and voting disk,
 # separated by commas.
 # Example:
 #     For Unix based Operating System:
@@ -351,7 +351,7 @@ oracle.install.crs.config.useIPMI=
 #-------------------------------------------------------------------------------
 # Applicable only if you choose to configure IPMI
 # i.e. oracle.install.crs.config.useIPMI=true
-# Specify the location of the ipmiutil binary 
+# Specify the location of the ipmiutil binary
 # Specify the username and password for using IPMI service
 #-------------------------------------------------------------------------------
 oracle.install.crs.config.ipmi.bmcBinpath=
@@ -380,7 +380,7 @@ oracle.install.asm.diskGroup.name={{ oracle_asm_init_dg }}
 
 #-------------------------------------------------------------------------------
 # Redundancy level to be used by ASM.
-# It can be one of the following  
+# It can be one of the following
 #   - NORMAL
 #   - HIGH
 #   - EXTERNAL
@@ -461,7 +461,8 @@ oracle.install.asm.diskGroup.quorumFailureGroupNames=
 #     oracle.install.asm.diskGroup.diskDiscoveryString=\\.\ORCLDISK*
 #
 #-------------------------------------------------------------------------------
-oracle.install.asm.diskGroup.diskDiscoveryString={{ oracle_asm_disk_string }}
+# todo: asm_diskstring includes the afd_diskstring which is wrong as well, but installation will not work, with afd_diskstring here...
+oracle.install.asm.diskGroup.diskDiscoveryString={% if device_persistence=='asmfd' %}{{ oracle_asmfd_disk_string }}{% else %}{{ oracle_asm_disk_string }}{% endif %}
 
 #-------------------------------------------------------------------------------
 # Password for ASMSNMP account
@@ -474,7 +475,8 @@ oracle.install.asm.monitorPassword={%if asmmonitorpassword is defined %}{{asmmon
 # Applicable only for FLEX_ASM_STORAGE option
 # Specify 'true' if you want to configure AFD, else specify 'false'
 #-------------------------------------------------------------------------------
-oracle.install.asm.configureAFD=
+oracle.install.asm.configureAFD={% if device_persistence | default('udev') == 'asmfd' %}true{% endif %}
+
 #-------------------------------------------------------------------------------
 # Configure RHPS - Rapid Home Provisioning Service
 # Applicable only for DOMAIN cluster configuration
@@ -501,9 +503,9 @@ oracle.install.crs.config.ignoreDownNodes=
 
 #------------------------------------------------------------------------------
 # Specify 'true' if you would like to configure Grid Infrastructure Management
-# Repository (GIMR), else specify 'false'. Applicable only if CRS_CONFIG is 
+# Repository (GIMR), else specify 'false'. Applicable only if CRS_CONFIG is
 # chosen as install option and STANDALONE is chosen as cluster configuration.
-# If you want to use or configure 
+# If you want to use or configure
 # Local GIMR : oracle.install.crs.configureGIMR=true and oracle.install.crs.configureRemoteGIMR=false
 # Remote GIMR : oracle.install.crs.configureGIMR=true, oracle.install.crs.configureRemoteGIMR=true
 # and oracle.install.crs.RemoteGIMRCredFile= path of the GIMR cred file
@@ -515,7 +517,7 @@ oracle.install.crs.RemoteGIMRCredFile=
 
 #------------------------------------------------------------------------------
 # Create a separate ASM DiskGroup to store GIMR data.
-# Specify 'true' if you would like to separate GIMR data with clusterware data, 
+# Specify 'true' if you would like to separate GIMR data with clusterware data,
 # else specify 'false'
 # Value should be 'true' for DOMAIN cluster configurations
 # Value can be true/false for STANDALONE cluster configurations.
@@ -524,7 +526,7 @@ oracle.install.asm.configureGIMRDataDG=
 
 #-------------------------------------------------------------------------------
 # GIMR Storage data ASM DiskGroup
-# Applicable only when 
+# Applicable only when
 # oracle.install.asm.configureGIMRDataDG=true
 # Example: oracle.install.asm.GIMRDG.name=MGMT
 #
@@ -533,7 +535,7 @@ oracle.install.asm.gimrDG.name=
 
 #-------------------------------------------------------------------------------
 # Redundancy level to be used by ASM.
-# It can be one of the following  
+# It can be one of the following
 #   - NORMAL
 #   - HIGH
 #   - EXTERNAL
@@ -667,7 +669,7 @@ oracle.install.crs.rootconfig.configMethod=
 oracle.install.crs.rootconfig.sudoPath=
 
 #--------------------------------------------------------------------------------------
-# Specify the name of the user who is in the sudoers list. 
+# Specify the name of the user who is in the sudoers list.
 # Applicable only when SUDO configuration method was chosen.
 # Note:For Grid Infrastructure for Standalone server installations,the sudo user name must be the username of the user performing the installation.
 #--------------------------------------------------------------------------------------
@@ -677,17 +679,17 @@ oracle.install.crs.rootconfig.sudoUserName=
 #
 # This should be a comma separated list of node:batch pairs.
 # During upgrade, you can sequence the automatic execution of root scripts
-# by pooling the nodes into batches. 
-# A maximum of three batches can be specified. 
+# by pooling the nodes into batches.
+# A maximum of three batches can be specified.
 # Installer will execute the root scripts on all the nodes in one batch before
 # proceeding to next batch.
 # Root script execution on the local node must be in Batch 1.
-# Examples: 
+# Examples:
 # 1. oracle.install.crs.config.batchinfo=Node1:1,Node2:2,Node3:2,Node4:3
 # 2. oracle.install.crs.config.batchinfo=Node1:1,Node2:2,Node3:2,Node4:2
 # 3. oracle.install.crs.config.batchinfo=Node1:1,Node2:1,Node3:2,Node4:3
 #
-# Applicable only for UPGRADE install option. 
+# Applicable only for UPGRADE install option.
 #--------------------------------------------------------------------------------------
 oracle.install.crs.config.batchinfo=
 #################################################################################
@@ -697,7 +699,7 @@ oracle.install.crs.config.batchinfo=
 #################################################################################
 
 #--------------------------------------------------------------------------------
-# Specify the node names to delete nodes from cluster. 
+# Specify the node names to delete nodes from cluster.
 # Delete node will be performed only for the remote nodes from the cluster.
 #--------------------------------------------------------------------------------
 oracle.install.crs.deleteNode.nodes=


### PR DESCRIPTION
This is the expeimental implementation of ASMFD (ASM Filter Driver) in ansible-oracle.
It is experimentalk, due to an open question in the installation.

- Why is the `afd_discoerystring` needed in `oracle.install.asm.diskGroup.diskDiscoveryString`?
The Responsefile for the installation requires the `ASMFD discoverysting` in `asm_diskstring`, which is wrong but installation will fail with the correct value.
Workarround:
Change the `asm_diskstring` after initial setup of ASM.
I am not sure, if this is the right way.
=> This is why it is experimentell for the moment.

This PR fixes #129 