### PR TITLE
orahost: fix for broken configure_hugepages=false

### DIFF
--- a/changelogs/fragments/hugepages.yml
+++ b/changelogs/fragments/hugepages.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "orahost: fix for broken configure_hugepages=false (oravirt#412)"

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -767,6 +767,10 @@ transparent_hugepage_disable:
 
 **_hostfs_**
 
+**_hugepages_**
+
+**_molecule-idempotence-notest_**
+
 **_nozeroconf_**
 
 **_orahost_assert_**
@@ -789,11 +793,7 @@ transparent_hugepage_disable:
 
 **_sudoadd_**
 
-**_sysctl,hugepages_**
-
-**_sysctl,hugepages,molecule-idempotence-notest_**
-
-**_sysctl,molecule-idempotence-notest_**
+**_sysctl_**
 
 **_tphnuma_**
 

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -365,47 +365,50 @@
     reload: true
     ignoreerrors: true
   with_items: "{{ oracle_sysctl }}"
-  tags: sysctl,molecule-idempotence-notest
+  tags:
+    - sysctl
+    - molecule-idempotence-notest
 
 - name: Oracle hugepages
-  ansible.posix.sysctl:
-    name: "{{ item.name }}"
-    value: "{{ item.value }}"
-    state: present
-    reload: true
-    ignoreerrors: true
-  with_items: "{{ oracle_hugepages }}"
-  register: systclcmd
-  tags: sysctl,hugepages,molecule-idempotence-notest
-
-# There is no safe way to allocate Hugepages in a running system.
-# => A reboot should be done after changing the configuration
-# => we won't reboot during installation
-# Work Arroud:
-# => Flush File Cache
-# => retry a sysctl -p
-- name: Flush Buffer Cache  # noqa no-handler
   when:
-    - systclcmd is defined
-    - systclcmd.changed
-  tags: sysctl,hugepages
+    - configure_hugepages | bool
+  tags:
+    - sysctl
+    - hugepages
+    - molecule-idempotence-notest
   block:
-    - name: Flush Buffer Cache when hugepages have been changed
-      ansible.builtin.command: echo 2 > /proc/sys/vm/drop_caches
-      # noqa no-changed-when
-      tags: sysctl,hugepages,molecule-idempotence-notest
-
-    - name: Try sysctl again
+    - name: Oracle hugepages
       ansible.posix.sysctl:
         name: "{{ item.name }}"
         value: "{{ item.value }}"
         state: present
         reload: true
+        ignoreerrors: true
       with_items: "{{ oracle_hugepages }}"
-      tags:
-        - sysctl
-        - hugepages
-        - molecule-idempotence-notest
+      register: systclcmd
+
+    # There is no safe way to allocate Hugepages in a running system.
+    # => A reboot should be done after changing the configuration
+    # => we won't reboot during installation
+    # Work Arroud:
+    # => Flush File Cache
+    # => retry a sysctl -p
+    - name: Flush Buffer Cache  # noqa no-handler
+      when:
+        - systclcmd is defined
+        - systclcmd.changed
+      block:
+        - name: Flush Buffer Cache when hugepages have been changed
+          ansible.builtin.command: echo 2 > /proc/sys/vm/drop_caches
+          # noqa no-changed-when
+
+        - name: Try sysctl again
+          ansible.posix.sysctl:
+            name: "{{ item.name }}"
+            value: "{{ item.value }}"
+            state: present
+            reload: true
+          with_items: "{{ oracle_hugepages }}"
 
 - name: Oracle-recommended PAM config
   ansible.builtin.lineinfile:


### PR DESCRIPTION
The configuration of hugepages should be disabled by configure_hugepages=false. That was broken, because the nr_hugepages has been set to 0 instead ignore the configuration of sysctl for hugepages.

fixes #410 