### PR TITLE
Small fixes for 4.5

### DIFF
--- a/changelogs/fragments/assert.yml
+++ b/changelogs/fragments/assert.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "orasw_meta: Removed warning from ansible (oravirt#409)"

--- a/changelogs/fragments/bash.yml
+++ b/changelogs/fragments/bash.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Change Shebang to /usr/bin/env bash (oravirt#409)"

--- a/changelogs/fragments/default_dbpass.yml
+++ b/changelogs/fragments/default_dbpass.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - "orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)"
+security_fixes:
+  - "orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)"

--- a/changelogs/fragments/default_dbpass_dbca.yml
+++ b/changelogs/fragments/default_dbpass_dbca.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_manage_db: Assert SYS password in inventory before dbca (oravirt#409)"

--- a/changelogs/fragments/default_gipass.yml
+++ b/changelogs/fragments/default_gipass.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - "Removed oracle_password - use default_gipass as replacement (oravirt#409)"

--- a/changelogs/fragments/default_gipass2.yml
+++ b/changelogs/fragments/default_gipass2.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - "oraswgi_install: Removed default password from default_gipass (oravirt#409)"
+security_fixes:
+  - "oraswgi_install: Removed default password from default_gipass (oravirt#409)"

--- a/changelogs/fragments/os_oracle.yml
+++ b/changelogs/fragments/os_oracle.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - "orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)"
+security_fixes:
+  - "orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)"

--- a/changelogs/fragments/role_sparation.yml
+++ b/changelogs/fragments/role_sparation.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "minor fixes for role separation in Oracle Restart (oravirt#409)"

--- a/extensions/molecule/shared_config/inventory/group_vars/all/password.yml
+++ b/extensions/molecule/shared_config/inventory/group_vars/all/password.yml
@@ -1,3 +1,10 @@
 ---
 oracle_wallet_password:
   wallet1: "aA_{{ ansible_machine_id }}"
+
+default_dbpass: Oracle_123
+# dbpasswords:
+#   DB1:
+#     sys: Oracle_123
+#     ORCLPDB:
+#       sys: Oracle_123

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -6,6 +6,17 @@
     quiet: true
   tags: always
 
+# We need to check if password is set in inventory
+# => Check for password length
+- name: Assert sys Password
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - _oradb_manage_db_dbca_sys_pass | length > 0
+    fail_msg: Please set dbpasswords and/or default_dbpass in inventory.
+  when:
+    - odb.state in ('present', 'absent')
+
 - name: manage_db | check if GI is present
   ansible.builtin.stat:
     path: /etc/oracle/olr.loc

--- a/roles/oradb_manage_db/vars/main.yml
+++ b/roles/oradb_manage_db/vars/main.yml
@@ -91,8 +91,13 @@ _oradb_manage_db_dbca_system_pass: "{% if dbpasswords[odb.oracle_db_name] is def
                     {%- else %}{{ default_dbpass }}\
                     {%- endif %}"
 
-_oradb_manage_db_default_gipass: "{{ oracle_password }}"
+# default_gipass could be '' when no GI/Restart is used
+_oradb_manage_db_default_gipass: >-
+  {{ (oracle_install_option_gi | length > 0) | ternary(default_gipass, '') }}
 
-_oradb_manage_db_sysasmpassword: "{{ oracle_password }}"
+# default_gipass could be '' when no GI/Restart is used
+_oradb_manage_db_sysasmpassword: >-
+  {{ (oracle_install_option_gi | length > 0) | ternary(default_gipass, '') }}
 
-_oradb_manage_db_asmmonitorpassword: "{{ oracle_password }}"
+_oradb_manage_db_asmmonitorpassword: >-
+  {{ (oracle_install_option_gi | length > 0) | ternary(default_gipass, '') }}

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -337,8 +337,6 @@ grid_users:
     primgroup: '{{ oracle_group }}'
     othergroups: '{{ asmadmin_group }},{{ asmdba_group }},{{ asmoper_group }},{{ dba_group
       }}'
