### PR TITLE
Added support for db_domain in init.ora

### DIFF
--- a/changelogs/fragments/db_domain.yml
+++ b/changelogs/fragments/db_domain.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Added support for db_domain in init.ora (oravirt#356)"

--- a/changelogs/fragments/oradb_facts.yml
+++ b/changelogs/fragments/oradb_facts.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_facts: Backported role from dev release (oravirt#356)"

--- a/roles/oradb_facts/README.md
+++ b/roles/oradb_facts/README.md
@@ -1,0 +1,115 @@
+# oradb_facts
+
+Gather Ansible Facts from database
+
+## Table of content
+
+- [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [__db_service_name](#__db_service_name)
+  - [__db_user](#__db_user)
+  - [__listener_port](#__listener_port)
+  - [__oracle_env](#__oracle_env)
+  - [__oracle_home_db](#__oracle_home_db)
+  - [_db_password_cdb](#_db_password_cdb)
+  - [listener_port](#listener_port)
+- [Discovered Tags](#discovered-tags)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Requirements
+
+- Minimum Ansible version: `2.9.0`
+
+
+## Default Variables
+
+### __db_service_name
+
+#### Default value
+
+```YAML
+__db_service_name: '{% if odb.0 is defined %} {%- if odb.0.oracle_db_unique_name is
+  defined %}{{ odb.0.oracle_db_unique_name }} {%- elif odb.0.oracle_db_instance_name
+  is defined %}{{ odb.0.oracle_db_instance_name }} {%- else %}{{ odb.0.oracle_db_name
+  }} {%- endif %} {%- endif %}'
+```
+
+### __db_user
+
+#### Default value
+
+```YAML
+__db_user: sys
+```
+
+### __listener_port
+
+#### Default value
+
+```YAML
+__listener_port: '{{ odb.0.listener_port | default(listener_port) }}'
+```
+
+### __oracle_env
+
+#### Default value
+
+```YAML
+__oracle_env:
+  ORACLE_HOME: '{{ __oracle_home_db }}'
+  LD_LIBRARY_PATH: '{{ __oracle_home_db }}/lib'
+```
+
+### __oracle_home_db
+
+#### Default value
+
+```YAML
+__oracle_home_db: >-
+  {%- if odb[0] is defined -%}
+  {%- if db_homes_config[odb[0]['home']]['oracle_home'] is defined -%}
+  {{ db_homes_config[odb[0]['home']]['oracle_home'] }}{%- endif -%}{%- endif -%}
+```
+
+### _db_password_cdb
+
+#### Default value
+
+```YAML
+_db_password_cdb: >-
+  {% if dbpasswords is defined
+      and dbpasswords[odb.0.oracle_db_name] is defined
+      and dbpasswords[odb.0.oracle_db_name][db_user] is defined -%}
+      {{ dbpasswords[odb.0.oracle_db_name][db_user] }}
+  {%- else %}{{ default_dbpass }}
+  {%- endif %}
+```
+
+### listener_port
+
+#### Default value
+
+```YAML
+listener_port: 1521
+```
+
+## Discovered Tags
+
+**_db_facts_**
+
+
+## Dependencies
+
+- orasw_meta
+
+## License
+
+license (MIT)
+
+## Author
+
+Thorsten Bruhns

--- a/roles/oradb_facts/defaults/main.yml
+++ b/roles/oradb_facts/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+__db_user: sys
+
+listener_port: 1521
+
+__listener_port: "{{ odb.0.listener_port | default(listener_port) }}"
+
+_db_password_cdb: >-
+  {% if dbpasswords is defined
+      and dbpasswords[odb.0.oracle_db_name] is defined
+      and dbpasswords[odb.0.oracle_db_name][db_user] is defined -%}
+      {{ dbpasswords[odb.0.oracle_db_name][db_user] }}
+  {%- else %}{{ default_dbpass }}
+  {%- endif %}
+
+__db_service_name: "{% if odb.0 is defined %}
+                    {%- if odb.0.oracle_db_unique_name is defined %}{{ odb.0.oracle_db_unique_name }}
+                    {%- elif odb.0.oracle_db_instance_name is defined %}{{ odb.0.oracle_db_instance_name }}
+                    {%- else %}{{ odb.0.oracle_db_name }}
+                    {%- endif %}
+                  {%- endif %}"
+
+__oracle_env:
+  ORACLE_HOME: "{{ __oracle_home_db }}"
+  LD_LIBRARY_PATH: "{{ __oracle_home_db }}/lib"
+
+__oracle_home_db: >-
+  {%- if odb[0] is defined -%}
+  {%- if db_homes_config[odb[0]['home']]['oracle_home'] is defined -%}
+  {{ db_homes_config[odb[0]['home']]['oracle_home'] }}{%- endif -%}{%- endif -%}

--- a/roles/oradb_facts/meta/main.yml
+++ b/roles/oradb_facts/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  role_name: oradb_facts
+  author: Thorsten Bruhns
+  description: Gather Ansible Facts from database
+  company: OPITZ CONSULTING Deutschland GmbH
+
+  license: license (MIT)
+
+  min_ansible_version: 2.9.0
+
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+        - "8"
+
+  galaxy_tags:
+    - database
+    - oracle
+
+dependencies:
+  - role: orasw_meta

--- a/roles/oradb_facts/tasks/db_facts.yml
+++ b/roles/oradb_facts/tasks/db_facts.yml
@@ -1,0 +1,29 @@
+---
+- name: Gather Facts from Database
+  opitzconsulting.ansible_oracle.oracle_facts:
+    hostname: "{{ ansible_hostname }}"
+    port: "{{ __listener_port }}"
+    service_name: "{{ __db_service_name }}"
+    user: "{{ __db_user }}"
+    password: "{{ _db_password_cdb }}"
+    mode: sysdba
+  environment: "{{ __oracle_env }}"
+  register: dbfactsreg
+
+# 2nd execution of oracle_factswill overwrite data of last execution.
+# => Store facts from oracle_facts in structure
+- name: Write facts to oracledb.db_unique_name
+  ansible.builtin.set_fact:
+    cacheable: true
+    oracledb_facts: "{{ oracledb_facts | default({}) | combine(_db_facts | items2dict) }}"
+  vars:
+    _db_facts:
+      - key: "{{ odb[0]['oracle_db_unique_name'] | default(odb[0]['oracle_db_name']) }}"
+        value:
+          database: "{{ ansible_facts['database'] }}"
+          instance: "{{ ansible_facts['instance'] }}"
+          parameter: "{{ ansible_facts['parameter'] }}"
+          rac: "{{ ansible_facts['rac'] }}"
+          redolog: "{{ ansible_facts['redolog'] }}"
+          tablespace: "{{ ansible_facts['tablespace'] }}"
+          userenv: "{{ ansible_facts['userenv'] }}"

--- a/roles/oradb_facts/tasks/main.yml
+++ b/roles/oradb_facts/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Gather Facts from Database
+  when:
+    - oracle_databases is defined
+  tags: db_facts
+  block:
+    - name: Assert inventory data
+      ansible.builtin.import_role:
+        name: orasw_meta
+        tasks_from: assert_oracle_databases.yml
+
+    # IMPORTANT
+    # loop over module oracle_facts, because each execution
+    # overwrites ansible_facts from the previous one
+    - name: Gather Facts from Database
+      ansible.builtin.include_tasks: db_facts.yml
+      loop:
+        - "{{ oracle_databases }}"
+      loop_control:
+        loop_var: odb
+        label: >-
+          db_name: {{ odb[0]['oracle_db_name'] | default('') }}
+          db_unique_name: {{ odb[0]['oracle_db_unique_name'] | default('') }}
+          port: {{ listener_port }}
+          service: {{ db_service_name }}
+          state: {{ odb[0]['state'] | default('present') }}
+      when:
+        - odb[0]['state'] | default('present') == 'present'

--- a/roles/oradb_manage_grants/README.md
+++ b/roles/oradb_manage_grants/README.md
@@ -1,0 +1,163 @@
+# oradb_manage_grants
+
+Manage grants for users in Oracle Databases
+
+## Table of content
+
+- [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [configure_cluster](#configure_cluster)
+  - [db_mode](#db_mode)
+  - [db_password_cdb](#db_password_cdb)
+  - [db_password_pdb](#db_password_pdb)
+  - [db_service_name](#db_service_name)
+  - [db_user](#db_user)
+  - [listener_port](#listener_port)
+  - [listener_port_template](#listener_port_template)
+  - [oracle_base](#oracle_base)
+  - [oracle_env](#oracle_env)
+  - [user_cdb_password](#user_cdb_password)
+  - [user_pdb_password](#user_pdb_password)
+- [Discovered Tags](#discovered-tags)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Requirements
+
+- Minimum Ansible version: `2.9.0`
+
+
+## Default Variables
+
+### configure_cluster
+
+#### Default value
+
+```YAML
+configure_cluster: false
+```
+
+### db_mode
+
+#### Default value
+
+```YAML
+db_mode: sysdba
+```
+
+### db_password_cdb
+
+#### Default value
+
+```YAML
+db_password_cdb: '{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name]
+  is defined and dbpasswords[item.0.oracle_db_name][db_user] is defined%}{{ dbpasswords[item.0.oracle_db_name][db_user]
+  }} {%- else %}{{ default_dbpass }} {%- endif %}'
+```
+
+### db_password_pdb
+
+#### Default value
+
+```YAML
+db_password_pdb: '{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined
+  and dbpasswords[item.0.cdb][db_user] is defined %}{{ dbpasswords[item.0.cdb][db_user]
+  }} {%- else %}{{ default_dbpass }} {%- endif %}'
+```
+
+### db_service_name
+
+#### Default value
+
+```YAML
+db_service_name: '{% if item.0 is defined %} {%- if item.0.oracle_db_unique_name is
+  defined %}{{ item.0.oracle_db_unique_name }} {%- elif item.0.oracle_db_instance_name
+  is defined %}{{ item.0.oracle_db_instance_name }} {%- else %}{{ item.0.oracle_db_name
+  }} {%- endif %} {%- endif %}'
+```
+
+### db_user
+
+#### Default value
+
+```YAML
+db_user: sys
+```
+
+### listener_port
+
+#### Default value
+
+```YAML
+listener_port: 1521
+```
+
+### listener_port_template
+
+#### Default value
+
+```YAML
+listener_port_template: '{% if item.0.listener_port is defined %}{{ item.0.listener_port
+  }}{% else %}{{ listener_port }}{% endif %}'
+```
+
+### oracle_base
+
+#### Default value
+
+```YAML
+oracle_base: /u01/app/oracle
+```
+
+### oracle_env
+
+#### Default value
+
+```YAML
+oracle_env:
+  ORACLE_HOME: '{{ oracle_home_db }}'
+  LD_LIBRARY_PATH: '{{ oracle_home_db }}/lib'
+```
+
+### user_cdb_password
+
+#### Default value
+
+```YAML
+user_cdb_password: '{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name]
+  is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{
+  dbpasswords[item.0.oracle_db_name][item.1.schema] }} {%- else %}{{ default_dbpass
+  }} {%- endif %}'
+```
+
+### user_pdb_password
+
+#### Default value
+
+```YAML
+user_pdb_password: '{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined
+  and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]
+  is defined %}{{ dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] }} {%- else
+  %}{{ default_dbpass }} {%- endif%}'
+```
+
+## Discovered Tags
+
+**_users,grants_**
+
+
+## Dependencies
+
+- orasw_meta
+- oradb_facts
+
+## License
+
+license (MIT)
+
+## Author
+
+Mikael Sandström

--- a/roles/oradb_manage_grants/meta/main.yml
+++ b/roles/oradb_manage_grants/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_grants/tasks/main.yml
+++ b/roles/oradb_manage_grants/tasks/main.yml
@@ -42,7 +42,7 @@
     directory_privs: "{{ item.1.directory_privs | default(omit) }}"
     hostname: "{{ ansible_hostname }}"
     port: "{{ listener_port_template }}"
-    service_name: "{{ item.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
     mode: "{{ db_mode }}"

--- a/roles/oradb_manage_parameters/meta/main.yml
+++ b/roles/oradb_manage_parameters/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_parameters/tasks/main.yml
+++ b/roles/oradb_manage_parameters/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Manage parameters (pdb)
   opitzconsulting.ansible_oracle.oracle_parameter:
     hostname: "{{ ansible_hostname }}"
-    service_name: "{{ item.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     port: "{{ listener_port_template }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"

--- a/roles/oradb_manage_profiles/README.md
+++ b/roles/oradb_manage_profiles/README.md
@@ -1,0 +1,174 @@
+# oradb_manage_profiles
+
+Manage database profiles in Oracle
+
+## Table of content
+
+- [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [attr_name](#attr_name)
+  - [attr_value](#attr_value)
+  - [configure_cluster](#configure_cluster)
+  - [db_password_cdb](#db_password_cdb)
+  - [db_password_pdb](#db_password_pdb)
+  - [db_service_name](#db_service_name)
+  - [db_user](#db_user)
+  - [listener_port](#listener_port)
+  - [listener_port_template](#listener_port_template)
+  - [oracle_base](#oracle_base)
+  - [oracle_env](#oracle_env)
+  - [user_cdb_password](#user_cdb_password)
+  - [user_pdb_password](#user_pdb_password)
+- [Discovered Tags](#discovered-tags)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Requirements
+
+- Minimum Ansible version: `2.9.0`
+
+
+## Default Variables
+
+### attr_name
+
+#### Default value
+
+```YAML
+attr_name: "{% if item.1.attributes is defined %}{{ item.1.attributes | default (omit)\
+  \ | map(attribute='name') | list }} {%- else %}None {%- endif %}"
+```
+
+### attr_value
+
+#### Default value
+
+```YAML
+attr_value: "{% if item.1.attributes is defined %}{{ item.1.attributes | default (omit)\
+  \ | map(attribute='value') | list }}{% else %}None{% endif %}"
+```
+
+### configure_cluster
+
+#### Default value
+
+```YAML
+configure_cluster: false
+```
+
+### db_password_cdb
+
+#### Default value
+
+```YAML
+db_password_cdb: '{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name]
+  is defined and dbpasswords[item.0.oracle_db_name][db_user] is defined%}{{ dbpasswords[item.0.oracle_db_name][db_user]
+  }} {%- else %}{{ default_dbpass }} {%- endif %}'
+```
+
+### db_password_pdb
+
+#### Default value
+
+```YAML
+db_password_pdb: '{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined
+  and dbpasswords[item.0.cdb][db_user] is defined %}{{ dbpasswords[item.0.cdb][db_user]
+  }} {%- else %}{{ default_dbpass }} {%- endif %}'
+```
+
+### db_service_name
+
+#### Default value
+
+```YAML
+db_service_name: '{% if item.0 is defined %} {%- if item.0.oracle_db_unique_name is
+  defined %}{{ item.0.oracle_db_unique_name }} {%- elif item.0.oracle_db_instance_name
+  is defined %}{{ item.0.oracle_db_instance_name }} {%- else %}{{ item.0.oracle_db_name
+  }} {%- endif %} {%- endif %}'
+```
+
+### db_user
+
+#### Default value
+
+```YAML
+db_user: system
+```
+
+### listener_port
+
+#### Default value
+
+```YAML
+listener_port: 1521
+```
+
+### listener_port_template
+
+#### Default value
+
+```YAML
+listener_port_template: '{% if item.0.listener_port is defined %}{{ item.0.listener_port
+  }}{% else %}{{ listener_port }}{% endif %}'
+```
+
+### oracle_base
+
+#### Default value
+
+```YAML
+oracle_base: /u01/app/oracle
+```
+
+### oracle_env
+
+#### Default value
+
+```YAML
+oracle_env:
+  ORACLE_HOME: '{{ oracle_home_db }}'
+  LD_LIBRARY_PATH: '{{ oracle_home_db }}/lib'
+```
+
+### user_cdb_password
+
+#### Default value
+
+```YAML
+user_cdb_password: '{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name]
+  is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{
+  dbpasswords[item.0.oracle_db_name][item.1.schema] }} {%- else %}{{ default_dbpass
+  }} {%- endif%}'
+```
+
+### user_pdb_password
+
+#### Default value
+
+```YAML
+user_pdb_password: '{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined
+  and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]
+  is defined %}{{ dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] }} {%- else
+  %}{{ default_dbpass }} {%- endif%}'
+```
+
+## Discovered Tags
+
+**_dbprofiles_**
+
+
+## Dependencies
+
+- orasw_meta
+- oradb_facts
+
+## License
+
+license (MIT)
+
+## Author
+
+Mikael Sandström

--- a/roles/oradb_manage_profiles/meta/main.yml
+++ b/roles/oradb_manage_profiles/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_profiles/tasks/main.yml
+++ b/roles/oradb_manage_profiles/tasks/main.yml
@@ -32,7 +32,7 @@
     attribute_value: "{{ attr_value | default(omit) }}"
     hostname: "{{ ansible_hostname }}"
     port: "{{ listener_port_template }}"
-    service_name: "{{ item.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
   with_subelements:

--- a/roles/oradb_manage_roles/meta/main.yml
+++ b/roles/oradb_manage_roles/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_roles/tasks/main.yml
+++ b/roles/oradb_manage_roles/tasks/main.yml
@@ -32,7 +32,7 @@
     state: "{{ item.1.state }}"
     hostname: "{{ ansible_hostname }}"
     port: "{{ listener_port_template }}"
-    service_name: "{{ item.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
     mode: "{{ db_mode }}"

--- a/roles/oradb_manage_services/meta/main.yml
+++ b/roles/oradb_manage_services/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_statspack/defaults/main.yml
+++ b/roles/oradb_manage_statspack/defaults/main.yml
@@ -12,8 +12,8 @@ snaplevel: 7
 
 db_user: system
 db_password_cdb: "{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name][db_user] is defined %}{{ dbpasswords[dbh.oracle_db_name][db_user] }}{% else %}{{ default_dbpass }}{% endif %}"
-db_password_pdb: "{%- if dbpasswords is defined and dbpasswords[pdb.0.cdb] is defined and dbpasswords[pdb.0.cdb][db_user] is defined -%}\
-                   {{ dbpasswords[pdb.0.cdb][db_user] }}\
+db_password_pdb: "{%- if dbpasswords is defined and dbpasswords[opdb.0.cdb] is defined and dbpasswords[opdb.0.cdb][db_user] is defined -%}\
+                   {{ dbpasswords[opdb.0.cdb][db_user] }}\
                   {%- else -%}\
                     {{ default_dbpass }}\
                   {%- endif -%}"

--- a/roles/oradb_manage_statspack/meta/main.yml
+++ b/roles/oradb_manage_statspack/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_statspack/tasks/main.yml
+++ b/roles/oradb_manage_statspack/tasks/main.yml
@@ -148,12 +148,12 @@
       environment:
         ORACLE_HOME: "{{ oracle_home_db }}"
         ORACLE_SID: "{{ oracle_db_instance_name }}"
-        pdb_name: "{{ pdb.0.pdb_name }}"
+        pdb_name: "{{ opdb.0.pdb_name }}"
       loop:
         - "{{ oracle_pdbs | flatten(levels=1) }}"
       loop_control:
-        loop_var: pdb
-        label: "{{ pdb.0.cdb | default('') }} {{ pdb.0.pdb_name | default('') }} {{ oracle_db_instance_name | default('') }}"
+        loop_var: opdb
+        label: "{{ opdb.0.cdb | default('') }} {{ opdb.0.pdb_name | default('') }} {{ oracle_db_instance_name | default('') }}"
       register: statspackdropcmd
       become: true
       become_user: "{{ oracle_user }}"
@@ -162,8 +162,8 @@
         - '"ORA-01920:" not in statspackdropcmd.stdout'  # ORA-01920: user name 'PERFSTAT' conflicts with another user
       when:
         - oracle_pdbs is defined
-        - pdb.0.statspack is defined
-        - pdb.0.statspack.state | default('present') == 'absent'
+        - opdb.0.statspack is defined
+        - opdb.0.statspack.state | default('present') == 'absent'
 
     - ansible.builtin.debug:  # noqa name[missing]
         msg: "{{ item.stdout_lines }}"
@@ -191,12 +191,12 @@
         default_tablespace: "{{ pdb.statspack.tablespace | default('sysaux') }}"
         purgedates: "{{ pdb.statspack.purgedays | default(35) }}"
         snaplevel: "{{ pdb.statspack.snaplevel | default(7) }}"
-        pdb_name: "{{ pdb.0.pdb_name }}"
+        pdb_name: "{{ opdb.0.pdb_name }}"
       loop:
         - "{{ oracle_pdbs | flatten(levels=1) }}"
       loop_control:
-        loop_var: pdb
-        label: "{{ pdb.0.cdb | default('') }} {{ pdb.0.pdb_name | default('') }} {{ oracle_db_instance_name | default('') }}"
+        loop_var: opdb
+        label: "{{ opdb.0.cdb | default('') }} {{ opdb.0.pdb_name | default('') }} {{ oracle_db_instance_name | default('') }}"
       register: statspackcmd
       become: true
       become_user: "{{ oracle_user }}"
@@ -205,9 +205,9 @@
         - '"ORA-01920:" not in statspackcmd.stdout'  # ORA-01920: user name 'PERFSTAT' conflicts with another user
       when:
         - oracle_pdbs is defined
-        - pdb.0.state | default('present') == 'present'
-        - pdb.0.statspack is defined
-        - pdb.0.statspack.state | default('present') == 'present'
+        - opdb.0.state | default('present') == 'present'
+        - opdb.0.statspack is defined
+        - opdb.0.statspack.state | default('present') == 'present'
 
     - ansible.builtin.debug:  # noqa name[missing]
         msg: "{{ item.stdout_lines }}"
@@ -222,7 +222,7 @@
 - name: oradb_manage_statspack | Create/Modify Purge Job (PDB)
   opitzconsulting.ansible_oracle.oracle_job:
     hostname: "{{ ansible_hostname }}"
-    service_name: "{{ pdb.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     port: "{{ pdb.listener_port | default(listener_port | default(1521)) }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
@@ -231,22 +231,22 @@
     job_type: "plsql_block"
     job_action: "PERFSTAT.STATSPACK.PURGE({{ pdb.statspack.purgedays | default(purgedays) }});"
     logging_level: "runs"
-    repeat_interval: "{{ pdb.0.statspack.purgeinterval | default(purgeinterval) }}"
+    repeat_interval: "{{ opdb.0.statspack.purgeinterval | default(purgeinterval) }}"
     state: "present"
   environment:
     ORACLE_HOME: "{{ oracle_home_db }}"
   loop:
     - "{{ oracle_pdbs | flatten(levels=1) }}"
   loop_control:
-    loop_var: pdb
-    label: "{{ pdb.0.cdb | default('') }} {{ pdb.0.pdb_name | default('') }}"
+    loop_var: opdb
+    label: "{{ opdb.0.cdb | default('') }} {{ opdb.0.pdb_name | default('') }}"
   when:
     - oracle_pdbs is defined
-    - pdb.0.cdb is defined
-    - pdb.0.pdb_name is defined
-    - pdb.0.state | default('present') == 'present'
-    - pdb.0.statspack is defined
-    - pdb.0.statspack.state | default('present') == 'present'
+    - opdb.0.cdb is defined
+    - opdb.0.pdb_name is defined
+    - opdb.0.state | default('present') == 'present'
+    - opdb.0.statspack is defined
+    - opdb.0.statspack.state | default('present') == 'present'
   become_user: "{{ oracle_user }}"
   tags:
     - spjob
@@ -255,31 +255,31 @@
 - name: oradb_manage_statspack | Create/Modify Snapshot Job (PDB)
   opitzconsulting.ansible_oracle.oracle_job:
     hostname: "{{ ansible_hostname }}"
-    service_name: "{{ pdb.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     port: "{{ pdb.listener_port | default(listener_port | default(1521)) }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
     job_name: "PERFSTAT.SNAPSHOT"
     comments: "Statspack Snapshot-Job"
     job_type: "plsql_block"
-    job_action: "PERFSTAT.STATSPACK.SNAP(i_snap_level => {{ pdb.0.statspack.snaplevel | default(snaplevel) }});"
+    job_action: "PERFSTAT.STATSPACK.SNAP(i_snap_level => {{ opdb.0.statspack.snaplevel | default(snaplevel) }});"
     logging_level: "runs"
-    repeat_interval: "{{ pdb.0.statspack.snapinterval | default(snapinterval) }}"
+    repeat_interval: "{{ opdb.0.statspack.snapinterval | default(snapinterval) }}"
     state: "present"
   environment:
     ORACLE_HOME: "{{ oracle_home_db }}"
   loop:
     - "{{ oracle_pdbs | flatten(levels=1) }}"
   loop_control:
-    loop_var: pdb
-    label: "{{ pdb.0.cdb | default('') }} {{ pdb.0.pdb_name | default('') }}"
+    loop_var: opdb
+    label: "{{ opdb.0.cdb | default('') }} {{ opdb.0.pdb_name | default('') }}"
   when:
     - oracle_pdbs is defined
-    - pdb.0.cdb is defined
-    - pdb.0.pdb_name is defined
-    - pdb.0.state | default('present') == 'present'
-    - pdb.0.statspack is defined
-    - pdb.0.statspack.state | default('present') == 'present'
+    - opdb.0.cdb is defined
+    - opdb.0.pdb_name is defined
+    - opdb.0.state | default('present') == 'present'
+    - opdb.0.statspack is defined
+    - opdb.0.statspack.state | default('present') == 'present'
   become: true
   become_user: "{{ oracle_user }}"
   tags:

--- a/roles/oradb_manage_tablespace/meta/main.yml
+++ b/roles/oradb_manage_tablespace/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_tablespace/tasks/main.yml
+++ b/roles/oradb_manage_tablespace/tasks/main.yml
@@ -32,7 +32,7 @@
   opitzconsulting.ansible_oracle.oracle_tablespace:
     hostname: "{{ ansible_hostname }}"
     port: "{{ listener_port_template }}"
-    service_name: "{{ item.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
     tablespace: "{{ item.1.name }}"
@@ -54,5 +54,5 @@
       skip_missing: true
   when: oracle_pdbs is defined and item.1 is defined and item.0.state | upper == 'PRESENT'
   loop_control:
-    label: "port: {{ listener_port_template }} service: {{ item.0.pdb_name }} tablespace: {{ item.1.name }} content: {{ item.1.content | default(omit) }} state: {{ item.1.state | default('present') }}"  # noqa yaml
+    label: "port: {{ listener_port_template }} pdb: {{ item.0.pdb_name }} tablespace: {{ item.1.name }} content: {{ item.1.content | default(omit) }} state: {{ item.1.state | default('present') }}"  # noqa yaml
   tags: tablespace

--- a/roles/oradb_manage_users/README.md
+++ b/roles/oradb_manage_users/README.md
@@ -1,0 +1,163 @@
+# oradb_manage_users
+
+Manage Users in Oracle
+
+## Table of content
+
+- [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [configure_cluster](#configure_cluster)
+  - [db_mode](#db_mode)
+  - [db_password_cdb](#db_password_cdb)
+  - [db_password_pdb](#db_password_pdb)
+  - [db_service_name](#db_service_name)
+  - [db_user](#db_user)
+  - [listener_port](#listener_port)
+  - [listener_port_template](#listener_port_template)
+  - [oracle_base](#oracle_base)
+  - [oracle_env](#oracle_env)
+  - [user_cdb_password](#user_cdb_password)
+  - [user_pdb_password](#user_pdb_password)
+- [Discovered Tags](#discovered-tags)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Requirements
+
+- Minimum Ansible version: `2.9.0`
+
+
+## Default Variables
+
+### configure_cluster
+
+#### Default value
+
+```YAML
+configure_cluster: false
+```
+
+### db_mode
+
+#### Default value
+
+```YAML
+db_mode: sysdba
+```
+
+### db_password_cdb
+
+#### Default value
+
+```YAML
+db_password_cdb: '{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name]
+  is defined and dbpasswords[item.0.oracle_db_name][db_user] is defined%}{{ dbpasswords[item.0.oracle_db_name][db_user]
+  }} {%- else %}{{ default_dbpass }} {%- endif %}'
+```
+
+### db_password_pdb
+
+#### Default value
+
+```YAML
+db_password_pdb: '{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined
+  and dbpasswords[item.0.cdb][db_user] is defined %}{{ dbpasswords[item.0.cdb][db_user]
+  }} {%- else %}{{ default_dbpass }} {%- endif %}'
+```
+
+### db_service_name
+
+#### Default value
+
+```YAML
+db_service_name: '{% if item.0 is defined %} {%- if item.0.oracle_db_unique_name is
+  defined %}{{ item.0.oracle_db_unique_name }} {%- elif item.0.oracle_db_instance_name
+  is defined %}{{ item.0.oracle_db_instance_name }} {%- else %}{{ item.0.oracle_db_name
+  }} {%- endif %} {%- endif %}'
+```
+
+### db_user
+
+#### Default value
+
+```YAML
+db_user: sys
+```
+
+### listener_port
+
+#### Default value
+
+```YAML
+listener_port: 1521
+```
+
+### listener_port_template
+
+#### Default value
+
+```YAML
+listener_port_template: '{% if item.0.listener_port is defined %}{{ item.0.listener_port
+  }}{% else %}{{ listener_port }}{% endif %}'
+```
+
+### oracle_base
+
+#### Default value
+
+```YAML
+oracle_base: /u01/app/oracle
+```
+
+### oracle_env
+
+#### Default value
+
+```YAML
+oracle_env:
+  ORACLE_HOME: '{{ oracle_home_db }}'
+  LD_LIBRARY_PATH: '{{ oracle_home_db }}/lib'
+```
+
+### user_cdb_password
+
+#### Default value
+
+```YAML
+user_cdb_password: '{% if dbpasswords is defined and dbpasswords[item.0.oracle_db_name]
+  is defined and dbpasswords[item.0.oracle_db_name][item.1.schema] is defined %}{{
+  dbpasswords[item.0.oracle_db_name][item.1.schema] }} {%- else %}{{ default_dbpass
+  }} {%- endif %}'
+```
+
+### user_pdb_password
+
+#### Default value
+
+```YAML
+user_pdb_password: '{% if dbpasswords is defined and dbpasswords[item.0.cdb] is defined
+  and dbpasswords[item.0.cdb][item.0.pdb_name] is defined and dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema]
+  is defined %}{{ dbpasswords[item.0.cdb][item.0.pdb_name][item.1.schema] }} {%- else
+  %}{{ default_dbpass }} {%- endif %}'
+```
+
+## Discovered Tags
+
+**_users_**
+
+
+## Dependencies
+
+- orasw_meta
+- oradb_facts
+
+## License
+
+license (MIT)
+
+## Author
+
+Mikael Sandström

--- a/roles/oradb_manage_users/meta/main.yml
+++ b/roles/oradb_manage_users/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
 
 dependencies:
   - role: orasw_meta
+  - role: oradb_facts

--- a/roles/oradb_manage_users/tasks/main.yml
+++ b/roles/oradb_manage_users/tasks/main.yml
@@ -41,7 +41,7 @@
   opitzconsulting.ansible_oracle.oracle_user:
     hostname: "{{ ansible_hostname }}"
     port: "{{ listener_port_template }}"
-    service_name: "{{ item.0.pdb_name }}"
+    service_name: "{{ _db_service_pdb }}"
     user: "{{ db_user }}"
     password: "{{ db_password_pdb }}"
     mode: "{{ db_mode }}"

--- a/roles/orasw_meta/defaults/main.yml
+++ b/roles/orasw_meta/defaults/main.yml
@@ -1,4 +1,19 @@
 ---
+_meta_helper_pdb: "{{ opdb.0 | default(item.0 | default({})) }}"
+
+# get db_unique_name from CDB for current pdb
+# get db_name when db_unique_name is missing
+_db_unique_name_for_pdb: >-
+  {{ (oracle_databases
+    | selectattr('oracle_db_name', 'match', _meta_helper_pdb.cdb)
+    | map(attribute='oracle_db_unique_name', default=_meta_helper_pdb.cdb))[0]
+  }}
+
+_db_service_pdb: >-
+  {%- set __db_domain_pdb = oracledb_facts[_db_unique_name_for_pdb]['parameter']['db_domain']['value'] -%}
+  {%- if __db_domain_pdb is defined and __db_domain_pdb is string and __db_domain_pdb | length > 0 -%}{{ _meta_helper_pdb.pdb_name }}.{{ __db_domain_pdb }}{%- else -%}
+  {{ _meta_helper_pdb.pdb_name }}{% endif %}
+
 install_from_nfs: false
 
 oracle_user: oracle                        # User that will own the Oracle Installations.
@@ -231,9 +246,9 @@ db_version: "{%- if dbh is defined and db_homes_config[dbh.home] is defined -%}
                  {%- endif -%}
              {%- endif -%}"
 
-oracle_db_instance_name: "{%- if pdb.0.cdb is defined -%}
+oracle_db_instance_name: "{%- if opdb.0.cdb is defined -%}
                             {%- for db in oracle_databases -%}
-                              {%- if db.oracle_db_name == pdb.0.cdb -%}
+                              {%- if db.oracle_db_name == opdb.0.cdb -%}
                               {{ db.oracle_db_instance_name | default(db.oracle_db_unique_name | default(db.oracle_db_name)) }}
                               {%- endif -%}
                             {%- endfor -%}

--- a/roles/orasw_meta/tasks/assert_oracle_databases.yml
+++ b/roles/orasw_meta/tasks/assert_oracle_databases.yml
@@ -1,6 +1,7 @@
 ---
 # @tag assert_ansible_oracle:description: Assert inventory variables from ansible-oracle
 - name: assert ansible-oracle variables
+  when: orasw_meta_assert_databases | default(true)
   tags:
     - always
     - assert_ansible_oracle
@@ -144,3 +145,9 @@
         - name: fail assert oracle_pdbs
           ansible.builtin.fail:
             msg: "See previous debug task for assertation failure"
+
+    # the orasw_meta role is defined as a dependency in many roles
+    # disable reexecution of assert now
+    - name: Set orasw_meta_assert_databases to false
+      ansible.builtin.set_fact:
+        orasw_meta_assert_databases: false


### PR DESCRIPTION
`ansible-oracle` did not support a non default value for `db_domain` in the past.

This has been changed with some limitations:

- `db_domain` could be set in nonCDB or CDB
- `db_domain` in PDB is not supported at the moment
- `oracle_listeners_config` and `listener_installed` are needed to configure SID_LIST_LISTENER for CDB
This is not mandatory when db_domain is empty.
    
The connection to nonCDB/CDB will fail, when SID_LIST_LISTENER is missing!
    
The whole commit will be replaced by a refactered one in 4.0.
