### PR TITLE
Release 3.10.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,23 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v3.10.0
+=======
+
+Minor Changes
+-------------
+
+- oracle_sqldba: refactoring code, make it usable for ansible-doc, Python3 usable only (oravirt#361)
+- oradb_manage_db: create _DGMGRL SID in listener.ora for EE only (oravirt#359)
+
+Bugfixes
+--------
+
+- Bugfix for missing Listener autostart and readonly Homes in systemd (oravirt#358)
+- oracle_sqldba: Bugfix for Python3 (oravirt#361)
+- oraswdb_install: shellchecker for manage_oracle_rdbms_procs.sh (oravirt#358)
+- pre-commit: Bugfix for known issue from ansible-oracle 3.8.0 (oravirt#383)
+
 v3.9.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -15,8 +15,13 @@ plugins:
       name: oracle_db
       namespace: ''
       version_added: 2.4.0
+    oracle_sqldba:
+      description: Execute sql (scripts) using sqlplus (BEQ) or catcon.pl
+      name: oracle_sqldba
+      namespace: ''
+      version_added: null
   netconf: {}
   shell: {}
   strategy: {}
   vars: {}
-version: 3.9.0
+version: 3.10.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -160,6 +160,23 @@ releases:
     - 282-sles_hugepages.yml
     - 282-sles_packages.yml
     release_date: '2022-10-03'
+  3.10.0:
+    changes:
+      bugfixes:
+      - Bugfix for missing Listener autostart and readonly Homes in systemd (oravirt#358)
+      - 'oracle_sqldba: Bugfix for Python3 (oravirt#361)'
+      - 'oraswdb_install: shellchecker for manage_oracle_rdbms_procs.sh (oravirt#358)'
+      - 'pre-commit: Bugfix for known issue from ansible-oracle 3.8.0 (oravirt#383)'
+      minor_changes:
+      - 'oracle_sqldba: refactoring code, make it usable for ansible-doc, Python3
+        usable only (oravirt#361)'
+      - 'oradb_manage_db: create _DGMGRL SID in listener.ora for EE only (oravirt#359)'
+    fragments:
+    - listener_dgmgrl.yml
+    - manage_oracle_rdbms_procs.yml
+    - oracle_sqldba.yml
+    - pre-commit.yml
+    release_date: '2023-07-26'
   3.2.0:
     changes:
       bugfixes:

--- a/changelogs/fragments/listener_dgmgrl.yml
+++ b/changelogs/fragments/listener_dgmgrl.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_manage_db: create _DGMGRL SID in listener.ora for EE only (oravirt#359)"

--- a/changelogs/fragments/manage_oracle_rdbms_procs.yml
+++ b/changelogs/fragments/manage_oracle_rdbms_procs.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "oraswdb_install: shellchecker for manage_oracle_rdbms_procs.sh (oravirt#358)"
-  - "Bugfix for missing Listener autostart and readonly Homes in systemd (oravirt#358)"

--- a/changelogs/fragments/oracle_sqldba.yml
+++ b/changelogs/fragments/oracle_sqldba.yml
@@ -1,6 +1,0 @@
----
-minor_changes:
-  - "oracle_sqldba: refactoring code, make it usable for ansible-doc, Python3 usable only (oravirt#361)"
-
-bugfixes:
-  - "oracle_sqldba: Bugfix for Python3 (oravirt#361)"

--- a/changelogs/fragments/pre-commit.yml
+++ b/changelogs/fragments/pre-commit.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "pre-commit: Bugfix for known issue from ansible-oracle 3.8.0 (oravirt#383)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 3.9.0
+version: 3.10.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v3.10.0
=======

Minor Changes
-------------

- oracle_sqldba: refactoring code, make it usable for ansible-doc, Python3 usable only (oravirt#361)
- oradb_manage_db: create _DGMGRL SID in listener.ora for EE only (oravirt#359)

Bugfixes
--------

- Bugfix for missing Listener autostart and readonly Homes in systemd (oravirt#358)
- oracle_sqldba: Bugfix for Python3 (oravirt#361)
- oraswdb_install: shellchecker for manage_oracle_rdbms_procs.sh (oravirt#358)
- pre-commit: Bugfix for known issue from ansible-oracle 3.8.0 (oravirt#383)
