### PR TITLE
common: removed assert for python due to oravirt#346

### DIFF
--- a/changelogs/fragments/assert.yml
+++ b/changelogs/fragments/assert.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "common: removed assert for python due to oravirt#346 (oravirt#350)"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,18 +1,5 @@
 # Common playbook - sets up the host generic stuff
 ---
-# ansible-oracle needs python2 on some distributions for later installation of cx_Oracle
-- name: Check for correct Ansible Interpreter on RHEL/OL 7
-  ansible.builtin.assert:
-    quiet: true
-    that:
-      - discovered_interpreter_python == '/usr/bin/python'
-    fail_msg: Set interpreter_python to /usr/bin/python
-  when:
-    - ansible_distribution in('OracleLinux', 'RedHat')
-    - ansible_distribution_major_version == '7'
-    - interpreter_python is not defined
-  tags:
-    - assert
 
 - name: Check for correct Ansible Version (>= 2.8)
   ansible.builtin.assert:


### PR DESCRIPTION
The assert is not needed anymore, due to cx_Oracle installation for Python3 and Python2 when needed.