### PR TITLE
Add task to register database in rman catalog

### DIFF
--- a/changelogs/fragments/rman_catalog_register.yml
+++ b/changelogs/fragments/rman_catalog_register.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "added task to REGISTER DATABASE in Rman Catalog (oravirt#334)"

--- a/roles/oradb_rman/defaults/main.yml
+++ b/roles/oradb_rman/defaults/main.yml
@@ -39,3 +39,9 @@ rman_catalog_param: "{% if item.0.rman_wallet is defined and item.0.rman_wallet 
                        {%- if item.0.rman_user is defined %}-c {{ item.0.rman_user }}/{{ dbpasswords[item.0.rman_tnsalias][item.0.rman_user] | default(item.0.rman_password) }}@{{ item.0.rman_tnsalias }}
                        {%- endif %}
                      {%- endif %}"
+rman_register_connect: >-
+  {%- if item.rman_wallet is defined -%}
+  /@{{ item.rman_tnsalias }}
+  {%- else -%}
+  {{ item.rman_user }}/{{ dbpasswords[item.rman_tnsalias][item.rman_user] | default(item.rman_password) }}@{{ item.rman_tnsalias }}
+  {%- endif -%}

--- a/roles/oradb_rman/tasks/main.yml
+++ b/roles/oradb_rman/tasks/main.yml
@@ -266,6 +266,26 @@
   tags:
     - wallet
 
+- name: Register Database in RMAN Catalog
+  become_user: "{{ oracle_user }}"
+  ansible.builtin.shell:
+    cmd: "$ORACLE_HOME/bin/rman target / catalog $CONNECTSTRING"
+    stdin: "REGISTER DATABASE;\n"
+  environment:
+    ORACLE_HOME: "{{ db_homes_config[item.home]['oracle_home'] }}"
+    ORACLE_SID: "{{ item.oracle_db_name }}"
+    CONNECTSTRING: "{{ rman_register_connect }}"
+    TNS_ADMIN: "{{ rman_tns_admin }}"
+  with_items:
+    - "{{ oracle_databases | selectattr('rman_tnsalias', 'defined') }}"
+  loop_control:
+    label: "{{ item.oracle_db_name | default('') }}"
+  register: rman_catalog_register
+  failed_when: '"RMAN-" in rman_catalog_register.stdout and "RMAN-20002" not in rman_catalog_register.stdout'
+  changed_when: '"RMAN-20002" not in rman_catalog_register.stdout'
+  tags:
+    - rmanregister
+
 # the following task is usefull for configuration of rman-parameters during setup of RMAN
 # It's also possible to execute the 1st Level0-Backup after setup, but be aware to configure the RMAN before starting a backup
 # The execution isn't done in async mode!


### PR DESCRIPTION
This PR adds a task to register the database in rman catalog if oracle_databases contain `rman_tnsalias`.
Can be skipped with `skip_tags: rmanregister`