### PR TITLE
oraswdb_install: enable CV_ASSUME_DISTID=OL7 for Golden-Image on OL/RHEL8

### DIFF
--- a/changelogs/fragments/assume_os.yml
+++ b/changelogs/fragments/assume_os.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oraswdb_install: enable CV_ASSUME_DISTID=OL7 for Golden-Image on OL/RHEL8 (oravirt#355)"

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,6 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.shell: "{% if ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 8 and db_homes_config[dbh.home]['imagename'] is not defined %}CV_ASSUME_DISTID=OL7 {% endif %}{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
+  ansible.builtin.shell: "{% if ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 8 %}CV_ASSUME_DISTID=OL7 {% endif %}{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ oracle_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
   # noqa command-instead-of-shell no-changed-when
   become: true
   become_user: "{{ oracle_user }}"


### PR DESCRIPTION
`CV_ASSUME_DISTID=OL7` was only set when no Golden-Image was used.
This needs to be changed to all installations on OL/RHEL8, because the needed fix is included in `OCW 19.6` or newer.
The problem is, that lot of customers only installs `DBRU` and not `OCW`.

The result is that `runInstaller` will fail.

I am responsible for this addional filter in #284 - sorry for that.