### PR TITLE
oradb_manage_db: customize ocenv init in bashrc

### DIFF
--- a/changelogs/fragments/ocenv_custom_bashrc.yml
+++ b/changelogs/fragments/ocenv_custom_bashrc.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "oradb_manage_db: customize ocenv initialization in bashrc"
+  - "oradb_manage_db: customize ocenv initialization in bashrc (oravirt#310)"

--- a/changelogs/fragments/ocenv_custom_bashrc.yml
+++ b/changelogs/fragments/ocenv_custom_bashrc.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_manage_db: customize ocenv initialization in bashrc"

--- a/roles/oradb_manage_db/defaults/main.yml
+++ b/roles/oradb_manage_db/defaults/main.yml
@@ -144,3 +144,7 @@ shell_aliases:
   - "lsnrservice='lsnrctl services $LSNRNAME'"
 
 deploy_ocenv: true  # deploy ocenv scripts
+ocenv_bashrc_init: true
+ocenv_bashrc_init_section: |
+  echo "execute ocenv to source Oracle Environment"
+  alias ocenv='. "{{ dbenvdir }}/ocenv"'

--- a/roles/oradb_manage_db/tasks/ocenv.yml
+++ b/roles/oradb_manage_db/tasks/ocenv.yml
@@ -22,10 +22,9 @@
       ansible.builtin.blockinfile:
         path: "{{ oracle_user_home }}/.bashrc"
         marker: "# {mark} ocenv ANSIBLE MANAGED BLOCK"
-        block: |
-          echo "execute ocenv to source Oracle Environment"
-          alias ocenv='. "{{ dbenvdir }}/ocenv"'
+        block: "{{ ocenv_bashrc_init_section }}"
         create: true
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
         mode: 0644
+        state: "{{ 'present' if ocenv_bashrc_init else 'absent' }}"


### PR DESCRIPTION
The default `ocenv` initialization in `.bashrc` file can cause issues, that is why it should be customizable. For example, on a newly provisioned DB server with `ocenv` installed, the EM agent deployment fails (see EM 12c/13c: Agent Deployment Fails at Remote Validations step with error "Banner check failed" (Doc ID 1453099.1)). This pull request introduces two new variables to control whether `.bashrc` should be changed (`ocenv_bashrc_init` variable) and how (`ocenv_bashrc_init_section` variable).