### PR TITLE
fix oracle packages for SLES 15.3

### DIFF
--- a/changelogs/fragments/311-orahost_sles153_packages.yml
+++ b/changelogs/fragments/311-orahost_sles153_packages.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fixed oracle packages for SLES 15.3 (#311)"

--- a/changelogs/fragments/311-orahost_sles153_packages.yml
+++ b/changelogs/fragments/311-orahost_sles153_packages.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "Fixed oracle packages for SLES 15.3 (#311)"
+  - "Fixed oracle packages for SLES 15.3 (oravirt#311)"

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -373,7 +373,7 @@ oracle_packages_sles_multi:
     - libcap-ng-utils
     - libcap-ng0
     - libcap-progs
-    - libcap1
+    # - libcap1 # "No provider of '+libcap1' found."
     - libcap2
     - libelf1
     - libgcc_s1


### PR DESCRIPTION
libcap1 is not available nor needed for SLES15, so here it should be also commented out