### PR TITLE
Remove password alias from datapatch module.

### DIFF
--- a/changelogs/fragments/datapatch_alias_fix.yml
+++ b/changelogs/fragments/datapatch_alias_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oracle_datapatch: Fix password alias"

--- a/changelogs/fragments/datapatch_alias_fix.yml
+++ b/changelogs/fragments/datapatch_alias_fix.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "oracle_datapatch: Fix password alias"
+  - "oracle_datapatch: Fix password alias (#304)"

--- a/plugins/modules/oracle_datapatch
+++ b/plugins/modules/oracle_datapatch
@@ -58,7 +58,7 @@ options:
             - Password for the DB user
         required: True
         default: None
-        aliases: ['pw','password']
+        aliases: ['pw']
     hostname:
         description:
             - The host of the database
@@ -280,7 +280,7 @@ def main():
             fail_on_db_not_exist = dict(default=True, type='bool'),
             output              = dict(default="short", choices = ["short","verbose"]),
             user                = dict(default='sys', aliases = ['un']),
-            password            = dict(required=True, no_log=True, aliases = ['pw','password']),
+            password            = dict(required=True, no_log=True, aliases = ['pw']),
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']),
             service_name        = dict(required=False, aliases = ['sn']),
             port                = dict(required=False, default = 1521),


### PR DESCRIPTION
When running datapatch module, the following warning is raised:

```
TASK [opitzconsulting.ansible_oracle.oradb_datapatch : oradb_datapatch | Run datapatch] ***
...
[WARNING]: Both option password and its alias password are set.
```

