### PR TITLE
extend oradb_facts and make password fields nolog

### DIFF
--- a/changelogs/fragments/375_nolog_modules.yml
+++ b/changelogs/fragments/375_nolog_modules.yml
@@ -1,0 +1,10 @@
+---
+security_fixes:
+  - "oracle_awr: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_facts: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_job: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_jobclass: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_jobschedule: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_jobwindow: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_ldapuser: added no_log attribute to password fields (oravirt#375)"
+  - "oracle_rsrc_consgroup: added no_log attribute to password fields (oravirt#375)"

--- a/changelogs/fragments/375_oradb_facts_attributes.yml
+++ b/changelogs/fragments/375_oradb_facts_attributes.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_facts: add missing attributes collected by oracle_facts module (oravirt#375)"

--- a/plugins/modules/oracle_awr
+++ b/plugins/modules/oracle_awr
@@ -112,7 +112,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             snapshot_interval_min = dict(default=60, type='int', aliases=['interval']),
             snapshot_retention_days = dict(default=8, type='int', aliases=['retention'])

--- a/plugins/modules/oracle_facts
+++ b/plugins/modules/oracle_facts
@@ -101,7 +101,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"])
         ),
         supports_check_mode=True

--- a/plugins/modules/oracle_job
+++ b/plugins/modules/oracle_job
@@ -366,7 +366,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             state         = dict(default="present", choices=["present", "absent"]),
             enabled       = dict(default=True, type='bool'),

--- a/plugins/modules/oracle_jobclass
+++ b/plugins/modules/oracle_jobclass
@@ -132,7 +132,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             state         = dict(default="present", choices=["present", "absent"]),
             name          = dict(required=True),

--- a/plugins/modules/oracle_jobschedule
+++ b/plugins/modules/oracle_jobschedule
@@ -127,7 +127,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             state         = dict(default="present", choices=["present", "absent"]),
             name          = dict(required=True),

--- a/plugins/modules/oracle_jobwindow
+++ b/plugins/modules/oracle_jobwindow
@@ -146,7 +146,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             state         = dict(default="enabled", choices=["absent","enabled","disabled"]),
             name          = dict(required=True, aliases=["window_name"]),

--- a/plugins/modules/oracle_ldapuser
+++ b/plugins/modules/oracle_ldapuser
@@ -220,17 +220,17 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             user_default_tablespace = dict(default='USERS'),
             user_quota_on_default_tbs_mb = dict(default=None, type='int'), # None is unlimited
             user_temp_tablespace = dict(default='TEMP'),
             user_profile  = dict(default='LDAP_USER'),
-            user_default_password = dict(default=None), # None means EXTERNAL
+            user_default_password = dict(default=None, no_log=True), # None means EXTERNAL
             user_grants   = dict(default=['create session'], type='list'),
             ldap_connect  = dict(required=True),
             ldap_binddn   = dict(required=True),
-            ldap_bindpassword = dict(required=True),
+            ldap_bindpassword = dict(required=True, no_log=True),
             ldap_user_basedn  = dict(required=True),
             ldap_user_subtree = dict(default=True, type='bool'),
             ldap_user_filter  = dict(default='(objectClass=user)'),

--- a/plugins/modules/oracle_rsrc_consgroup
+++ b/plugins/modules/oracle_rsrc_consgroup
@@ -267,7 +267,7 @@ def main():
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
             user          = dict(required=False),
-            password      = dict(required=False),
+            password      = dict(required=False, no_log=True),
             mode          = dict(default='normal', choices=["normal","sysdba"]),
             state         = dict(default="present", choices=["present", "absent"]),
             name          = dict(required=True),

--- a/roles/oradb_facts/tasks/db_facts.yml
+++ b/roles/oradb_facts/tasks/db_facts.yml
@@ -22,10 +22,14 @@
     _db_facts:
       - key: "{{ odb[0]['oracle_db_unique_name'] | default(odb[0]['oracle_db_name']) }}"
         value:
+          version: "{{ ansible_facts['version'] }}"
           database: "{{ ansible_facts['database'] }}"
           instance: "{{ ansible_facts['instance'] }}"
+          pdb: "{{ ansible_facts['pdb'] }}"
           parameter: "{{ ansible_facts['parameter'] }}"
           rac: "{{ ansible_facts['rac'] }}"
           redolog: "{{ ansible_facts['redolog'] }}"
           tablespace: "{{ ansible_facts['tablespace'] }}"
+          temp_tablespace: "{{ ansible_facts['temp_tablespace'] }}"
           userenv: "{{ ansible_facts['userenv'] }}"
+          option: "{{ ansible_facts['option'] }}"


### PR DESCRIPTION
This PR covers 2 things:
* it extends attributes mapped to `oracledb_facts` fact allowing customization which attributes will be exported by using `ordb_facts_categories` list parameter variable
* sets no_log on password fields of following modules:
  * oracle_awr
  * oracle_facts
  * oracle_job
  * oracle_jobclass
  * oracle_jobschedule
  * oracle_jobwindow
  * oracle_ldapuser
  * oracle_rsrc_consgroup