### PR TITLE
oradb_manage_db: support for dbca custom scripts

### DIFF
--- a/changelogs/fragments/customscripts_support.yml
+++ b/changelogs/fragments/customscripts_support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_manage_db: support for dbca custom scripts"

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -27,8 +27,8 @@
 # without executing a template task before.
 - name: manage_db | Copy custom dbca Templates for Database to ORACLE_HOME/assistants/dbca/templates
   ansible.builtin.template:
-    src: "{{ (dbh.dbca_templatepath | default(''), dbh.dbca_templatename) | path_join }}"
-    dest: "{{ oracle_home_db }}/assistants/dbca/templates/{{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}"
+    src: "{{ (dbh.dbca_templatepath | default(''), item) | path_join }}"
+    dest: "{{ oracle_home_db }}/assistants/dbca/templates/{{ dbh.oracle_db_name }}_{{ item }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: "0640"
@@ -37,6 +37,9 @@
     - dbh.dbca_templatename is defined
     - dbh.dbca_copy_template | default(true)
     - dbh.dbca_templatename not in('New_Database.dbt','General_Purpose.dbc')
+  with_items:
+    - "{{ dbh.dbca_templatename }}"
+    - "{{ dbh.customscripts | default([]) }}"
   tags:
     - customdbcatemplate
     - dbcatemplate


### PR DESCRIPTION
It should be possible to deploy all custom scripts defined in a dbca template. With this PR you may define the following section in your dbca template:

```
<CustomScripts Execute="true"><CustomScript script="{ORACLE_HOME}/assistants/dbca/templates/{{ dbh.oracle_db_name }}_post_install_script.sql"/></CustomScripts>
```
Then, `customscripts` variable for the database to be created should point out to the relevant custom scripts defined in the template:

```
oracle_databases:
  - home: 19c
    oracle_db_name: DUMMYDB
    dbca_templatepath: templates/
    dbca_templatename: dummydb.dbt
    ...
    customscripts:
      - post_install_script.sql
    state: present
```

All defined custom scripts are copied over to the target remote `ORACLE_HOME/assistants/dbca/templates/`, from the same `dbca_templatepath` location. Like the dbca template file, the scripts are staged on the target, prefixed with the name of the database.
