### PR TITLE
Release 3.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,56 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v3.8.0
+======
+
+Release Summary
+---------------
+
+This is ansible-oracle 3.8.0.
+The target database server must have Python3 installaed which is automatically done with role `orahost`.
+It is mandatory for the module `oracle_db` which is used in `oradb_manage_db`.
+
+
+Minor Changes
+-------------
+
+- Add restart possibility after scope=spfile init parameters change (oravirt#342)
+- Add state=restarted to oracle_db (oravirt#342)
+- Remove deprecation warnings for community.general 7.x (oravirt#339)
+- black: adding black to pre-commit (oravirt#343)
+- flake8: adding flake8 to pre-commit (oravirt#343)
+- github Actions: adding Action for black and flake8 (oravirt#343)
+- ocenv: version 2023-06-06 of ocenv environment script (oravirt#347)
+- oracle_db: Refactoring code for flake8 (oravirt#342)
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- cx_Oracle: requires Python3 installed on target system  (oravirt#342)
+- cx_oracle: Added installation of cx_Oracle for Python3 (oravirt#346)
+- oradb_manage_db: requires Python3 installed on target system  (oravirt#342)
+
+Deprecated Features
+-------------------
+
+- modules: all modules will loose support for Python2 in ansible-oracle 4.0.0  (oravirt#346)
+
+Bugfixes
+--------
+
+- common: removed assert for python due to oravirt#346 (oravirt#350)
+- orasw_download_patches: added missing assert for oracle_sw_source_local (oravirt#340)
+- oraswdb_install: changed oracle_databases to db_homes_installed for installation source of ORACLE_HOMEs (oravirt#348)
+- oraswdb_manage_patches: Bugfix for missing opatch or opatchauto in db_homs_config dict (oravirt#349)
+- pre-commit: added antsibull-changelog-lint (oravirt#345)
+- pre-commit: moved ansible-lint to end of pre-commit hooks (oravirt#344)
+
+Known Issues
+------------
+
+- pre-commit: Ignore [WARNING] The 'rev' field of repo 'https://github.com/ansible-community/antsibull-changelog.git'. This will be fixed with next antsibull-changelog release.
+
 v3.7.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -9,9 +9,14 @@ plugins:
   httpapi: {}
   inventory: {}
   lookup: {}
-  module: {}
+  module:
+    oracle_db:
+      description: Manage an Oracle database
+      name: oracle_db
+      namespace: ''
+      version_added: 2.4.0
   netconf: {}
   shell: {}
   strategy: {}
   vars: {}
-version: 3.7.0
+version: 3.8.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -278,3 +278,56 @@ releases:
     - rman_catalog_register.yml
     - sles_os_packages.yml
     release_date: '2023-05-07'
+  3.8.0:
+    changes:
+      breaking_changes:
+      - 'cx_Oracle: requires Python3 installed on target system  (oravirt#342)'
+      - 'cx_oracle: Added installation of cx_Oracle for Python3 (oravirt#346)'
+      - 'oradb_manage_db: requires Python3 installed on target system  (oravirt#342)'
+      bugfixes:
+      - 'common: removed assert for python due to oravirt#346 (oravirt#350)'
+      - 'orasw_download_patches: added missing assert for oracle_sw_source_local (oravirt#340)'
+      - 'oraswdb_install: changed oracle_databases to db_homes_installed for installation
+        source of ORACLE_HOMEs (oravirt#348)'
+      - 'oraswdb_manage_patches: Bugfix for missing opatch or opatchauto in db_homs_config
+        dict (oravirt#349)'
+      - 'pre-commit: added antsibull-changelog-lint (oravirt#345)'
+      - 'pre-commit: moved ansible-lint to end of pre-commit hooks (oravirt#344)'
+      deprecated_features:
+      - 'modules: all modules will loose support for Python2 in ansible-oracle 4.0.0  (oravirt#346)'
+      known_issues:
+      - 'pre-commit: Ignore [WARNING] The ''rev'' field of repo ''https://github.com/ansible-community/antsibull-changelog.git''.
+        This will be fixed with next antsibull-changelog release.'
+      minor_changes:
+      - Add restart possibility after scope=spfile init parameters change (oravirt#342)
+      - Add state=restarted to oracle_db (oravirt#342)
+      - Remove deprecation warnings for community.general 7.x (oravirt#339)
+      - 'black: adding black to pre-commit (oravirt#343)'
+      - 'flake8: adding flake8 to pre-commit (oravirt#343)'
+      - 'github Actions: adding Action for black and flake8 (oravirt#343)'
+      - 'ocenv: version 2023-06-06 of ocenv environment script (oravirt#347)'
+      - 'oracle_db: Refactoring code for flake8 (oravirt#342)'
+      release_summary: 'This is ansible-oracle 3.8.0.
+
+        The target database server must have Python3 installaed which is automatically
+        done with role `orahost`.
+
+        It is mandatory for the module `oracle_db` which is used in `oradb_manage_db`.
+
+        '
+    fragments:
+    - _known_issues.yml
+    - assert.yml
+    - communiy_collection.yml
+    - cx_oracle.yml
+    - download_patch.yml
+    - flake8.yml
+    - ocenv.yml
+    - opatchauto.yml
+    - oraswdb_install_curl.yml
+    - pre-commit.yml
+    - python-lint.yml
+    - python2_deprecated.yml
+    - release.yml
+    - restart_spfile_parameters.yml
+    release_date: '2023-07-08'

--- a/changelogs/fragments/assert.yml
+++ b/changelogs/fragments/assert.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "common: removed assert for python due to oravirt#346 (oravirt#350)"

--- a/changelogs/fragments/communiy_collection.yml
+++ b/changelogs/fragments/communiy_collection.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Remove deprecation warnings for community.general 7.x (oravirt#339)"

--- a/changelogs/fragments/cx_oracle.yml
+++ b/changelogs/fragments/cx_oracle.yml
@@ -1,3 +1,0 @@
----
-breaking_changes:
-  - "cx_oracle: Added installation of cx_Oracle for Python3 (oravirt#346)"

--- a/changelogs/fragments/download_patch.yml
+++ b/changelogs/fragments/download_patch.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orasw_download_patches: added missing assert for oracle_sw_source_local (oravirt#340)"

--- a/changelogs/fragments/flake8.yml
+++ b/changelogs/fragments/flake8.yml
@@ -1,9 +1,0 @@
----
-minor_changes:
-  - "flake8: adding flake8 to pre-commit (oravirt#343)"
-  - "black: adding black to pre-commit (oravirt#343)"
-  - "oracle_db: Refactoring code for flake8 (oravirt#342)"
-
-breaking_changes:
-  - "oradb_manage_db: requires Python3 installed on target system  (oravirt#342)"
-  - "cx_Oracle: requires Python3 installed on target system  (oravirt#342)"

--- a/changelogs/fragments/ocenv.yml
+++ b/changelogs/fragments/ocenv.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "ocenv: version 2023-06-06 of ocenv environment script (oravirt#347)"

--- a/changelogs/fragments/opatchauto.yml
+++ b/changelogs/fragments/opatchauto.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_manage_patches: Bugfix for missing opatch or opatchauto in db_homs_config dict (oravirt#349)"

--- a/changelogs/fragments/oraswdb_install_curl.yml
+++ b/changelogs/fragments/oraswdb_install_curl.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_install: changed oracle_databases to db_homes_installed for installation source of ORACLE_HOMEs (oravirt#348)"

--- a/changelogs/fragments/pre-commit.yml
+++ b/changelogs/fragments/pre-commit.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - "pre-commit: moved ansible-lint to end of pre-commit hooks (oravirt#344)"
-  - "pre-commit: added antsibull-changelog-lint (oravirt#345)"

--- a/changelogs/fragments/python-lint.yml
+++ b/changelogs/fragments/python-lint.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "github Actions: adding Action for black and flake8 (oravirt#343)"

--- a/changelogs/fragments/python2_deprecated.yml
+++ b/changelogs/fragments/python2_deprecated.yml
@@ -1,3 +1,0 @@
----
-deprecated_features:
-  - "modules: all modules will loose support for Python2 in ansible-oracle 4.0.0  (oravirt#346)"

--- a/changelogs/fragments/restart_spfile_parameters.yml
+++ b/changelogs/fragments/restart_spfile_parameters.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - "Add state=restarted to oracle_db (oravirt#342)"
-  - "Add restart possibility after scope=spfile init parameters change (oravirt#342)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 3.7.0
+version: 3.8.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v3.8.0
======

Release Summary
---------------

This is ansible-oracle 3.8.0.
The target database server must have Python3 installaed which is automatically done with role `orahost`.
It is mandatory for the module `oracle_db` which is used in `oradb_manage_db`.


Minor Changes
-------------

- Add restart possibility after scope=spfile init parameters change (oravirt#342)
- Add state=restarted to oracle_db (oravirt#342)
- Remove deprecation warnings for community.general 7.x (oravirt#339)
- black: adding black to pre-commit (oravirt#343)
- flake8: adding flake8 to pre-commit (oravirt#343)
- github Actions: adding Action for black and flake8 (oravirt#343)
- ocenv: version 2023-06-06 of ocenv environment script (oravirt#347)
- oracle_db: Refactoring code for flake8 (oravirt#342)

Breaking Changes / Porting Guide
--------------------------------

- cx_Oracle: requires Python3 installed on target system  (oravirt#342)
- cx_oracle: Added installation of cx_Oracle for Python3 (oravirt#346)
- oradb_manage_db: requires Python3 installed on target system  (oravirt#342)

Deprecated Features
-------------------

- modules: all modules will loose support for Python2 in ansible-oracle 4.0.0  (oravirt#346)

Bugfixes
--------

- common: removed assert for python due to oravirt#346 (oravirt#350)
- orasw_download_patches: added missing assert for oracle_sw_source_local (oravirt#340)
- oraswdb_install: changed oracle_databases to db_homes_installed for installation source of ORACLE_HOMEs (oravirt#348)
- oraswdb_manage_patches: Bugfix for missing opatch or opatchauto in db_homs_config dict (oravirt#349)
- pre-commit: added antsibull-changelog-lint (oravirt#345)
- pre-commit: moved ansible-lint to end of pre-commit hooks (oravirt#344)

Known Issues
------------

- pre-commit: Ignore [WARNING] The 'rev' field of repo 'https://github.com/ansible-community/antsibull-changelog.git'. This will be fixed with next antsibull-changelog release.