### PR TITLE
pre-commit: added antsibull-changelog-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,17 @@ repos:
         # language_version: python3
         # files: plugins/modules/*.py
         files: \.py$
-        include: lugins/modules
+        include: plugins/modules
 
   - repo: https://github.com/pycqa/flake8
     rev: '6.0.0'
     hooks:
       - id: flake8
+
+  - repo: https://github.com/ansible-community/antsibull-changelog.git
+    rev: main
+    hooks:
+      - id: antsibull-changelog-lint
 
   - repo: https://github.com/ansible-community/ansible-lint.git
     rev: v6.14.4

--- a/changelogs/fragments/pre-commit.yml
+++ b/changelogs/fragments/pre-commit.yml
@@ -1,2 +1,3 @@
 bugfixes:
-  - "moved ansible-lint to end of pre-commit hooks (oravirt#344)"
+  - "pre-commit: moved ansible-lint to end of pre-commit hooks (oravirt#344)"
+  - "pre-commit: added antsibull-changelog-lint (oravirt#345)"


### PR DESCRIPTION
The pre-commit for antsibull-changelog-lint is only availible on main branch at the moment. This will be changed in the future to the next release of antsibull-changelog.