### PR TITLE
Release 4.3.0 - 4th Beta Release of ansible-oracle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,28 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.3.0
+======
+
+Release Summary
+---------------
+
+This is a BETA Release of ansible-oracle. Do not use it in production environments!
+
+Minor Changes
+-------------
+
+- ansible-lint v6.22.1 (oravirt#392)
+- molecule: add tnsname configuration to shared inventory (oravirt#388)
+- oradb_facts: Skip oracledb_facts when db not reachable (oravirt#387)
+
+Bugfixes
+--------
+
+- common: install lsof for all RHEL/OL distributions (oravirt#391)
+- oradb_manage_db: Bugfix for undefined variable listener_home_config (oravirt#386)
+- orahost: Fix warning conditional statements should not include jinja2 templating (oravirt#391)
+
 v4.2.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.2.0
+version: 4.3.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -620,3 +620,25 @@ releases:
     - oraswdb_manage_patches.yml
     - patch_download.yml
     release_date: '2023-11-19'
+  4.3.0:
+    changes:
+      bugfixes:
+      - 'common: install lsof for all RHEL/OL distributions (oravirt#391)'
+      - 'oradb_manage_db: Bugfix for undefined variable listener_home_config (oravirt#386)'
+      - 'orahost: Fix warning conditional statements should not include jinja2 templating
+        (oravirt#391)'
+      minor_changes:
+      - ansible-lint v6.22.1 (oravirt#392)
+      - 'molecule: add tnsname configuration to shared inventory (oravirt#388)'
+      - 'oradb_facts: Skip oracledb_facts when db not reachable (oravirt#387)'
+      release_summary: This is a BETA Release of ansible-oracle. Do not use it in
+        production environments!
+    fragments:
+    - ansible-lint.yml
+    - assert.yml
+    - dbfacts.yml
+    - listener_home_config.yml
+    - lsof.yml
+    - molecule.yml
+    - release.yml
+    release_date: '2023-12-08'

--- a/changelogs/fragments/ansible-lint.yml
+++ b/changelogs/fragments/ansible-lint.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "ansible-lint v6.22.1 (oravirt#392)"

--- a/changelogs/fragments/assert.yml
+++ b/changelogs/fragments/assert.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost: Fix warning conditional statements should not include jinja2 templating (oravirt#391)"

--- a/changelogs/fragments/dbfacts.yml
+++ b/changelogs/fragments/dbfacts.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_facts: Skip oracledb_facts when db not reachable (oravirt#387)"

--- a/changelogs/fragments/listener_home_config.yml
+++ b/changelogs/fragments/listener_home_config.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oradb_manage_db: Bugfix for undefined variable listener_home_config (oravirt#386)"

--- a/changelogs/fragments/lsof.yml
+++ b/changelogs/fragments/lsof.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "common: install lsof for all RHEL/OL distributions (oravirt#391)"

--- a/changelogs/fragments/molecule.yml
+++ b/changelogs/fragments/molecule.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: add tnsname configuration to shared inventory (oravirt#388)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.2.0
+version: 4.3.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.3.0
======

Release Summary
---------------

This is a BETA Release of ansible-oracle. Do not use it in production environments!

Minor Changes
-------------

- ansible-lint v6.22.1 (oravirt#392)
- molecule: add tnsname configuration to shared inventory (oravirt#388)
- oradb_facts: Skip oracledb_facts when db not reachable (oravirt#387)

Bugfixes
--------

- common: install lsof for all RHEL/OL distributions (oravirt#391)
- oradb_manage_db: Bugfix for undefined variable listener_home_config (oravirt#386)
- orahost: Fix warning conditional statements should not include jinja2 templating (oravirt#391)
