### PR TITLE
oradb_manage_db: Remove visible password for sys, system and dbsnmp from dbca responsefile for 12.2+

### DIFF
--- a/changelogs/fragments/dbca-response.yml
+++ b/changelogs/fragments/dbca-response.yml
@@ -1,0 +1,3 @@
+---
+security_fixes:
+  - "oradb_manage_db: Remove visible password for sys, system and dbsnmp from dbca responsefile for 12.2+ ()"

--- a/roles/oradb_manage_db/templates/dbca-create-db.rsp.12.2.0.1.j2
+++ b/roles/oradb_manage_db/templates/dbca-create-db.rsp.12.2.0.1.j2
@@ -247,11 +247,7 @@ templateName={{dbca_templatename}}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name]is defined and dbpasswords[dbh.oracle_db_name]['sys'] is defined %}
-sysPassword={{dbpasswords[dbh.oracle_db_name]['sys']}}
-{% else %}
-sysPassword={{default_dbpass }}
-{% endif %}
+sysPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : systemPassword
@@ -261,11 +257,7 @@ sysPassword={{default_dbpass }}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['system'] is defined %}
-systemPassword={{dbpasswords[dbh.oracle_db_name]['system']}}
-{% else %}
-systemPassword={{default_dbpass }}
-{% endif %}
+systemPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : serviceUserPassword
@@ -317,11 +309,7 @@ runCVUChecks=false
 # Mandatory     : Yes, if emConfiguration is specified or
 #                 the value of runCVUChecks is TRUE
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['dbsnmp'] is defined %}
-dbsnmpPassword={{dbpasswords[dbh.oracle_db_name]['dbsnmp']}}
-{% else %}
-dbsnmpPassword={{default_dbpass }}
-{% endif %}
+dbsnmpPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : omsHost

--- a/roles/oradb_manage_db/templates/dbca-create-db.rsp.18.3.0.0.j2
+++ b/roles/oradb_manage_db/templates/dbca-create-db.rsp.18.3.0.0.j2
@@ -247,11 +247,7 @@ templateName={{dbca_templatename}}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name]is defined and dbpasswords[dbh.oracle_db_name]['sys'] is defined %}
-sysPassword={{dbpasswords[dbh.oracle_db_name]['sys']}}
-{% else %}
-sysPassword={{default_dbpass }}
-{% endif %}
+# sysPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : systemPassword
@@ -261,11 +257,7 @@ sysPassword={{default_dbpass }}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['system'] is defined %}
-systemPassword={{dbpasswords[dbh.oracle_db_name]['system']}}
-{% else %}
-systemPassword={{default_dbpass }}
-{% endif %}
+# systemPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : oracleHomeUserPassword
@@ -317,11 +309,7 @@ runCVUChecks=
 # Mandatory     : Yes, if emConfiguration is specified or
 #                 the value of runCVUChecks is TRUE
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['dbsnmp'] is defined %}
-dbsnmpPassword={{dbpasswords[dbh.oracle_db_name]['dbsnmp']}}
-{% else %}
-dbsnmpPassword={{default_dbpass }}
-{% endif %}
+dbsnmpPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : omsHost

--- a/roles/oradb_manage_db/templates/dbca-create-db.rsp.19.3.0.0.j2
+++ b/roles/oradb_manage_db/templates/dbca-create-db.rsp.19.3.0.0.j2
@@ -247,11 +247,7 @@ templateName={{dbca_templatename}}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name]is defined and dbpasswords[dbh.oracle_db_name]['sys'] is defined %}
-sysPassword={{dbpasswords[dbh.oracle_db_name]['sys']}}
-{% else %}
-sysPassword={{default_dbpass }}
-{% endif %}
+# sysPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : systemPassword
@@ -261,11 +257,7 @@ sysPassword={{default_dbpass }}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['system'] is defined %}
-systemPassword={{dbpasswords[dbh.oracle_db_name]['system']}}
-{% else %}
-systemPassword={{default_dbpass }}
-{% endif %}
+# systemPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : oracleHomeUserPassword
@@ -317,11 +309,7 @@ runCVUChecks=
 # Mandatory     : Yes, if emConfiguration is specified or
 #                 the value of runCVUChecks is TRUE
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['dbsnmp'] is defined %}
-dbsnmpPassword={{dbpasswords[dbh.oracle_db_name]['dbsnmp']}}
-{% else %}
-dbsnmpPassword={{default_dbpass }}
-{% endif %}
+dbsnmpPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : omsHost

--- a/roles/oradb_manage_db/templates/dbca-create-db.rsp.21.3.0.0.j2
+++ b/roles/oradb_manage_db/templates/dbca-create-db.rsp.21.3.0.0.j2
@@ -256,11 +256,7 @@ templateName={{dbca_templatename}}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name]is defined and dbpasswords[dbh.oracle_db_name]['sys'] is defined %}
-sysPassword={{dbpasswords[dbh.oracle_db_name]['sys']}}
-{% else %}
-sysPassword={{default_dbpass }}
-{% endif %}
+# sysPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : systemPassword
@@ -270,11 +266,7 @@ sysPassword={{default_dbpass }}
 # Default value : None
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['system'] is defined %}
-systemPassword={{dbpasswords[dbh.oracle_db_name]['system']}}
-{% else %}
-systemPassword={{default_dbpass }}
-{% endif %}
+# systemPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : oracleHomeUserPassword
@@ -326,11 +318,7 @@ runCVUChecks=
 # Mandatory     : Yes, if emConfiguration is specified or
 #                 the value of runCVUChecks is TRUE
 #-----------------------------------------------------------------------------
-{% if dbpasswords is defined and dbpasswords[dbh.oracle_db_name] is defined and dbpasswords[dbh.oracle_db_name]['dbsnmp'] is defined %}
-dbsnmpPassword={{dbpasswords[dbh.oracle_db_name]['dbsnmp']}}
-{% else %}
-dbsnmpPassword={{default_dbpass }}
-{% endif %}
+dbsnmpPassword=
 
 #-----------------------------------------------------------------------------
 # Name          : omsHost


### PR DESCRIPTION
The plaintext passwords are removed from dbca template. This is limited to RDBMS 12.2 or newer for the moment.

IMPORTANT!

Please change the passwords for existing database created before this security fix..