### PR TITLE
Release 4.4.0 - 5th Beta Release of ansible-oracle

### DIFF
--- a/changelogs/fragments/dbca-response.yml
+++ b/changelogs/fragments/dbca-response.yml
@@ -1,3 +1,3 @@
 ---
 security_fixes:
-  - "oradb_manage_db: Remove visible password for sys, system and dbsnmp from dbca responsefile for 12.2+ ()"
+  - "oradb_manage_db: Remove visible password for sys, system and dbsnmp from dbca responsefile for 12.2+ (oravirt#401)"

--- a/changelogs/fragments/galaxy.aml
+++ b/changelogs/fragments/galaxy.aml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "added missing dependencies in galay.yml and removed requirements.yml (oravirt#383)"

--- a/changelogs/fragments/galaxy.yml
+++ b/changelogs/fragments/galaxy.yml
@@ -1,0 +1,4 @@
+---
+release_summary: >-
+  This is a BETA Release of ansible-oracle.
+  Do not use it in production environments!

--- a/changelogs/fragments/sqlnet_ansible.yml
+++ b/changelogs/fragments/sqlnet_ansible.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "oradb_manage_db: allow multiline values for keys in sqlnet_ansible.ora ()"
+  - "oradb_manage_db: allow multiline values for keys in sqlnet_ansible.ora (oravirt#400)"

--- a/changelogs/fragments/tnsnames_alias.yml
+++ b/changelogs/fragments/tnsnames_alias.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "oradb_manage_db: Added support for aliasnames for Oracle Wallet ()"
+  - "oradb_manage_db: Added support for aliasnames for Oracle Wallet (oravirt#400)"

--- a/changelogs/fragments/wallet.yml
+++ b/changelogs/fragments/wallet.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "oradb_manage_wallet: New role for managing Oracle Wallets ()"
+  - "oradb_manage_wallet: New role for managing Oracle Wallets (oravirt#400)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.3.0
+version: 4.4.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.4.0
======

Release Summary
---------------

This is a BETA Release of ansible-oracle. Do not use it in production environments!

Minor Changes
-------------

- ansible-doctor: Update to 4.0.1 (oravirt#397)
- oradb_manage_db: Added support for aliasnames for Oracle Wallet (oravirt#400)
- oradb_manage_db: allow multiline values for keys in sqlnet_ansible.ora (oravirt#400)
- oradb_manage_wallet: New role for managing Oracle Wallets (oravirt#400)
- pre-commit: Update multiple hooks (oravirt#397)

Security Fixes
--------------

- dependabo: Update ansible-core in dev-tools (oravirt#398)
- dependabo: bump ansible from 6.7.0 to 8.5.0 in /tools/ansible (oravirt#395)
- dependabo: bump tj-actions/changed-files from 31 to 41 in /.github/workflows (oravirt#396)
- oradb_manage_db: Remove visible password for sys, system and dbsnmp from dbca responsefile for 12.2+ (oravirt#401)