### PR TITLE
Release 4.4.2 - 6th Beta Release of ansible-oracle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.4.2
+======
+
+Release Summary
+---------------
+
+This is a BETA Release of ansible-oracle. Do not use it in production environments!
+
+Bugfixes
+--------
+
+- oradb_manage_wallet: bugfix for broken Remove DB-Credentials (oravirt#406)
+- oradb_manage_wallet: bugfix for broken oracle_wallet_password (oravirt#406)
+- oraswdb_manage_patches: refresh opatch lsinv after opatch rollback (oravirt#405)
+
 v4.4.1
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.4.1
+version: 4.4.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -682,3 +682,17 @@ releases:
     - galaxy.yml
     - oradb_manage_wallet.yml
     release_date: '2024-01-21'
+  4.4.2:
+    changes:
+      bugfixes:
+      - 'oradb_manage_wallet: bugfix for broken Remove DB-Credentials (oravirt#406)'
+      - 'oradb_manage_wallet: bugfix for broken oracle_wallet_password (oravirt#406)'
+      - 'oraswdb_manage_patches: refresh opatch lsinv after opatch rollback (oravirt#405)'
+      release_summary: This is a BETA Release of ansible-oracle. Do not use it in
+        production environments!
+    fragments:
+    - opatch_apply.yml
+    - release.yml
+    - wallet.yml
+    - wallet2.yml
+    release_date: '2024-02-05'

--- a/changelogs/fragments/opatch_apply.yml
+++ b/changelogs/fragments/opatch_apply.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_manage_patches: refresh opatch lsinv after opatch rollback (oravirt#405)"

--- a/changelogs/fragments/wallet.yml
+++ b/changelogs/fragments/wallet.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oradb_manage_wallet: bugfix for broken Remove DB-Credentials (oravirt#406)"

--- a/changelogs/fragments/wallet2.yml
+++ b/changelogs/fragments/wallet2.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oradb_manage_wallet: bugfix for broken oracle_wallet_password (oravirt#406)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.4.1
+version: 4.4.2
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.4.2
======

Release Summary
---------------

This is a BETA Release of ansible-oracle. Do not use it in production environments!

Bugfixes
--------

- oradb_manage_wallet: bugfix for broken Remove DB-Credentials (oravirt#406)
- oradb_manage_wallet: bugfix for broken oracle_wallet_password (oravirt#406)
- oraswdb_manage_patches: refresh opatch lsinv after opatch rollback (oravirt#405)
