### PR TITLE
Remove deprecation warnings for community.general 7.x

### DIFF
--- a/changelogs/fragments/communiy_collection.yml
+++ b/changelogs/fragments/communiy_collection.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Remove deprecation warnings for community.general 7.x (oravirt#339)"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -69,7 +69,7 @@
     - commonpackages
 
 - name: Install common packages SLES12
-  community.general.packaging.os.zypper:
+  community.general.zypper:
     name: "{{ common_packages_sles }}"
     state: installed
   when: install_os_packages and ansible_os_family == 'Suse'

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -23,7 +23,7 @@
   tags: os_packages, oscheck
 
 - name: Install custom packages required by Oracle on SLES (oracle_packages_sles)
-  community.general.packaging.os.zypper:
+  community.general.zypper:
     name: "{{ oracle_packages_sles }}"
     state: installed
   when:
@@ -33,7 +33,7 @@
   tags: os_packages, oscheck
 
 - name: Install default packages required by Oracle on SLES (version dependant)
-  community.general.packaging.os.zypper:
+  community.general.zypper:
     name: "{{ item.packages }}"
     state: installed
   with_items:
@@ -61,7 +61,7 @@
   tags: os_packages, oscheck
 
 - name: Install packages required by Oracle for ASMlib on SLES
-  community.general.packaging.os.zypper:
+  community.general.zypper:
     name: "{{ oracle_asm_packages_sles }}"
     state: installed
   when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'Suse' and asm_diskgroups is defined
@@ -103,7 +103,7 @@
   when: os_timezone is defined
   block:  # noqa name[missing]
     - name: Set Timezone
-      community.general.system.timezone:
+      community.general.timezone:
         name: "{{ os_timezone }}"
         hwclock: "{{ os_hwclock | default(omit) }}"
       register: timezoneresult
@@ -337,7 +337,7 @@
   tags: hostfs
 
 - name: filesystem | Create vg
-  community.general.system.lvg:
+  community.general.lvg:
     vg: "{{ item.vgname }}"
     pvs: "{{ host_fs_layout_vgdisks }}"
     state: "{{ item.state }}"
@@ -346,7 +346,7 @@
   tags: hostfs
 
 - name: filesystem | create lv
-  community.general.system.lvol:
+  community.general.lvol:
     vg: "{{ item.0.vgname }}"
     lv: "{{ item.1.lvname }}"
     size: "{{ item.1.lvsize }}"
@@ -360,7 +360,7 @@
   tags: hostfs
 
 - name: filesystem | create fs
-  community.general.system.filesystem:
+  community.general.filesystem:
     fstype: "{{ item.1.fstype }}"
     dev: "/dev/{{ item.0.vgname }}/{{ item.1.lvname }}"
     opts: "{{ item.1.fsopts | default(omit) }}"
@@ -490,7 +490,7 @@
   tags: seclimit
 
 - name: Oracle-recommended security limits on SLES
-  community.general.system.pam_limits:
+  community.general.pam_limits:
     domain: oracle
     limit_type: "{{ item.name.split(' ')[0] }}"
     limit_item: "{{ item.name.split(' ')[1] }}"


### PR DESCRIPTION
Remove following warnings during playbook execution:

> community.general.system.timezone has been deprecated. 
> You are using an internal name to access the community.general.timezone modules. This has never been supported or documented, and will stop working in community.general 9.0.0. This feature will be removed from community.general in version 9.0.0.

This has been fixed for different modules.