### PR TITLE
add configuration variables for pam_limits

### DIFF
--- a/changelogs/fragments/pam_limits_config.yml
+++ b/changelogs/fragments/pam_limits_config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add configuration variables for pam_limits to orahost (oravirt#317)

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -119,6 +119,9 @@ configure_ssh: false                        # (true/false). Should passwordless 
 # mountpoints are described in host_fs_layout
 configure_host_disks: false
 
+configure_limits_pam: true  # entry in /etc/pam.d/limits
+configure_limits: true      # /etc/security.d/limits.d/99-oracle-limits.conf file
+
 configure_etc_hosts: false
 configure_cluster: false
 oracle_stage: /u01/stage

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -463,6 +463,7 @@
     state: present
     line: "session required pam_limits.so"
   tags: pamconfig
+  when: configure_limits_pam and configure_limits
 
 - name: Oracle-recommended security limits
   ansible.builtin.template:
@@ -470,7 +471,7 @@
     dest: /etc/security/limits.d/99-oracle-limits.conf
     backup: true
     mode: "0644"
-  when: ansible_os_family == 'RedHat'
+  when: configure_limits and ansible_os_family == 'RedHat'
   tags: seclimit
 
 - name: Oracle-recommended security limits on SLES


### PR DESCRIPTION
This PR adds possibility to switch on/off the configuration of pam.d entry in pam.d/login and security.d/limits.d/99-oracle-limits.conf for oracle user. It was currently only possible to exclude this by using skip_tags, now it should be possible also via inventory.