### PR TITLE
Release 3.9.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,26 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v3.9.0
+======
+
+Release Summary
+---------------
+
+This release adds support for db_domain in init.ora for nonCDB and CDB. Read (oravirt#356) for requirements and notes.
+
+Minor Changes
+-------------
+
+- Added support for db_domain in init.ora (oravirt#356)
+- oradb_facts: Backported role from dev release (oravirt#356)
+- oraswdb_install: fixed wrong creates in curl.yml (oravirt#354)
+
+Bugfixes
+--------
+
+- oraswdb_install: enable CV_ASSUME_DISTID=OL7 for Golden-Image on OL/RHEL8 (oravirt#355)
+
 v3.8.1
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -1,4 +1,5 @@
-objects: {}
+objects:
+  role: {}
 plugins:
   become: {}
   cache: {}
@@ -18,4 +19,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 3.8.1
+version: 3.9.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -338,3 +338,21 @@ releases:
     fragments:
     - oraimage.yml
     release_date: '2023-07-10'
+  3.9.0:
+    changes:
+      bugfixes:
+      - 'oraswdb_install: enable CV_ASSUME_DISTID=OL7 for Golden-Image on OL/RHEL8
+        (oravirt#355)'
+      minor_changes:
+      - Added support for db_domain in init.ora (oravirt#356)
+      - 'oradb_facts: Backported role from dev release (oravirt#356)'
+      - 'oraswdb_install: fixed wrong creates in curl.yml (oravirt#354)'
+      release_summary: This release adds support for db_domain in init.ora for nonCDB
+        and CDB. Read (oravirt#356) for requirements and notes.
+    fragments:
+    - assume_os.yml
+    - curl.yml
+    - db_domain.yml
+    - oradb_facts.yml
+    - release390.yml
+    release_date: '2023-07-16'

--- a/changelogs/fragments/assume_os.yml
+++ b/changelogs/fragments/assume_os.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_install: enable CV_ASSUME_DISTID=OL7 for Golden-Image on OL/RHEL8 (oravirt#355)"

--- a/changelogs/fragments/curl.yml
+++ b/changelogs/fragments/curl.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraswdb_install: fixed wrong creates in curl.yml (oravirt#354)"

--- a/changelogs/fragments/db_domain.yml
+++ b/changelogs/fragments/db_domain.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Added support for db_domain in init.ora (oravirt#356)"

--- a/changelogs/fragments/oradb_facts.yml
+++ b/changelogs/fragments/oradb_facts.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_facts: Backported role from dev release (oravirt#356)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 3.8.1
+version: 3.9.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v3.9.0
======

Release Summary
---------------

This release adds support for db_domain in init.ora for nonCDB and CDB. Read (oravirt#356) for requirements and notes.

Minor Changes
-------------

- Added support for db_domain in init.ora (oravirt#356)
- oradb_facts: Backported role from dev release (oravirt#356)
- oraswdb_install: fixed wrong creates in curl.yml (oravirt#354)

Bugfixes
--------

- oraswdb_install: enable CV_ASSUME_DISTID=OL7 for Golden-Image on OL/RHEL8 (oravirt#355)
