### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,38 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.2.0
+======
+
+Release Summary
+---------------
+
+This is a BETA Release of ansible-oracle. Do not use it in production environments!
+
+Major Changes
+-------------
+
+- Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x (oravirt#384)
+
+Minor Changes
+-------------
+
+- example: added oracle_listeners_config and listener_installed due to new asserts in 4.0 (oravirt#384)
+- experimental support for OracleLinux 9 (oravirt#384)
+- molecule: Switch to RU 19.21 (oravirt#384)
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x (oravirt#384)
+- oraswdb_golden_image: Fixed wrong varible names oraswdb_golen_* to oraswdb_golden_* from breaking change oravirt#383 (oravirt#384)
+- oraswgi_golden_image: Fixed wrong varible names oraswgi_golen_* to oraswgi_golden_* from breaking change oravirt#383 (oravirt#384)
+
+Bugfixes
+--------
+
+- oraswdb_manage_patches: bugfix for wrong stage directory when oracle_sw_copy=true (oravirt#384)
+
 v4.1.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configured RAC Cluster.
 
 ## Pre-requisites
 
-* Ansible >= 2.9
+* Ansible >= 2.14
 
   2.12 is recommended
 * Oracle Linux (or any RHEL-based Linux System) >= 7

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.1.0
+version: 4.2.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -590,3 +590,33 @@ releases:
     - release_410.yml
     - statspack.yml
     release_date: '2023-11-08'
+  4.2.0:
+    changes:
+      breaking_changes:
+      - Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x (oravirt#384)
+      - 'oraswdb_golden_image: Fixed wrong varible names oraswdb_golen_* to oraswdb_golden_*
+        from breaking change oravirt#383 (oravirt#384)'
+      - 'oraswgi_golden_image: Fixed wrong varible names oraswgi_golen_* to oraswgi_golden_*
+        from breaking change oravirt#383 (oravirt#384)'
+      bugfixes:
+      - 'oraswdb_manage_patches: bugfix for wrong stage directory when oracle_sw_copy=true
+        (oravirt#384)'
+      major_changes:
+      - Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x (oravirt#384)
+      minor_changes:
+      - 'example: added oracle_listeners_config and listener_installed due to new
+        asserts in 4.0 (oravirt#384)'
+      - experimental support for OracleLinux 9 (oravirt#384)
+      - 'molecule: Switch to RU 19.21 (oravirt#384)'
+      release_summary: This is a BETA Release of ansible-oracle. Do not use it in
+        production environments!
+    fragments:
+    - ansible_version.yml
+    - beginner_example.yml
+    - beta_release.yml
+    - golen_image_typo.yml
+    - molecule.yml
+    - ol9.yml
+    - oraswdb_manage_patches.yml
+    - patch_download.yml
+    release_date: '2023-11-19'

--- a/changelogs/fragments/ansible_version.yml
+++ b/changelogs/fragments/ansible_version.yml
@@ -1,6 +1,0 @@
----
-breaking_changes:
-  - "Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x ()"
-
-major_changes:
-  - "Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x ()"

--- a/changelogs/fragments/ansible_version.yml
+++ b/changelogs/fragments/ansible_version.yml
@@ -1,0 +1,6 @@
+---
+breaking_changes:
+  - "Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x ()"
+
+major_changes:
+  - "Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x ()"

--- a/changelogs/fragments/beginner_example.yml
+++ b/changelogs/fragments/beginner_example.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "example: added oracle_listeners_config and listener_installed due to new asserts in 4.0 ()"

--- a/changelogs/fragments/beginner_example.yml
+++ b/changelogs/fragments/beginner_example.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "example: added oracle_listeners_config and listener_installed due to new asserts in 4.0 ()"

--- a/changelogs/fragments/golen_image_typo.yml
+++ b/changelogs/fragments/golen_image_typo.yml
@@ -1,4 +1,0 @@
----
-breaking_changes:
-  - "oraswgi_golden_image: Fixed wrong varible names oraswgi_golen_* to oraswgi_golden_* from breaking change oravirt#383 ()"
-  - "oraswdb_golden_image: Fixed wrong varible names oraswdb_golen_* to oraswdb_golden_* from breaking change oravirt#383 ()"

--- a/changelogs/fragments/golen_image_typo.yml
+++ b/changelogs/fragments/golen_image_typo.yml
@@ -1,3 +1,4 @@
 ---
 breaking_changes:
   - "oraswgi_golden_image: Fixed wrong varible names oraswgi_golen_* to oraswgi_golden_* from breaking change oravirt#383 ()"
+  - "oraswdb_golden_image: Fixed wrong varible names oraswdb_golen_* to oraswdb_golden_* from breaking change oravirt#383 ()"

--- a/changelogs/fragments/golen_image_typo.yml
+++ b/changelogs/fragments/golen_image_typo.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - "oraswgi_golden_image: Fixed wrong varible names oraswgi_golen_* to oraswgi_golden_* from breaking change oravirt#383 ()"

--- a/changelogs/fragments/molecule.yml
+++ b/changelogs/fragments/molecule.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: Switch to RU 19.21 ()"

--- a/changelogs/fragments/molecule.yml
+++ b/changelogs/fragments/molecule.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "molecule: Switch to RU 19.21 ()"

--- a/changelogs/fragments/ol9.yml
+++ b/changelogs/fragments/ol9.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "experimental support for OracleLinux 9 ()"

--- a/changelogs/fragments/ol9.yml
+++ b/changelogs/fragments/ol9.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "experimental support for OracleLinux 9 ()"

--- a/changelogs/fragments/oraswdb_manage_patches.yml
+++ b/changelogs/fragments/oraswdb_manage_patches.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oraswdb_manage_patches: bugfix for wrong stage directory when oracle_sw_copy=true ()"

--- a/changelogs/fragments/oraswdb_manage_patches.yml
+++ b/changelogs/fragments/oraswdb_manage_patches.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_manage_patches: bugfix for wrong stage directory when oracle_sw_copy=true ()"

--- a/changelogs/fragments/patch_download.yml
+++ b/changelogs/fragments/patch_download.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "orasw_download_patches: assert oracle_sw_patches ()"

--- a/changelogs/fragments/patch_download.yml
+++ b/changelogs/fragments/patch_download.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - "orasw_download_patches: assert oracle_sw_patches ()"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/python:3.10-slim-buster
 ARG ansible_version
 ARG ansible_lint_version
 
-ENV ansible_version=5.8.0
+ENV ansible_version=8.6.1
 ENV ansible_lint_version=6.6.1
 
 ENV LC_ALL=C.UTF-8

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,12 +6,12 @@ services:
       dockerfile: Dockerfile
       args:
         ansible_lint_version: 6.6.1
-        ansible_version: 5.8.0
+        ansible_version: 7.0.0
     #     ansible_version: 2.9.26
     # container_name: ansible-oracle-2.9.26
     # image: ansible:2.9.26
-    container_name: ansible-oracle-2.12.6
-    image: ansible:2.12.6
+    container_name: ansible-oracle
+    image: willhallonline/ansible:2.15-alpine-3.16
     hostname: ansible-oracle
     mem_limit: 1000m
     privileged: true

--- a/docker/molecule/Dockerfile-ol9
+++ b/docker/molecule/Dockerfile-ol9
@@ -1,0 +1,48 @@
+FROM oraclelinux:9
+LABEL maintainer="Thorsten Bruhns"
+# Original code is copied from:
+# https://raw.githubusercontent.com/geerlingguy/docker-ubi8-ansible/master/Dockerfile
+#
+ENV container=docker
+
+ENV pip_packages "ansible"
+
+# Silence annoying subscription messages.
+RUN echo "enabled=0" >> /etc/yum/pluginconf.d/subscription-manager.conf
+
+# Install systemd -- See https://hub.docker.com/_/centos/
+RUN yum -y update; yum clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+# Install requirements.
+RUN yum makecache --timer \
+ && yum -y install initscripts \
+ && yum -y update \
+ && yum -y install \
+      sudo \
+      which \
+      hostname \
+      python3 \
+      python3-pip \
+ && yum clean all
+
+# Install Ansible via Pip.
+RUN pip3 install --upgrade pip \
+ && pip3 install $pip_packages
+
+# Disable requiretty.
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+# Install Ansible inventory file.
+RUN mkdir -p /etc/ansible
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/usr/lib/systemd/systemd"]

--- a/example/beginner/ansible/ansible.cfg
+++ b/example/beginner/ansible/ansible.cfg
@@ -1,9 +1,5 @@
 [defaults]
 
-# following entries are only needed when working with ansible < 2.9
-# roles_path    = ${PWD}/../ansible-oracle/roles/
-# library    = ${PWD}/../ansible-oracle/library/, ${PWD}/../ansible-oracle/plugins/modules
-
 host_key_checking = False
 display_skipped_hosts = false
 duplicate_dict_key = ignore

--- a/example/beginner/ansible/inventory/group_vars/dbfs/listener.yml
+++ b/example/beginner/ansible/inventory/group_vars/dbfs/listener.yml
@@ -1,0 +1,14 @@
+---
+
+oracle_listeners_config:
+  LISTENER:
+    home: &listener_home db19-si-ee
+    address:
+      - host: "{{ ansible_hostname }}"
+        protocol: TCP
+        port: 1521
+
+listener_installed:
+  - home: *listener_home
+    listener_name: LISTENER
+    state: present

--- a/example/beginner_patching/ansible/ansible.cfg
+++ b/example/beginner_patching/ansible/ansible.cfg
@@ -1,9 +1,5 @@
 [defaults]
 
-# following entries are only needed when working with ansible < 2.9
-# roles_path    = ${PWD}/../ansible-oracle/roles/
-# library    = ${PWD}/../ansible-oracle/library/, ${PWD}/../ansible-oracle/plugins/modules
-
 host_key_checking = False
 display_skipped_hosts = false
 duplicate_dict_key = ignore

--- a/extensions/molecule/dbfs/converge.yml
+++ b/extensions/molecule/dbfs/converge.yml
@@ -1,4 +1,15 @@
 ---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  any_errors_fatal: true
+  tasks:
+    # install missing cron on rhel9 container
+    - name: Install cron on RHEL/OL9
+      ansible.builtin.package:
+        name: cronie
+      when: ansible_distribution_major_version | int == 9
+
 - name: Converge os
   ansible.builtin.import_playbook: opitzconsulting.ansible_oracle.os
 

--- a/extensions/molecule/dbfs/side_effect.yml
+++ b/extensions/molecule/dbfs/side_effect.yml
@@ -4,6 +4,8 @@
   ansible.builtin.import_playbook: opitzconsulting.ansible_oracle.opatch
   vars:
     is_sw_source_local: true
+    oracle_sw_copy: true
+    oracle_sw_unpack: true
     db_homes_installed:
       - home: db19-si-ee
         state: present

--- a/extensions/molecule/default/converge.yml
+++ b/extensions/molecule/default/converge.yml
@@ -4,6 +4,12 @@
   gather_facts: true
   any_errors_fatal: true
   tasks:
+    # install missing cron on rhel9 container
+    - name: Install cron on RHEL/OL9
+      ansible.builtin.package:
+        name: cronie
+      when: ansible_distribution_major_version | int == 9
+
     - name: "Import common"
       ansible.builtin.import_role:
         name: opitzconsulting.ansible_oracle.common

--- a/extensions/molecule/default/molecule.yml
+++ b/extensions/molecule/default/molecule.yml
@@ -24,6 +24,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
+  - name: ol9
+    image: "quay.io/rendanic/docker-ol9-ansible:latest"
+    pre_build_image: true
+    # The following 4 lines are needed only for making systemd work
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
     # - name: SLES-15-3
     #   image: "registry.suse.com/bci/bci-base-ansible:15.3"
     #   pre_build_image: true

--- a/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
+++ b/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
@@ -3,7 +3,7 @@
 # is_sw_source_local: false
 # oracle_sw_source_www: http://10.0.2.15:8080
 
-oraswdb_golen_image_create: true
+oraswdb_golden_image_create: true
 golden_image_dest: /u01/golden
 
 oracle_sw_source_local: /vagrant

--- a/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
+++ b/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
@@ -11,22 +11,23 @@ oracle_sw_source_local: /vagrant
 apply_patches_db: true
 
 oracle_sw_patches:
-  - filename: p35320081_190000_Linux-x86-64.zip
-    patchid: 35320081
+  - filename: p35643107_190000_Linux-x86-64.zip
+    patchid: 35643107
     version: 19.3.0.0
-    description: Database Release Update 19.20.0.0.230718
-  - filename: p35354406_190000_Linux-x86-64.zip
-    patchid: 35354406
+    description: Database Release Update 19.21.0.0.231017
+  - filename: p35648110_190000_Linux-x86-64.zip
+    patchid: 35648110
     version: 19.3.0.0
-    description: OJVM RELEASE UPDATE 19.20.0.0.0
+    description: OJVM RELEASE UPDATE 19.21.0.0
     creates: 35354406/README.txt
-  - filename: p35512813_1920000DBRU_Generic.zip
-    patchid: 35512813
+  - filename: p35787077_1921000DBRU_Generic.zip
+    patchid: 35787077
+    unique_patchid: 25410019
     version: 19.3.0.0
-    description: DATAPUMP BUNDLE PATCH 19.20.0.0.0
-  - filename: p29213893_1920000DBRU_Generic.zip
+    description: DATAPUMP BUNDLE PATCH 19.21.0.0.0
+  - filename: p29213893_1921000DBRU_Generic.zip
     patchid: 29213893
-    unique_patchid: 25224952
+    unique_patchid: 25362849
     version: 19.3.0.0
     description: "DBMS_STATS FAILING WITH ERROR ORA-01422"
 
@@ -45,28 +46,29 @@ db_homes_config:
     oracle_home: /u01/app/oracle/product/19/db19-si-ee
     edition: EE
     opatch_minversion: 12.2.0.1.36
-    # imagename: db_home_19.15.zip
+    # imagename: db_home_19_ol9.21.zip
     opatch:
-      - {patchid: 29213893, state: absent, excludeUPI: 25224952, stop_processes: true}  # 19.3
-      - {patchid: 29213893, state: absent, excludeUPI: 24722761, stop_processes: true}  # 19.15
-      - patchid: 35320081
-        # Database Release Update 19.20.0.0.230718
-        patchversion: 19.20.0.0.230718
+      # - {patchid: 29213893, state: absent, excludeUPI: 25224952, stop_processes: true}  # 19.3
+      # - {patchid: 29213893, state: absent, excludeUPI: 24722761, stop_processes: true}  # 19.15
+      - patchid: 35643107
+        # Database Release Update 19.21.0.0.231017
+        patchversion: 19.21.0.0.231017
         stop_processes: true
         state: present
-      - patchid: 35354406
-        # Oracle JavaVM Component Release Update (OJVM RU) 19.20.0.0.230718
+      - patchid: 35648110
+        # Oracle JavaVM Component Release Update (OJVM RU) 19.21.0.0.0.0.231017
         stop_processes: true
         state: present
-      - patchid: 35512813
-        # DATAPUMP BUNDLE PATCH 19.20.0.0.0
+      - patchid: 35787077
+        # DATAPUMP BUNDLE PATCH 19.21.0.0.0
         stop_processes: false
         state: present
+        excludeUPI: 25410019
       - patchid: 29213893
         # DBMS_STATS FAILING WITH ERROR ORA-01422"
         stop_processes: true
         state: present
-        excludeUPI: 25224952
+        excludeUPI: 25362849
 
 oracle_listeners_config:
   LISTENER:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.1.0
+version: 4.2.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:
@@ -16,5 +16,5 @@ tags:
   - infrastructure
   - oracle
 dependencies:
-  community.general: '>=3.8.0,<7.0.0'
+  community.general: '>=7.0.0'
   devsec.hardening: 8.6.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.14.0'

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -10,6 +10,7 @@ sets up the host generic stuff
   - [common_packages_el6](#common_packages_el6)
   - [common_packages_el7](#common_packages_el7)
   - [common_packages_el8](#common_packages_el8)
+  - [common_packages_el9](#common_packages_el9)
   - [common_packages_sles](#common_packages_sles)
   - [configure_epel_repo](#configure_epel_repo)
   - [configure_motd](#configure_motd)
@@ -18,6 +19,7 @@ sets up the host generic stuff
   - [epel6_rpm](#epel6_rpm)
   - [epel7_rpm](#epel7_rpm)
   - [epel8_rpm](#epel8_rpm)
+  - [epel9_rpm](#epel9_rpm)
   - [install_os_packages](#install_os_packages)
   - [motd_template](#motd_template)
   - [ntp_type](#ntp_type)
@@ -202,6 +204,59 @@ common_packages_el8:
   - python3-pip
 ```
 
+### common_packages_el9
+
+#### Default value
+
+```YAML
+common_packages_el9:
+  - screen
+  - facter
+  - lsof
+  - nc
+  - rlwrap
+  - expect
+  - git
+  - lvm2
+  - xfsprogs
+  - autofs
+  - parted
+  - mlocate
+  - lvm2
+  - python3
+  - python3-pip
+  - bind-utils
+  - binutils
+  - ethtool
+  - glibc
+  - glibc-devel
+  - initscripts
+  - ksh
+  - libaio
+  - libaio-devel
+  - libgcc
+  - libnsl
+  - libstdc++
+  - libstdc++-devel
+  - make
+  - module-init-tools
+  - net-tools
+  - nfs-utils
+  - openssh-clients
+  - pam
+  - policycoreutils
+  - policycoreutils-python-utils
+  - procps
+  - psmisc
+  - smartmontools
+  - sysstat
+  - tar
+  - unzip
+  - util-linux-ng
+  - xorg-x11-utils
+  - xorg-x11-xauth
+```
+
 ### common_packages_sles
 
 List of RPMs for SuSE Linux Enterprise Server
@@ -290,6 +345,16 @@ Url for epel-release-latest-8.noarch.rpm
 
 ```YAML
 epel8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+### epel9_rpm
+
+Url for epel-release-latest-8.noarch.rpm
+
+#### Default value
+
+```YAML
+epel9_rpm: oracle-epel-release-el9
 ```
 
 ### install_os_packages

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -32,7 +32,7 @@ sets up the host generic stuff
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,5 +1,9 @@
 # Lab playbook - sets up the host specific shit
 ---
+# @var epel9_rpm:description: Url for epel-release-latest-8.noarch.rpm
+# epel9_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+epel9_rpm: oracle-epel-release-el9
+
 # @var epel8_rpm:description: Url for epel-release-latest-8.noarch.rpm
 epel8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
@@ -45,6 +49,7 @@ ntp_type: "{% if ansible_distribution_major_version | int >= 8 %}chrony\
 common_packages: "{% if ansible_distribution_major_version | int == 6 %}{{ common_packages_el6 }}\
                   {%- elif ansible_distribution_major_version | int == 7 %}{{ common_packages_el7 }}\
                   {%- elif ansible_distribution_major_version | int == 8 %}{{ common_packages_el8 }}\
+                  {%- elif ansible_distribution_major_version | int == 9 %}{{ common_packages_el9 }}\
                   {%- else %}None\
                   {%- endif %}"
 
@@ -184,6 +189,55 @@ common_packages_el8:
   - psmisc
   - python3
   - python3-pip
+
+# @var common_packages_el8:description: >
+# List of RPMs for RHEL8 or OL8
+common_packages_el9:
+  - screen
+  - facter
+  - lsof
+  - nc
+  - rlwrap
+  - expect
+  - git
+  - lvm2
+  - xfsprogs
+  - autofs
+  - parted
+  - mlocate
+  - lvm2
+  - python3
+  - python3-pip
+  - bind-utils
+  - binutils
+  - ethtool
+  - glibc
+  - glibc-devel
+  - initscripts
+  - ksh
+  - libaio
+  - libaio-devel
+  - libgcc
+  - libnsl
+  - libstdc++
+  - libstdc++-devel
+  - make
+  - module-init-tools
+  - net-tools
+  - nfs-utils
+  - openssh-clients
+  - pam
+  - policycoreutils
+  - policycoreutils-python-utils
+  - procps
+  - psmisc
+  - smartmontools
+  - sysstat
+  - tar
+  - unzip
+  - util-linux-ng
+  - xorg-x11-utils
+  - xorg-x11-xauth
 
 # @var common_packages_sles:description: >
 # List of RPMs for SuSE Linux Enterprise Server

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/common/tasks/assert.yml
+++ b/roles/common/tasks/assert.yml
@@ -1,4 +1,8 @@
 ---
+- name: OS + Distribution
+  ansible.builtin.debug:
+    msg: "{{ ansible_os_family }} {{ ansible_distribution_major_version }} ({{ ansible_distribution }})"
+
 - name: Assert Distribution
   ansible.builtin.assert:
     quiet: true

--- a/roles/common/tasks/assert.yml
+++ b/roles/common/tasks/assert.yml
@@ -11,7 +11,7 @@
       - (
           ansible_os_family == 'RedHat'
           and ansible_distribution_major_version is version('6', '>=')
-          and ansible_distribution_major_version is version('8', '<=')
+          and ansible_distribution_major_version is version('9', '<=')
         )
         or
           (ansible_os_family == 'Suse')

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -3,7 +3,8 @@
 _common_epel_rpm: >-
   {%- if ansible_distribution_major_version | int == 6 %}{{ epel6_rpm }}
   {% elif ansible_distribution_major_version | int == 7 %}{{ epel7_rpm }}
-  {% elif ansible_distribution_major_version | int == 8 %}{{ epel8_rpm }}{%- else %}None{%- endif %}
+  {% elif ansible_distribution_major_version | int == 8 %}{{ epel8_rpm }}
+  {% elif ansible_distribution_major_version | int == 9 %}{{ epel9_rpm }}{%- else %}None{%- endif %}
 
 # helper variable for internal use
 _common_ol_repo_file: >-

--- a/roles/cxoracle/README.md
+++ b/roles/cxoracle/README.md
@@ -22,7 +22,7 @@ Install cx_Oracle with pip
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/cxoracle/meta/main.yml
+++ b/roles/cxoracle/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraasm_manage_diskgroups/README.md
+++ b/roles/oraasm_manage_diskgroups/README.md
@@ -19,7 +19,7 @@ Do not set them in inventory!
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oraasm_manage_diskgroups/meta/main.yml
+++ b/roles/oraasm_manage_diskgroups/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_datapatch/README.md
+++ b/roles/oradb_datapatch/README.md
@@ -17,7 +17,7 @@ Manage datapatch for Oracle Database
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oradb_datapatch/meta/main.yml
+++ b/roles/oradb_datapatch/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_facts/README.md
+++ b/roles/oradb_facts/README.md
@@ -17,7 +17,7 @@ Gather Ansible Facts from database
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oradb_facts/meta/main.yml
+++ b/roles/oradb_facts/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_db/README.md
+++ b/roles/oradb_manage_db/README.md
@@ -20,7 +20,7 @@ Create, modify and remove Oracle Databases
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oradb_manage_db/meta/main.yml
+++ b/roles/oradb_manage_db/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_grants/README.md
+++ b/roles/oradb_manage_grants/README.md
@@ -14,7 +14,7 @@ Manage grants for users in Oracle Databases
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_grants/meta/main.yml
+++ b/roles/oradb_manage_grants/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_parameters/README.md
+++ b/roles/oradb_manage_parameters/README.md
@@ -16,7 +16,7 @@ Manage Oracle Database Parameters
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oradb_manage_parameters/meta/main.yml
+++ b/roles/oradb_manage_parameters/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_pdb/README.md
+++ b/roles/oradb_manage_pdb/README.md
@@ -14,7 +14,7 @@ Manage pluggable databases in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_pdb/meta/main.yml
+++ b/roles/oradb_manage_pdb/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_profiles/README.md
+++ b/roles/oradb_manage_profiles/README.md
@@ -14,7 +14,7 @@ Manage database profiles in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_profiles/meta/main.yml
+++ b/roles/oradb_manage_profiles/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_redo/README.md
+++ b/roles/oradb_manage_redo/README.md
@@ -14,7 +14,7 @@ Manage redolog groups in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_redo/meta/main.yml
+++ b/roles/oradb_manage_redo/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_roles/README.md
+++ b/roles/oradb_manage_roles/README.md
@@ -14,7 +14,7 @@ Manage roles in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_roles/meta/main.yml
+++ b/roles/oradb_manage_roles/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_services/README.md
+++ b/roles/oradb_manage_services/README.md
@@ -15,7 +15,7 @@ Manage services in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_services/meta/main.yml
+++ b/roles/oradb_manage_services/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_statspack/README.md
+++ b/roles/oradb_manage_statspack/README.md
@@ -21,7 +21,7 @@ Not RAC aware at the moment.
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oradb_manage_statspack/meta/main.yml
+++ b/roles/oradb_manage_statspack/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_tablespace/README.md
+++ b/roles/oradb_manage_tablespace/README.md
@@ -14,7 +14,7 @@ Manage Tablespaces in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_tablespace/meta/main.yml
+++ b/roles/oradb_manage_tablespace/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_manage_users/README.md
+++ b/roles/oradb_manage_users/README.md
@@ -14,7 +14,7 @@ Manage Users in Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oradb_manage_users/meta/main.yml
+++ b/roles/oradb_manage_users/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_rman/README.md
+++ b/roles/oradb_rman/README.md
@@ -32,7 +32,7 @@ All other role variables from `oradb_rman` are deprecated and will be removed in
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oradb_rman/meta/main.yml
+++ b/roles/oradb_rman/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oradb_tzupgrade/README.md
+++ b/roles/oradb_tzupgrade/README.md
@@ -13,7 +13,7 @@ Manage timezone upgrades for an Oracle Database
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 

--- a/roles/oradb_tzupgrade/meta/main.yml
+++ b/roles/oradb_tzupgrade/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -64,7 +64,7 @@ Role to configure the hostsystem for ansible-oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orahost/meta/main.yml
+++ b/roles/orahost/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orahost/tasks/RedHat.yml
+++ b/roles/orahost/tasks/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 # OL8/RHEL8 has all needed RPMs in orahost role!
-- name: Install packages required by Oracle on OL/RHEL version 6 and 7
+- name: Install packages required by Oracle on OL/RHEL version 6,7,8,9
   ansible.builtin.yum:
     name: "{{ oracle_packages }}"
     state: installed

--- a/roles/orahost/tasks/assert.yml
+++ b/roles/orahost/tasks/assert.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check for correct OS family & min version
   ansible.builtin.assert:
+    quiet: true
     that:
       - "ansible_os_family == '{{ os_family_supported }}'"
       - "ansible_facts['distribution_version'] is version('{{ os_min_supported_version }}', '>=')"

--- a/roles/orahost_cron/README.md
+++ b/roles/orahost_cron/README.md
@@ -16,7 +16,7 @@ Configure cronjobs for ansible-oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orahost_cron/meta/main.yml
+++ b/roles/orahost_cron/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orahost_logrotate/README.md
+++ b/roles/orahost_logrotate/README.md
@@ -22,7 +22,7 @@ Configure logrotate for ansible-oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orahost_logrotate/meta/main.yml
+++ b/roles/orahost_logrotate/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   company: Thorsten Bruhns
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -33,7 +33,7 @@ Meta role used by other roles to share variable defaults.
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orahost_meta/meta/main.yml
+++ b/roles/orahost_meta/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orahost_ssh/README.md
+++ b/roles/orahost_ssh/README.md
@@ -22,7 +22,7 @@ This role needs a complete refactoring in the future!
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orahost_ssh/meta/main.yml
+++ b/roles/orahost_ssh/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orahost_storage/README.md
+++ b/roles/orahost_storage/README.md
@@ -22,7 +22,7 @@ Role to configure the storage for oracle.
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orahost_storage/meta/main.yml
+++ b/roles/orahost_storage/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orasw_download_patches/README.md
+++ b/roles/orasw_download_patches/README.md
@@ -25,7 +25,7 @@ Download all patches from Oracle
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orasw_download_patches/meta/main.yml
+++ b/roles/orasw_download_patches/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orasw_download_patches/tasks/main.yml
+++ b/roles/orasw_download_patches/tasks/main.yml
@@ -12,6 +12,20 @@
           - oracle_sw_source_local is defined
         quiet: true
 
+    - name: Check attributes in oracle_sw_patches
+      ansible.builtin.assert:
+        quiet: true
+        that:
+          - osp.filename is defined
+          - osp.patchid is defined
+          - osp.version is defined
+          - osp.description is defined
+      with_items:
+        - "{{ oracle_sw_patches }}"
+      loop_control:
+        loop_var: osp
+        label: "{{ osp.filename | default('') }}"
+
     - name: Ensure destination directory exists
       ansible.builtin.file:
         path: "{{ oracle_patch_download_dir }}"

--- a/roles/orasw_meta/README.md
+++ b/roles/orasw_meta/README.md
@@ -70,7 +70,7 @@ There are a lot of variables who are used by `orasw_meta`
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orasw_meta/meta/main.yml
+++ b/roles/orasw_meta/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
   company: Thorsten Bruhns
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/orasw_meta/tasks/main.yml
+++ b/roles/orasw_meta/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
 # @tag assert_ansible:description: Assert version of Ansible Core
-- name: assert ansible version
+- name: Assert ansible version
   ansible.builtin.assert:
     quiet: true
     that:
-      - "ansible_version.full is version('2.9', '>=')"
+      - "ansible_version.full is version('{{ _ao_ansible_executable_min_version }}', '>=')"
+    fail_msg: "Found version {{ ansible_version.full }} expected {{ _ao_ansible_executable_min_version }} or newer"
+  vars:
+    _ao_ansible_executable_min_version: 2.14
   tags:
     - always
     - assert_ansible

--- a/roles/orasw_meta_internal/README.md
+++ b/roles/orasw_meta_internal/README.md
@@ -57,7 +57,7 @@ This will create issues and problems in `ansible-oracle` and is not supported.
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/orasw_meta_internal/meta/main.yml
+++ b/roles/orasw_meta_internal/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   company: Thorsten Bruhns
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswahf_install/README.md
+++ b/roles/oraswahf_install/README.md
@@ -13,7 +13,7 @@ Install Oracle Autonomous Health Framework
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 

--- a/roles/oraswahf_install/meta/main.yml
+++ b/roles/oraswahf_install/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswdb_golden_image/README.md
+++ b/roles/oraswdb_golden_image/README.md
@@ -17,7 +17,7 @@ Create Golden-Images from Oracle Database Homes and Oracle Grid-Infrastructure/R
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oraswdb_golden_image/README.md
+++ b/roles/oraswdb_golden_image/README.md
@@ -7,7 +7,7 @@ Create Golden-Images from Oracle Database Homes and Oracle Grid-Infrastructure/R
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
   - [golden_image_dest](#golden_image_dest)
-  - [oraswdb_golen_image_create](#oraswdb_golen_image_create)
+  - [oraswdb_golden_image_create](#oraswdb_golden_image_create)
 - [Discovered Tags](#discovered-tags)
 - [Dependencies](#dependencies)
 - [License](#license)
@@ -28,14 +28,14 @@ Set destination directory for Golden-Image extraction.
 
 Variable has no default value.
 
-### oraswdb_golen_image_create
+### oraswdb_golden_image_create
 
 Crfeate Golden-Image for Database Home.
 
 #### Default value
 
 ```YAML
-oraswdb_golen_image_create: false
+oraswdb_golden_image_create: false
 ```
 
 ## Discovered Tags

--- a/roles/oraswdb_golden_image/defaults/main.yml
+++ b/roles/oraswdb_golden_image/defaults/main.yml
@@ -5,7 +5,7 @@
 # Variable has no default value.
 # @end
 
-# @var oraswdb_golen_image_create:description: >
+# @var oraswdb_golden_image_create:description: >
 # Crfeate Golden-Image for Database Home.
 # @end
-oraswdb_golen_image_create: false
+oraswdb_golden_image_create: false

--- a/roles/oraswdb_golden_image/meta/main.yml
+++ b/roles/oraswdb_golden_image/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswdb_golden_image/tasks/main.yml
+++ b/roles/oraswdb_golden_image/tasks/main.yml
@@ -13,7 +13,7 @@
     - golden_image_db
   when:
     - db_homes_installed is defined
-    - oraswdb_golen_image_create | bool
+    - oraswdb_golden_image_create | bool
   block:
 
     - name: Assert Oracle RDBMS version for Golden-Image creation

--- a/roles/oraswdb_install/README.md
+++ b/roles/oraswdb_install/README.md
@@ -28,7 +28,7 @@ Install Oracle Database Software
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oraswdb_install/meta/main.yml
+++ b/roles/oraswdb_install/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,6 +1,18 @@
 ---
 - name: install_home_db | Install Oracle Database Server
-  ansible.builtin.shell: "{% if ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 8 %}CV_ASSUME_DISTID=OL7 {% endif %}{{ oracle_home_db }}/runInstaller -responseFile {{ oracle_rsp_stage }}/{{ _oraswdb_install_db_responsefile }} -ignorePrereq -silent -waitforcompletion {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}"
+  ansible.builtin.shell: >-
+    {% if ansible_os_family == 'RedHat' %}
+    {% if ansible_distribution_major_version | int == 8 %}
+    CV_ASSUME_DISTID=OL7{% endif %}
+    {% if ansible_distribution_major_version | int == 9 %}
+    CV_ASSUME_DISTID=OL8{% endif %}
+    {% endif %}
+    {{ oracle_home_db }}/runInstaller
+    -responseFile {{ oracle_rsp_stage }}/{{ _oraswdb_install_db_responsefile }}
+    -ignorePrereq
+    -silent
+    -waitforcompletion
+    {% if db_homes_config[dbh.home]['oracle_home_name'] is defined %}ORACLE_HOME_NAME={{ db_homes_config[dbh.home]['oracle_home_name'] }}{% endif %}
   # noqa command-instead-of-shell no-changed-when
   become: true
   become_user: "{{ oracle_user }}"

--- a/roles/oraswdb_manage_patches/README.md
+++ b/roles/oraswdb_manage_patches/README.md
@@ -16,7 +16,7 @@ Manage Patch Installation in Database ORACLE_HOMEs.
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oraswdb_manage_patches/meta/main.yml
+++ b/roles/oraswdb_manage_patches/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswdb_manage_patches/tasks/loop_opatch_apply.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_opatch_apply.yml
@@ -3,7 +3,7 @@
 # See main.yml for loop decriptions
 #
 
-- name: State data for loop_opatch_apply.yml
+- name: loop_opatch_apply | State data for loop_opatch_apply.yml
   ansible.builtin.debug:
     msg:
       - >-
@@ -17,7 +17,7 @@
           creates: {{ __sw_patches_filename_creates }}
           patch_unarchive_dir: {{ __patch_unarchive_dir }}
 
-- name: Become User to oracle
+- name: loop_opatch_apply | Become User to oracle
   become: true
   become_user: "{{ oracle_user }}"
   block:
@@ -27,14 +27,14 @@
         - dhc_opatch.state == 'present'
       block:
 
-        - name: db_opatch | Check for unarchived patch archive
+        - name: loop_opatch_apply | Check for unarchived patch archive
           ansible.builtin.stat:
             path: "{{ __patch_unarchive_dir }}/{{ __sw_patches_filename_creates }}"
           register: checkpatcharchiveres
           vars:
             __sw_patches_filename_creates: "{{ osp_loop.creates | default((dhc_opatch.patchid | string) + '/README.txt') }}"
 
-        - name: db_opatch | Copy oracle DB patch (opatch) to server (local)
+        - name: loop_opatch_apply | Copy oracle DB patch (opatch) to server (local)
           ansible.builtin.copy:
             src: "{{ oracle_sw_source_local }}/{{ osp_loop.filename }}"
             dest: "{{ oracle_stage }}/{{ osp_loop.filename }}"
@@ -44,7 +44,7 @@
             - is_sw_source_local | bool
             - not checkpatcharchiveres.stat.exists
 
-        - name: db_opatch | Copy oracle DB patch (opatch) to server (www)
+        - name: loop_opatch_apply | Copy oracle DB patch (opatch) to server (www)
           ansible.builtin.get_url:
             url: "{{ oracle_sw_source_www }}/{{ osp_loop.filename }}"
             dest: "{{ oracle_stage }}/{{ osp_loop.filename }}"
@@ -54,7 +54,7 @@
             - not is_sw_source_local | bool
             - not checkpatcharchiveres.stat.exists | bool
 
-    - name: db_opatch | Extract one-off patch files to patch base
+    - name: loop_opatch_apply | Extract one-off patch files to patch base
       when:
         - oracle_sw_copy | bool
         - oracle_sw_unpack | bool
@@ -62,20 +62,20 @@
       tags:
         - oraswdbpsuunpack1
       block:
-        - name: db_opatch | Create destination folder for unarchive
+        - name: loop_opatch_apply | Create destination folder for unarchive
           ansible.builtin.file:
             dest: "{{ __patch_unarchive_dir }}"
             mode: 0755
             state: directory
 
-        - name: db_opatch | Extract one-off patch files to patch base
+        - name: loop_opatch_apply | Extract one-off patch files to patch base
           ansible.builtin.unarchive:
             src: "{{ oracle_stage }}/{{ osp_loop.filename }}"
             dest: "{{ __patch_unarchive_dir }}"
             creates: "{{ __patch_unarchive_dir }}/{{ __sw_patches_filename_creates }}"
             copy: false
 
-        - name: db_opatch | Remove patch archive from stage
+        - name: loop_opatch_apply | Remove patch archive from stage
           ansible.builtin.file:
             path: "{{ oracle_stage }}/{{ osp_loop.filename }}"
             state: absent

--- a/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
@@ -1,5 +1,5 @@
 ---
-- name: Work on Patch {{ dhc_opatch.patchid }}
+- name: loop_Patchid | Work on Patch {{ dhc_opatch.patchid }}
   ansible.builtin.debug:
     msg:
       - >-
@@ -14,16 +14,26 @@
           opatchauto: {{ __opatchauto_patchtype }}
       - >-
           excludeUPI: {{ dhc_opatch.excludeUPI | default('') }}
-          patchsubdir: {{ __oraswdb_manage_patches_patchsubdir | default('') }}
+      - >-
+          oracle_patch_stage: {{ oracle_patch_stage }}
+          oracle_sw_copy: {{ oracle_sw_copy | bool }}
+          is_sw_source_local: {{ is_sw_source_local | bool }}
 
-- name: Work on oracle_sw_patches
+# - name: loop_Patchid | debug data
+#   ansible.builtin.debug:
+#     msg:
+#       - "{{ oracle_sw_patches | selectattr('patchid', 'equalto', dhc_opatch.patchid) }}"
+#       - "{{ dhc_opatch.patchid }}"
+
+- name: loop_Patchid | Work on oracle_sw_patches
   ansible.builtin.include_tasks: loop_opatch_apply.yml
   vars:
     __sw_patches_filename_creates: "{{ osp_loop.creates | default((dhc_opatch.patchid | string) + '/README.txt') }}"
     __patch_unarchive_dir: "{{ oracle_patch_stage }}/{{ db_version }}/{{ __patch_upisubdir }}/"
     __patch_upisubdir: >-
-      {%- if osp_loop.unique_patchid is defined -%}
-      upi_{{ osp_loop.unique_patchid -}}/{% endif -%}
+      {{ osp_loop.unique_patchid is defined
+          | ternary(osp_loop.unique_patchid,
+                    osp_loop.patchid) }}/
   with_items:
     - "{{ oracle_sw_patches | selectattr('patchid', 'equalto', dhc_opatch.patchid) }}"
   loop_control:
@@ -38,16 +48,16 @@
     - not dbhome_patches.stdout_lines | select('match', osp_loop.patchid | string) | length > 0
     - osp_loop.unique_patchid | default(0) == dhc_opatch.excludeUPI | default(0)
 
-- name: Info
+- name: loop_Patchid | Info
   ansible.builtin.debug:
     msg: Starting opatch apply. This could take some time to complete...
 
 # opatchauto needs root user for execution
-- name: Manage patch for DB
+- name: loop_Patchid | Manage patch for DB
   opitzconsulting.ansible_oracle.oracle_opatch:
     oracle_home: "{{ oracle_home_db }}"
     patch_base: >-
-      {{ oracle_patch_install }}/{{ db_version }}/{{ dhc_opatch.path | default(__patch_upisubdir + (dhc_opatch.patchid | string)) }}
+      {{ oracle_patch_install }}/{{ db_version }}/{{ dhc_opatch.path | default(__patch_localsubdir) }}
     patch_id: "{{ dhc_opatch.patchid }}"
     patch_version: "{{ dhc_opatch.patchversion | default(omit) }}"
     exclude_upi: "{{ dhc_opatch.excludeUPI | default(omit) }}"
@@ -60,6 +70,5 @@
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', oracle_user) }}"
   vars:
-    __patch_upisubdir: >-
-      {%- if dhc_opatch.excludeUPI is defined -%}
-      upi_{{ dhc_opatch.excludeUPI -}}/{% endif -%}
+    __patch_localsubdir: >-
+      {{ dhc_opatch.excludeUPI | default(dhc_opatch.patchid) }}/{{ dhc_opatch.patchid | string }}

--- a/roles/oraswgi_golden_image/README.md
+++ b/roles/oraswgi_golden_image/README.md
@@ -18,7 +18,7 @@ Create Golden-Images from Oracle Grid-Infrastructure/Restart
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oraswgi_golden_image/README.md
+++ b/roles/oraswgi_golden_image/README.md
@@ -7,8 +7,8 @@ Create Golden-Images from Oracle Grid-Infrastructure/Restart
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
   - [golden_image_dest](#golden_image_dest)
+  - [oraswgi_golden_image_create](#oraswgi_golden_image_create)
   - [oraswgi_golden_image_filename](#oraswgi_golden_image_filename)
-  - [oraswgi_golen_image_create](#oraswgi_golen_image_create)
 - [Discovered Tags](#discovered-tags)
 - [Dependencies](#dependencies)
 - [License](#license)
@@ -29,6 +29,16 @@ Set destination directory for Golden-Image extraction.
 
 Variable has no default value.
 
+### oraswgi_golden_image_create
+
+Crfeate Golden-Image for Grid-Infrastructure/Restart.
+
+#### Default value
+
+```YAML
+oraswgi_golden_image_create: false
+```
+
 ### oraswgi_golden_image_filename
 
 Filename of created Image archive.
@@ -40,16 +50,6 @@ oraswgi_golden_image_filename: >-
   {% if oracle_install_option_gi == 'CRS_CONFIG' -%}
   gi_{% else %}restart_{% endif %}{{ oracle_install_version_gi | split('.') | first
   }}.zip
-```
-
-### oraswgi_golen_image_create
-
-Crfeate Golden-Image for Grid-Infrastructure/Restart.
-
-#### Default value
-
-```YAML
-oraswgi_golen_image_create: false
 ```
 
 ## Discovered Tags

--- a/roles/oraswgi_golden_image/defaults/main.yml
+++ b/roles/oraswgi_golden_image/defaults/main.yml
@@ -5,10 +5,10 @@
 # Variable has no default value.
 # @end
 
-# @var oraswgi_golen_image_create:description: >
+# @var oraswgi_golden_image_create:description: >
 # Crfeate Golden-Image for Grid-Infrastructure/Restart.
 # @end
-oraswgi_golen_image_create: false
+oraswgi_golden_image_create: false
 
 # @var oraswgi_golden_image_filename:description: >
 # Filename of created Image archive.

--- a/roles/oraswgi_golden_image/meta/main.yml
+++ b/roles/oraswgi_golden_image/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswgi_golden_image/tasks/main.yml
+++ b/roles/oraswgi_golden_image/tasks/main.yml
@@ -11,7 +11,7 @@
   become_user: "{{ oracle_user }}"
   when:
     - oracle_home_gi is defined
-    - oraswgi_golen_image_create | bool
+    - oraswgi_golden_image_create | bool
   tags:
     - golden_image_gi
   block:

--- a/roles/oraswgi_install/README.md
+++ b/roles/oraswgi_install/README.md
@@ -38,7 +38,7 @@ This role has a dependency to `orahost_meta` and `orasw_meta` for default parame
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oraswgi_install/meta/main.yml
+++ b/roles/oraswgi_install/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   company: Mikael Sandström
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswgi_manage_patches/README.md
+++ b/roles/oraswgi_manage_patches/README.md
@@ -14,7 +14,7 @@ Install/Remove Patches from Oracle Database Homes
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Discovered Tags

--- a/roles/oraswgi_manage_patches/meta/main.yml
+++ b/roles/oraswgi_manage_patches/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL

--- a/roles/oraswgi_meta/README.md
+++ b/roles/oraswgi_meta/README.md
@@ -32,7 +32,7 @@ There are a lot of variables who are used by `orasw_meta`
 
 ## Requirements
 
-- Minimum Ansible version: `2.9.0`
+- Minimum Ansible version: `2.14.0`
 
 
 ## Default Variables

--- a/roles/oraswgi_meta/meta/main.yml
+++ b/roles/oraswgi_meta/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
   company: Thorsten Bruhns
   license: license (MIT)
 
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.14.0
 
   platforms:
     - name: EL


### PR DESCRIPTION
v4.2.0
======

Release Summary
---------------

This is a BETA Release of ansible-oracle. Do not use it in production environments!

Major Changes
-------------

- Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x (oravirt#384)

Minor Changes
-------------

- example: added oracle_listeners_config and listener_installed due to new asserts in 4.0 (oravirt#384)
- experimental support for OracleLinux 9 (oravirt#384)
- molecule: Switch to RU 19.21 (oravirt#384)

Breaking Changes / Porting Guide
--------------------------------

- Ansible 7 (2.14) is new minimal version in ansible-oracle 4.x (oravirt#384)
- oraswdb_golden_image: Fixed wrong varible names oraswdb_golen_* to oraswdb_golden_* from breaking change oravirt#383 (oravirt#384)
- oraswgi_golden_image: Fixed wrong varible names oraswgi_golen_* to oraswgi_golden_* from breaking change oravirt#383 (oravirt#384)

Bugfixes
--------

- oraswdb_manage_patches: bugfix for wrong stage directory when oracle_sw_copy=true (oravirt#384)