-    passwd: 
-      $6$0xHoAXXF$K75HKb64Hcb/CEcr3YEj2LGERi/U2moJgsCK.ztGxLsKoaXc4UBiNZPL0hlxB5ng6GL.gyipfQOOXplzcdgvD0
 ```
 
 ### host_fs_layout
@@ -670,8 +668,6 @@ oracle_users:
     primgroup: '{{ oracle_group }}'
     othergroups: '{{ dba_group }},{{ asmadmin_group }},{{ asmdba_group }},{{ asmoper_group
       }},backupdba,dgdba,kmdba,{{ oper_group }}'
-    passwd: 
-      $6$0xHoAXXF$K75HKb64Hcb/CEcr3YEj2LGERi/U2moJgsCK.ztGxLsKoaXc4UBiNZPL0hlxB5ng6GL.gyipfQOOXplzcdgvD0
 ```
 
 ### os_family_supported
@@ -804,8 +800,6 @@ transparent_hugepage_disable:
 ## Open Tasks
 
 - (improvement): SSH-Setup needs a rework...
-- (security): remove fixed password from oracle OS-Users
-- (security): remove fixed password from grid OS-Users
 
 ## Dependencies
 

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -107,23 +107,19 @@ oracle_groups:
   - {group: dgdba, gid: 54325}
   - {group: kmdba, gid: 54326}
 
-# @todo security: remove fixed password from oracle OS-Users
 # @var oracle_users:description: oracle OS-User
 oracle_users:         # Passwd :Oracle123
   - username: oracle
     uid: 54321
     primgroup: "{{ oracle_group }}"
     othergroups: "{{ dba_group }},{{ asmadmin_group }},{{ asmdba_group }},{{ asmoper_group }},backupdba,dgdba,kmdba,{{ oper_group }}"
-    passwd: "$6$0xHoAXXF$K75HKb64Hcb/CEcr3YEj2LGERi/U2moJgsCK.ztGxLsKoaXc4UBiNZPL0hlxB5ng6GL.gyipfQOOXplzcdgvD0"
 
-# @todo security: remove fixed password from grid OS-Users
 # @var grid_users:description: grid OS-User
 grid_users:
   - username: grid
     uid: 54320
     primgroup: "{{ oracle_group }}"
     othergroups: "{{ asmadmin_group }},{{ asmdba_group }},{{ asmoper_group }},{{ dba_group }}"
-    passwd: "$6$0xHoAXXF$K75HKb64Hcb/CEcr3YEj2LGERi/U2moJgsCK.ztGxLsKoaXc4UBiNZPL0hlxB5ng6GL.gyipfQOOXplzcdgvD0"
 
 # @var firewall_service:description: >
 # Used firewall service in OS. Value depends on used Distribution and version.

