### PR TITLE
Release: ansible-oracle v3.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v3.5.0
+======
+
+Release Summary
+---------------
+
+This is a small monthly release of ansible-oracle.
+
+Minor Changes
+-------------
+
+- add configuration variables for pam_limits to orahost (oravirt#317)
+
+Deprecated Features
+-------------------
+
+- Removal of deprecated directory /inventory from repository with next release.
+
 v3.4.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -14,4 +14,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 3.4.0
+version: 3.5.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -234,3 +234,14 @@ releases:
     - 311-orahost_sles153_packages.yml
     - ocenv_custom_bashrc.yml
     release_date: '2022-12-31'
+  3.5.0:
+    changes:
+      deprecated_features:
+      - Removal of deprecated directory /inventory from repository with next release.
+      minor_changes:
+      - add configuration variables for pam_limits to orahost (oravirt#317)
+      release_summary: This is a small monthly release of ansible-oracle.
+    fragments:
+    - pam_limits_config.yml
+    - release-info.yml
+    release_date: '2023-02-02'

--- a/changelogs/fragments/pam_limits_config.yml
+++ b/changelogs/fragments/pam_limits_config.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - add configuration variables for pam_limits to orahost (oravirt#317)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,9 +1,9 @@
 ---
 namespace: opitzconsulting
 name: ansible_oracle
-description: "This is the collection of ansible-oracle from Branch oc on https://github.com/opitzconsulting/ansible-oracle"
-version: 3.4.0
-repository: https://github.com/opitzconsulting/ansible-oracle.git
+description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
+version: 3.5.0
+repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:
   - Mikael Sandström


### PR DESCRIPTION
v3.5.0
======

Release Summary
---------------

This is a small monthly release of ansible-oracle.

Minor Changes
-------------

- add configuration variables for pam_limits to orahost (oravirt#317)

Deprecated Features
-------------------

- Removal of deprecated directory /inventory from repository with next release.
