### PR TITLE
new role orasw_download_patches

### DIFF
--- a/changelogs/fragments/role_orasw_download_patches.yml
+++ b/changelogs/fragments/role_orasw_download_patches.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "added new orasw_download_patches role (oravirt#332)"

--- a/roles/orasw_download_patches/.ansibledoctor.yml
+++ b/roles/orasw_download_patches/.ansibledoctor.yml
@@ -1,0 +1,8 @@
+---
+logging:
+  level: warning
+template: readme
+force_overwrite: true
+exclude_tags:
+  - always
+  - never

--- a/roles/orasw_download_patches/README.md
+++ b/roles/orasw_download_patches/README.md
@@ -1,0 +1,143 @@
+# orasw_download_patches
+
+Download all patches from Oracle
+
+## Table of content
+
+- [Default Variables](#default-variables)
+  - [http_proxy](#http_proxy)
+  - [https_proxy](#https_proxy)
+  - [mos_login](#mos_login)
+  - [mos_password](#mos_password)
+  - [no_proxy](#no_proxy)
+  - [opatchinfo](#opatchinfo)
+  - [oracle_patch_download_dir](#oracle_patch_download_dir)
+  - [oracle_patch_download_host](#oracle_patch_download_host)
+  - [oracle_plat_lang](#oracle_plat_lang)
+  - [proxy_env](#proxy_env)
+  - [use_proxy](#use_proxy)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Default Variables
+
+### http_proxy
+
+Define the http proxy for downloads
+
+#### Default value
+
+```YAML
+http_proxy:
+```
+
+### https_proxy
+
+Define the https proxy for downloads
+
+#### Default value
+
+```YAML
+https_proxy:
+```
+
+### mos_login
+
+Login name for My Oracle Support (required)
+
+### mos_password
+
+Password for My Oracle Support (required)
+
+### no_proxy
+
+Define no_proxy list für downlads.
+
+#### Default value
+
+```YAML
+no_proxy:
+```
+
+### opatchinfo
+
+This is an internal variable for downloading patches.
+Usually no need to change it.
+
+#### Default value
+
+```YAML
+opatchinfo: []
+```
+
+### oracle_patch_download_dir
+
+Target directory for patch downloads
+
+#### Default value
+
+```YAML
+oracle_patch_download_dir: '{{ oracle_sw_source_local }}'
+```
+
+### oracle_patch_download_host
+
+`delegate_to` host for downloads
+
+#### Default value
+
+```YAML
+oracle_patch_download_host: localhost
+```
+
+### oracle_plat_lang
+
+This is an internal variable for downloading patches.
+Usually no need to change it.
+
+#### Default value
+
+```YAML
+oracle_plat_lang: 226P
+```
+
+### proxy_env
+
+This is an internal variable for downloading patches.
+Usually no need to change it.
+
+#### Default value
+
+```YAML
+proxy_env:
+  http_proxy: '{{ http_proxy }}'
+  https_proxy: '{{ https_proxy }}'
+  no_proxy: '{{ no_proxy }}'
+```
+
+### use_proxy
+
+Enable Proxy for Download
+
+#### Default value
+
+```YAML
+use_proxy: false
+```
+
+
+
+## Dependencies
+
+- orasw_meta
+
+## License
+
+license (MIT)
+
+## Author
+
+bartowl <github@bartowl.eu>

--- a/roles/orasw_download_patches/defaults/main.yml
+++ b/roles/orasw_download_patches/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# @var mos_login:description: Login name for My Oracle Support (required)
+# @var mos_password:description: Password for My Oracle Support (required)
+
+# proxy support
+use_proxy: false
+http_proxy:
+https_proxy:
+no_proxy:
+
+proxy_env:
+  http_proxy: "{{ http_proxy }}"
+  https_proxy: "{{ https_proxy }}"
+  no_proxy: "{{ no_proxy }}"
+
+oracle_plat_lang: 226P  # Linux x86-64
+
+opatchinfo: []
+
+oracle_patch_download_dir: "{{ oracle_sw_source_local }}"  # by default download to ansible controller stage area
+oracle_patch_download_host: "localhost"                    # by default download on ansible controller

--- a/roles/orasw_download_patches/defaults/main.yml
+++ b/roles/orasw_download_patches/defaults/main.yml
@@ -2,20 +2,41 @@
 # @var mos_login:description: Login name for My Oracle Support (required)
 # @var mos_password:description: Password for My Oracle Support (required)
 
-# proxy support
+# @var use_proxy:description: Enable Proxy for Download
 use_proxy: false
+
+# @var http_proxy:description: Define the http proxy for downloads
 http_proxy:
+
+# @var https_proxy:description: Define the https proxy for downloads
 https_proxy:
+
+# @var no_proxy:description: Define no_proxy list für downlads.
 no_proxy:
 
+# @var proxy_env:description: >
+# This is an internal variable for downloading patches.
+# Usually no need to change it.
+# @end
 proxy_env:
   http_proxy: "{{ http_proxy }}"
   https_proxy: "{{ https_proxy }}"
   no_proxy: "{{ no_proxy }}"
 
+# @var oracle_plat_lang:description: >
+# This is an internal variable for downloading patches.
+# Usually no need to change it.
+# @end
 oracle_plat_lang: 226P  # Linux x86-64
 
+# @var opatchinfo:description: >
+# This is an internal variable for downloading patches.
+# Usually no need to change it.
+# @end
 opatchinfo: []
 
-oracle_patch_download_dir: "{{ oracle_sw_source_local }}"  # by default download to ansible controller stage area
-oracle_patch_download_host: "localhost"                    # by default download on ansible controller
+# @var oracle_patch_download_dir:description: Target directory for patch downloads
+oracle_patch_download_dir: "{{ oracle_sw_source_local }}"
+
+# @var oracle_patch_download_host:description: `delegate_to` host for downloads
+oracle_patch_download_host: "localhost"

--- a/roles/orasw_download_patches/meta/main.yml
+++ b/roles/orasw_download_patches/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: orasw_download_patches
+  author: bartowl <github@bartowl.eu>
+  description: Download all patches from Oracle
+  company: OPITZ CONSULTING
+
+  license: license (MIT)
+
+  min_ansible_version: 2.9.0
+
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+        - "8"
+
+  galaxy_tags:
+    - oracle
+
+dependencies:
+  - role: orasw_meta

--- a/roles/orasw_download_patches/meta/main.yml
+++ b/roles/orasw_download_patches/meta/main.yml
@@ -1,4 +1,8 @@
 ---
+# @meta description: >
+# Download all patches from Oracle
+# @end
+# @meta author: bartowl <github@bartowl.eu>
 galaxy_info:
   role_name: orasw_download_patches
   author: bartowl <github@bartowl.eu>

--- a/roles/orasw_download_patches/tasks/main.yml
+++ b/roles/orasw_download_patches/tasks/main.yml
@@ -1,0 +1,133 @@
+---
+- name: Download patches from Oracle on ansible-controller just once
+  run_once: true
+  delegate_to: "{{ oracle_patch_download_host }}"
+  block:
+    - name: Check if credentials are known
+      ansible.builtin.assert:
+        that:
+          - mos_login is defined
+          - mos_password is defined
+          - oracle_patch_download_dir is defined
+
+    - name: Ensure destination directory exists
+      ansible.builtin.file:
+        path: "{{ oracle_patch_download_dir }}"
+        state: directory
+        mode: 0755
+
+    - name: Login to Oracle
+      ansible.builtin.uri:
+        url: https://updates.oracle.com/Orion/Services/download
+        url_username: "{{ mos_login }}"
+        url_password: "{{ mos_password }}"
+        force_basic_auth: true
+        http_agent: "Wget/1.14 (linux-gnu)"
+        use_proxy: "{{ use_proxy }}"
+        return_content: true
+      environment: "{{ proxy_env }}"
+      register: mos_cookies
+
+    - name: Prepare list of OPatch patches needed
+      vars:
+        opatch:
+          patchid: 6880880
+          filename: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) | map(attribute='filename') | join }}"
+          description: "Current OPatch for {{ db_version }}"
+      ansible.builtin.set_fact:
+        opatchinfo: "{{ opatchinfo + [opatch] }}"
+      with_items:
+        - "{{ db_homes_installed }}"
+      when:
+        - opatch.filename | length > 0
+        - "opatch.filename not in (opatchinfo | map(attribute='filename'))"  # do not create duplicates
+      loop_control:
+        label: "{{ item.home }}: {{ opatch.filename | d('cannot find oracle_opatch_patch entry for ' + db_version, true) }}"
+
+    - name: Get ARU and URL
+      vars:
+        url: "https://updates.oracle.com/Orion/SimpleSearch/process_form?search_type=patch&plat_lang={{ oracle_plat_lang }}&patch_number={{ item.patchid }}"
+        aru: "{{ aru_list.content | regex_findall(item.filename + '[^ ]+aru=(\\d+)') | d(['missing'], true) | first }}"
+        password_required: "{{ aru_list.content is regex('password is required') }}"
+        summary: >-
+          {% if password_required %}
+          Password is needed for download, yet currently not supported. Please open Issue.
+          {% elif aru == 'missing' %}
+          Could not determine ARU - is patch number valid? see URL {{ url }}
+          {% else %}
+          ARU={{ aru }}
+          {% endif %}
+      ansible.builtin.uri:
+        url: "{{ url }}"
+        http_agent: "Wget/1.14 (linux-gnu)"
+        return_content: true
+        headers:
+          Cookie: "{{ mos_cookies.cookies_string }}"
+        use_proxy: "{{ use_proxy }}"
+      environment: "{{ proxy_env }}"
+      with_items:
+        - "{{ opatchinfo }}"
+        - "{{ oracle_sw_patches }}"
+      failed_when: "aru == 'missing' or password_required"
+      loop_control:
+        label: "{{ item.filename }} {{ summary }}"
+      register: aru_list
+
+    - name: Get Digest checksums
+      vars:
+        url: "https://updates.oracle.com//Orion/ViewDigest/get_form?aru={{ aru }}"
+        aru: "{{ aru_list.results[idx].content | d('') | regex_findall(item.filename + '[^ ]+aru=(\\d+)') | first }}"
+        sha256: "{{ sha_list.content | regex_findall('([A-F0-9]{64})') | d(['missing'], true) | first }}"
+        summary: >-
+          {% if sha256 == 'missing' %}
+          Could not get SHA256. Check URL output: {{ url }}
+          {% else %}
+          SHA256:{{ sha256 | lower }}
+          {% endif %}
+      ansible.builtin.uri:
+        url: "{{ url }}"
+        http_agent: "Wget/1.14 (linux-gnu)"
+        return_content: true
+        headers:
+          Cookie: "{{ mos_cookies.cookies_string }}"
+        use_proxy: "{{ use_proxy }}"
+      environment: "{{ proxy_env }}"
+      register: sha_list
+      when: aru != 'missing'
+      failed_when: sha256 == 'missing'
+      with_items:
+        - "{{ aru_list.results | map(attribute='item') }}"  # use original loop
+      loop_control:
+        index_var: idx
+        label: "{{ item.filename }} {{ summary }}"
+
+    - name: Download Patches
+      vars:
+        aru: "{{ aru_list.results[idx].content | regex_findall(item.filename + '[^ ]+aru=(\\d+)') | first }}"
+        download_url: "{{ aru_list.results[idx].content | regex_findall('(https://[^ ]+/process_form/' + item.filename + '[^ ]+). ') | first }}"
+        sha256: "{{ sha_list.results[idx].content | regex_findall('([A-F0-9]{64})') | first }}"
+        summary: >-
+          {% if download_patches.msg is search('exists') %}
+          Already downloaded (SHA256 match)
+          {% else %}
+          {{ item.description | d('no description available') }} {{ download_patches.msg | default('') }}
+          {% endif %}
+      ansible.builtin.get_url:
+        url: "{{ download_url }}"
+        dest: "{{ oracle_sw_source_local }}/{{ item.filename }}"
+        http_agent: "Wget/1.14 (linux-gnu)"
+        headers:
+          Cookie: "{{ mos_cookies.cookies_string }}"
+          Accept: "application/zip"
+        checksum: "sha256:{{ sha256 }}"
+        use_proxy: "{{ use_proxy }}"
+        # owner: "{{ oracle_user }}"   # not always ansible contorller knows this user
+        # group: "{{ oracle_group }}"  # not always ansible contorller knows this group
+        mode: 0644
+      environment: "{{ proxy_env }}"
+      register: download_patches
+      with_items:
+        - "{{ aru_list.results | map(attribute='item') }}"  # use original loop
+      loop_control:
+        index_var: idx
+        label: "{{ item.filename }} - {{ summary }}"


### PR DESCRIPTION
This is a new role, that can be used to download all patches referenced in `oracle_sw_patches` plus current OPatch for all `db_homes_installed` versions.

Required variables:
  - `mos_login`: login for My Oracle Support
  - `mos_password`: password for My Oracle support