### PR TITLE
black and flake8 for Python modules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+
+max-line-length = 88
+
+filename =
+    plugins/modules/oracle_*.py

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,36 @@
+name: Python-lint
+
+on:
+  pull_request:
+    branches:
+      - master
+      - development
+  push:
+    branches:
+      - 'pr*'
+
+jobs:
+  black-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: black
+        uses: psf/black@stable
+        with:
+          options: "--diff --check --verbose"
+          src: "./plugins/modules"
+          version: "23.3.0"
+
+  flake8-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+        with:
+          include: "./plugins/modules"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,17 @@ repos:
         pass_filenames: false
         always_run: true
         verbose: true
+
+  - repo: https://github.com/python/black.git
+    rev: 23.3.0
+    hooks:
+      - id: black
+        # language_version: python3
+        # files: plugins/modules/*.py
+        files: \.py$
+        include: lugins/modules
+
+  - repo: https://github.com/pycqa/flake8
+    rev: '6.0.0'
+    hooks:
+      - id: flake8

--- a/changelogs/fragments/flake8.yml
+++ b/changelogs/fragments/flake8.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "flake8: adding flake8 to pre-commit (oravirt#343)"
+  - "black: adding black to pre-commit (oravirt#343)"

--- a/changelogs/fragments/python-lint.yml
+++ b/changelogs/fragments/python-lint.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "github Actions: adding Action for black and flake8 (oravirt#343)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+# pyproject.toml
+[tool.black]
+skip-string-normalization = true


### PR DESCRIPTION
Added black und flake8 for linting of Python code.
Only modules with '*.py' are check by the linters.

Configurations for pre-commit and Github Actions are part of this Pull-Request.