### PR TITLE
cx_oracle: Added installation of cx_Oracle for Python3

### DIFF
--- a/changelogs/fragments/cx_oracle.yml
+++ b/changelogs/fragments/cx_oracle.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - "cx_oracle: Added installation of cx_Oracle for Python3 (oravirt#346)"

--- a/changelogs/fragments/python2_deprecated.yml
+++ b/changelogs/fragments/python2_deprecated.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - "modules: all modules will loose support for Python2 in ansible-oracle 4.0.0  (oravirt#346)"

--- a/roles/cxoracle/tasks/main.yml
+++ b/roles/cxoracle/tasks/main.yml
@@ -1,10 +1,26 @@
 # cxoracle-install playbook
 ---
-- name: Install cx_oracle
+# The cx_Oracle is installed for Python2 only, when Python2 is
+# used as an interpreter in Ansible.
+- name: Install cx_oracle for Python2
   ansible.builtin.pip:
-     name: "{{ cx_oracle_source | default('cx_oracle<8.0') }}"
-     extra_args: "{{ extra_args }}"
-     umask: "{{ cx_oracle_umask | default(omit) }}"
-     state: present
+    name: "{{ cx_oracle_source | default('cx_oracle<8.0') }}"
+    extra_args: "{{ extra_args }}"
+    umask: "{{ cx_oracle_umask | default(omit) }}"
+    state: present
+  when:
+    - install_cx_oracle
+    - ansible_python.version.major == 2
+  tags: cx_oracle
+
+# The future ansible-oracle modules are using Python3 only
+# => Install cx_Oracle for Python3 as well
+- name: Install cx_oracle for Python3
+  ansible.builtin.pip:
+    name: "{{ cx_oracle3_source | default(cx_oracle_source) | default('cx_oracle') }}"
+    executable: pip3
+    extra_args: "{{ extra_args }}"
+    umask: "{{ cx_oracle_umask | default(omit) }}"
+    state: present
   when: install_cx_oracle
   tags: cx_oracle


### PR DESCRIPTION
The Release 3.8.0 of ansible-oracle changes the module `oracle_db`.
It requires an installation of Python3 and cx_Oracle for Python3.
The role cx_oracle installs cx_Oracle for Python2 and Python3 when '`ansible_python_interpreter`' points to Python2.

Please execute the role cx_oracle for old systems to install cx_Oracle for Python3.

This PR is mandatory for #342 