--- a/roles/orahost_logrotate/templates/oracle_cleanup.j2
+++ b/roles/orahost_logrotate/templates/oracle_cleanup.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # {{ ansible_managed }}
 #

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -18,7 +18,6 @@ Meta role used by other roles to share variable defaults.
   - [oper_group](#oper_group)
   - [oracle_group](#oracle_group)
   - [oracle_inventory_loc](#oracle_inventory_loc)
-  - [oracle_password](#oracle_password)
   - [oracle_rsp_stage](#oracle_rsp_stage)
   - [oracle_seclimits](#oracle_seclimits)
   - [oracle_stage](#oracle_stage)
@@ -206,22 +205,6 @@ Directory for central Oracle Inventory.
 
 ```YAML
 oracle_inventory_loc: /u01/app/oraInventory
-```
-
-### oracle_password
-
-This is the default password for sys, system, ASM etc.
-
-IMPORTANT!
-
-This will be a mandatory inventory variable in the future!
-
-See: https://github.com/oravirt/ansible-oracle/issues/327
-
-#### Default value
-
-```YAML
-oracle_password: Oracle123
 ```
 
 ### oracle_rsp_stage

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -1,15 +1,4 @@
 ---
-# @var oracle_password:description: >
-# This is the default password for sys, system, ASM etc.
-#
-# IMPORTANT!
-#
-# This will be a mandatory inventory variable in the future!
-#
-# See: https://github.com/oravirt/ansible-oracle/issues/327
-# @end
-oracle_password: Oracle123
-
 # @var configure_host_disks:description: >
 # Should the specified directories be on their
 # devices -> (true), or do they live in the root-filesystem (/) -> (false).

--- a/roles/orahost_storage/templates/label-asm-disks.sh.j2
+++ b/roles/orahost_storage/templates/label-asm-disks.sh.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while read -r asmlabel device
 do

--- a/roles/orahost_storage/templates/part-device.sh.j2
+++ b/roles/orahost_storage/templates/part-device.sh.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while read -r label device
 do

--- a/roles/orahost_storage/templates/setup-udev.sh.j2
+++ b/roles/orahost_storage/templates/setup-udev.sh.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEMPFILE=/tmp/udev-temp-file
 UDEVRULE=/etc/udev/rules.d/99-asm-devices.rules
 scsi_id_bin={% if ansible_distribution_major_version == '6' %}/sbin/scsi_id{% elif ansible_distribution_major_version == '7' %}/usr/lib/udev/scsi_id{% endif %}

--- a/roles/orasw_meta/README.md
+++ b/roles/orasw_meta/README.md
@@ -172,25 +172,66 @@ dbenvdir: '{{ oracle_user_home }}/dbenv'
 
 ### dbpasswords
 
+Define the passwords for DB-Users in nonCDB, CDB and PDBs.
+
 #### Default value
 
 ```YAML
+dbpasswords: {}
+```
+
+#### Example usage
+
+```YAML
+
+nonCDB with db_name: orcl
+
+dbpasswords:
+  <db_name>:
+    <db_user>: <db_password>
+
 dbpasswords:
   orcl:
-    sys: Oracle_456
-    system: Oracle_456
-    dbsnmp: Oracle_456
-    pdbadmin: Oracle_456
+    SYS: Oracle_456
+    SYSTEM: Oracle_456
+    DBSNMP: Oracle_456
+
+CDB with `db_name: orcl` and `PDB: orclpdb`
+
+dbpasswords:
+  <CDB db_name>:
+    <CDB db_user>: <db_password>
+    <PDB name>:
+      <PDB db_user>: <db_password>
+
+dbpasswords:
+  orcl:
+    SYS: Oracle_456
+    SYSTEM: Oracle_456
+    DBSNMP: Oracle_456
+    ORCLPDB:
+      PDBADMIN: Oracle_789
 ```
 
 ### default_dbpass
 
+Set the default password for all DB-Users not defined in `dbpasswords`.
+
 #### Default value
 
 ```YAML
-default_dbpass: '{% if item is defined and item.oracle_db_passwd is defined %}{{ item.oracle_db_passwd
-  }}{%- elif dbh is defined and dbh.oracle_db_passwd is defined %}{{ dbh.oracle_db_passwd
-  }}{%- else %}Oracle123{%- endif %}'
+default_dbpass: >-
+  {% if item is defined and item.oracle_db_passwd is defined %}{{ item.oracle_db_passwd
+  -}}
+  {%- elif dbh is defined and dbh.oracle_db_passwd is defined %}{{ dbh.oracle_db_passwd
+  -}}
+  {%- endif %}
+```
+
+#### Example usage
+
+```YAML
+default_dbpass: topeS3cr§t
 ```
 
 ### deploy_ocenv
@@ -874,8 +915,6 @@ shell_ps1: "'[$LOGNAME'@'$ORACLE_SID `basename $PWD`]$'"
 - (information): variable description is missing
 - (information): variable description is missing
 - (information): db_homes_installed not used for a long time...
-- (information): variable description is missing
-- (information): variable description is missing
 - (information): variable description is missing
 - (information): variable description is missing
 - (todo): Remove variable _www_download_bin

--- a/roles/orasw_meta/defaults/main.yml
+++ b/roles/orasw_meta/defaults/main.yml
@@ -554,16 +554,48 @@ oracle_ee_options_213:
 #       - {name: temp, size: 10M, autoextend: true, next: 50M, maxsize: 4G, content: permanent, state: present, bigfile: false}
 # @end
 
-# @todo information: variable description is missing
-default_dbpass: "{% if item is defined and item.oracle_db_passwd is defined %}{{ item.oracle_db_passwd }}\
-                 {%- elif dbh is defined and dbh.oracle_db_passwd is defined %}{{ dbh.oracle_db_passwd }}\
-                 {%- else %}Oracle123\
-                 {%- endif %}"
+# @var default_dbpass:description: >
+# Set the default password for all DB-Users not defined in `dbpasswords`.
+# @end
+# @var default_dbpass:example: >
+# default_dbpass: topeS3cr§t
+# @end
+default_dbpass: >-
+  {% if item is defined and item.oracle_db_passwd is defined %}{{ item.oracle_db_passwd -}}
+  {%- elif dbh is defined and dbh.oracle_db_passwd is defined %}{{ dbh.oracle_db_passwd -}}
+  {%- endif %}
 
-# @todo information: variable description is missing
-dbpasswords:
-  orcl:
-    sys: Oracle_456
-    system: Oracle_456
-    dbsnmp: Oracle_456
-    pdbadmin: Oracle_456
+# @var dbpasswords:description: >
+# Define the passwords for DB-Users in nonCDB, CDB and PDBs.
+# @end
+# @var dbpasswords:example: >
+#
+# nonCDB with db_name: orcl
+#
+# dbpasswords:
+#   <db_name>:
+#     <db_user>: <db_password>
+#
+# dbpasswords:
+#   orcl:
+#     SYS: Oracle_456
+#     SYSTEM: Oracle_456
+#     DBSNMP: Oracle_456
+#
+# CDB with `db_name: orcl` and `PDB: orclpdb`
+#
+# dbpasswords:
+#   <CDB db_name>:
+#     <CDB db_user>: <db_password>
+#     <PDB name>:
+#       <PDB db_user>: <db_password>
+#
+# dbpasswords:
+#   orcl:
+#     SYS: Oracle_456
+#     SYSTEM: Oracle_456
+#     DBSNMP: Oracle_456
+#     ORCLPDB:
+#       PDBADMIN: Oracle_789
+# @end
+dbpasswords: {}

--- a/roles/orasw_meta/tasks/main.yml
+++ b/roles/orasw_meta/tasks/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.assert:
     quiet: true
     that:
-      - "ansible_version.full is version('{{ _ao_ansible_executable_min_version }}', '>=')"
+      - ansible_version.full is version(_ao_ansible_executable_min_version , '>=')
     fail_msg: "Found version {{ ansible_version.full }} expected {{ _ao_ansible_executable_min_version }} or newer"
   vars:
     _ao_ansible_executable_min_version: 2.14

--- a/roles/orasw_meta_internal/defaults/main.yml
+++ b/roles/orasw_meta_internal/defaults/main.yml
@@ -5,8 +5,9 @@
 # Do not set it in inventory!
 # @end
 # @var _db_password_cdb: $ "_internal_used_"
-_db_password_cdb: "{{ dbpasswords[odb.0.oracle_db_name][db_user] | \
-                      default(default_dbpass) }}"
+_db_password_cdb: >-
+  {{ dbpasswords[odb.0.oracle_db_name][db_user]
+     | default(default_dbpass | mandatory) }}
 
 # @var _db_password_pdb:description: >
 # The variable is internal used only.
@@ -14,8 +15,9 @@ _db_password_cdb: "{{ dbpasswords[odb.0.oracle_db_name][db_user] | \
 # Do not set it in inventory!
 # @end
 # @var _db_password_pdb: $ "_internal_used_"
-_db_password_pdb: "{{ dbpasswords[opdb[0]['cdb']][opdb[0]['pdb_name']][db_user] | \
-                      default(default_dbpass) }}"
+_db_password_pdb: >-
+  {{ dbpasswords[opdb[0]['cdb']][opdb[0]['pdb_name']][db_user]
+     | default(default_dbpass | mandatory) }}
 
 # @var _db_service_name:description: >
 # The variable is internal used only.

--- a/roles/oraswdb_install/templates/run-db-install.sh.j2
+++ b/roles/oraswdb_install/templates/run-db-install.sh.j2
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
+#
 # {{ ansible_managed }}
-#!/bin/bash
 
 chkifinstalled=`grep "{{ oracle_home_db }}" "{{ oracle_inventory_loc }}/ContentsXML/inventory.xml" |wc -l`
 if [[ $chkifinstalled == 1 ]]; then

--- a/roles/oraswgi_install/README.md
+++ b/roles/oraswgi_install/README.md
@@ -65,12 +65,16 @@ default_dbpass: '{% if item.0.oracle_db_passwd is defined %}{{ item.0.oracle_db_
 
 ### default_gipass
 
-Default password for Grid-Infrastructure.
+Default password for Grid-Infrastructure and ASM-Users.
+
+Important
+
+It is mandatory to set this variable in your inventory!
 
 #### Default value
 
 ```YAML
-default_gipass: "{{ oracle_password | default('') }}"
+default_gipass: ''
 ```
 
 ### endoracle_scan_port

--- a/roles/oraswgi_install/defaults/main.yml
+++ b/roles/oraswgi_install/defaults/main.yml
@@ -7,10 +7,13 @@
 gi_ignoreprereq: false
 
 # @var default_gipass:description: >
-# Default password for Grid-Infrastructure.
+# Default password for Grid-Infrastructure and ASM-Users.
 #
+# Important
+#
+# It is mandatory to set this variable in your inventory!
 # @end
-default_gipass: "{{ oracle_password | default('') }}"
+default_gipass: ""
 
 # The check for the old passwords are there for  backwards compatibility and only temporary, will be removed
 default_dbpass: "{% if item.0.oracle_db_passwd is defined %}{{ item.0.oracle_db_passwd }}{% else %}Oracle123{% endif %}"

--- a/roles/oraswgi_install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi_install/tasks/19.3.0.0.yml
@@ -36,8 +36,6 @@
         - patch_before_rootsh
         - oracle_home_gi not in checkgiinstall.stdout
         - oracle_install_version_gi is version(19, '>=')
-      vars:
-        oracle_user: "{{ grid_user }}"
 
 - name: install_home_gi | Check for file GridSetup.sh
   no_log: true

--- a/roles/oraswgi_install/tasks/assert.yml
+++ b/roles/oraswgi_install/tasks/assert.yml
@@ -3,7 +3,7 @@
   ansible.builtin.assert:
     quiet: true
     that:
-      - oracle_password | length > 0
+      - default_gipass | length > 0
       - oracle_install_version_gi is defined
       - oracle_gi_cluster_type in ('STANDARD', 'STANDALONE')
   tags: always

--- a/roles/oraswgi_install/tasks/assert.yml
+++ b/roles/oraswgi_install/tasks/assert.yml
@@ -1,5 +1,5 @@
 ---
-- name: Oraswdb_install | Assert variables
+- name: Oraswgi_install | Assert variables
   ansible.builtin.assert:
     quiet: true
     that:
@@ -9,7 +9,7 @@
   tags: always
 
 # RAC is not supported at the moment!
-- name: Oraswdb_install | Assert oracle_install_option_gi
+- name: Oraswgi_install | Assert oracle_install_option_gi
   ansible.builtin.assert:
     quiet: true
     that:
@@ -17,7 +17,20 @@
       # - oracle_install_option_gi in ('HA_CONFIG', 'CRS_CONFIG')
   tags: always
 
-- name: Oraswdb_install | Assert Grid-Infrastructure variables
+- name: Oraswgi_install | Assert role_separation
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - (role_separation and grid_user != oracle_user)
+        or
+        not role_separation
+    fail_msg: >-
+      Role separation is enabled.
+      Different values for grid_user={{ grid_user }}
+      and oracle_user={{ oracle_user }} needed.
+  tags: always
+
+- name: Oraswgi_install | Assert Grid-Infrastructure variables
   ansible.builtin.assert:
     quiet: true
     that:

--- a/roles/oraswgi_manage_patches/tasks/loop_remove_single_opatch.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_remove_single_opatch.yml
@@ -2,7 +2,7 @@
 - name: loop_remove_single_opatch | Get unique_patch_id from installed patch
   ansible.builtin.command: "{{ oracle_home_gi }}/OPatch/opatch lspatches -oh {{ oracle_home_gi }} -id {{ gip_opatch.patchid }}"
   become: true
-  become_user: "{{ oracle_user }}"
+  become_user: "{{ _grid_install_user }}"
   changed_when: false
   register: gihome_oneoff_res
 
@@ -33,4 +33,4 @@
         output: verbose
         state: "{{ gip_opatch.state }}"
       become: true
-      become_user: "{{ oracle_user }}"
+      become_user: "{{ _grid_install_user }}"

--- a/roles/oraswgi_manage_patches/tasks/loop_stage_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_stage_patch.yml
@@ -19,7 +19,7 @@
 
 - name: Loop_stage_patch | Become User to oracle
   become: true
-  become_user: "{{ oracle_user }}"
+  become_user: "{{ _grid_install_user }}"
   block:
     - name: Loop_stage_patch | Copy oracle DB patch (opatch) to server
       when:

--- a/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
@@ -2,7 +2,7 @@
 - name: post_install_patch | Get list of current installed patches
   ansible.builtin.command: "{{ oracle_home_gi }}/OPatch/opatch lspatches -oh {{ oracle_home_gi }}"
   become: true
-  become_user: "{{ grid_user }}"
+  become_user: "{{ _grid_install_user }}"
   changed_when: false
   register: gihome_patches
 
@@ -116,7 +116,7 @@
 - name: post_install_patch | Get new list of current installed patches
   ansible.builtin.command: "{{ oracle_home_gi }}/OPatch/opatch lspatches -oh {{ oracle_home_gi }}"
   become: true
-  become_user: "{{ oracle_user }}"
+  become_user: "{{ _grid_install_user }}"
   changed_when: false
   register: dbhome_patches
   when:

--- a/roles/oraswgi_manage_patches/tasks/roothas_postpatch.yml
+++ b/roles/oraswgi_manage_patches/tasks/roothas_postpatch.yml
@@ -3,7 +3,7 @@
   ansible.builtin.stat:
     path: "{{ oracle_home_gi }}/bin"
   become: true
-  become_user: "{{ grid_user }}"
+  become_user: "{{ _grid_install_user }}"
   register: oraclehomegi_stat
 
 - name: roothas_postpatch | Execute roothas.sh -postpatch

--- a/roles/oraswgi_manage_patches/tasks/roothas_prepatch.yml
+++ b/roles/oraswgi_manage_patches/tasks/roothas_prepatch.yml
@@ -3,7 +3,7 @@
   ansible.builtin.stat:
     path: "{{ oracle_home_gi }}/bin"
   become: true
-  become_user: "{{ grid_user }}"
+  become_user: "{{ _grid_install_user }}"
   register: oraclehomegi_stat
 
 - name: roothas_prepatch | Execute roothas.sh -prepatch

--- a/roles/oraswgi_meta/README.md
+++ b/roles/oraswgi_meta/README.md
@@ -80,7 +80,7 @@ ASMSNMP Password for ASM.
 #### Default value
 
 ```YAML
-asmmonitorpassword: '{{ oracle_password }}'
+asmmonitorpassword: '{{ default_gipass }}'
 ```
 
 ### gi_patches
@@ -137,7 +137,7 @@ SYSASM Password for ASM.
 #### Default value
 
 ```YAML
-sysasmpassword: '{{ oracle_password }}'
+sysasmpassword: '{{ default_gipass }}'
 ```
 
 ## Discovered Tags

--- a/roles/oraswgi_meta/defaults/main.yml
+++ b/roles/oraswgi_meta/defaults/main.yml
@@ -17,12 +17,12 @@ _oraswgi_meta_configure_cluster: false
 # @var sysasmpassword:description: >
 # SYSASM Password for ASM.
 # @end
-sysasmpassword: "{{ oracle_password }}"
+sysasmpassword: "{{ default_gipass }}"
 
 # @var asmmonitorpassword:description: >
 # ASMSNMP Password for ASM.
 # @end
-asmmonitorpassword: "{{ oracle_password }}"
+asmmonitorpassword: "{{ default_gipass }}"
 
 # @var patch_before_rootsh:description: >
 # Patch Grid-Infrastructure during gridSetup.sh

--- a/roles/oraswgi_meta/tasks/assert.yml
+++ b/roles/oraswgi_meta/tasks/assert.yml
@@ -26,7 +26,10 @@
 
     - name: Type of Installation
       ansible.builtin.debug:
-        msg: "oracle_install_option_gi: {{ oracle_install_option_gi }}"
+        msg:
+          - "oracle_install_option_gi: {{ oracle_install_option_gi }}"
+          - "role_separation:          {{ role_separation }}"
+          - "_grid_install_user:       {{ _grid_install_user }} (internal variable. Use grid_user + role_separation in inventory.)"
 
     - name: Assert Variables for Restart/Grid Infrastructure Setup
       ansible.builtin.assert:


### PR DESCRIPTION
minor_changes:
  - Change Shebang to /usr/bin/env bash (oravirt#409)
  - oradb_manage_db: Assert SYS password in inventory before dbca (oravirt#409)
  - minor fixes for role separation in Oracle Restart (oravirt#409)

bugfixes:
  - orasw_meta: Removed warning from ansible (oravirt#409)
  
breaking_changes:
  - orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)
  - orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)
  - Removed oracle_password - use default_gipass as replacement (oravirt#409)
  - oraswgi_install: Removed default password from default_gipass (oravirt#409)

security_fixes:
  - orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)
  - orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)
  - oraswgi_install: Removed default password from default_gipass (oravirt#409)