### PR TITLE
Release 4.5.0 - 7th Beta Release of ansible-oracle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,39 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.5.0
+======
+
+Minor Changes
+-------------
+
+- Change Shebang to /usr/bin/env bash (oravirt#409)
+- Documentation updates (oravirt#389)
+- build(deps): bump ansible-core from 2.15.8 to 2.15.9 in /tools/dev (oravirt#408)
+- minor fixes for role separation in Oracle Restart (oravirt#409)
+- oradb_manage_db: Assert SYS password in inventory before dbca (oravirt#409)
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Removed oracle_password - use default_gipass as replacement (oravirt#409)
+- orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)
+- orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)
+- oraswgi_install: Removed default password from default_gipass (oravirt#409)
+
+Security Fixes
+--------------
+
+- orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)
+- orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)
+- oraswgi_install: Removed default password from default_gipass (oravirt#409)
+
+Bugfixes
+--------
+
+- orahost: fix for broken configure_hugepages=false (oravirt#412)
+- orasw_meta: Removed warning from ansible (oravirt#409)
+
 v4.4.2
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -6,7 +6,6 @@ plugins:
   callback: {}
   cliconf: {}
   connection: {}
-  filter: {}
   httpapi: {}
   inventory: {}
   lookup: {}
@@ -157,6 +156,5 @@ plugins:
   netconf: {}
   shell: {}
   strategy: {}
-  test: {}
   vars: {}
-version: 4.4.2
+version: 4.5.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -696,3 +696,38 @@ releases:
     - wallet.yml
     - wallet2.yml
     release_date: '2024-02-05'
+  4.5.0:
+    changes:
+      breaking_changes:
+      - Removed oracle_password - use default_gipass as replacement (oravirt#409)
+      - 'orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)'
+      - 'orasw_meta: Removed default passwords from default_dbpass and dbpasswords
+        (oravirt#409)'
+      - 'oraswgi_install: Removed default password from default_gipass (oravirt#409)'
+      bugfixes:
+      - 'orahost: fix for broken configure_hugepages=false (oravirt#412)'
+      - 'orasw_meta: Removed warning from ansible (oravirt#409)'
+      minor_changes:
+      - Change Shebang to /usr/bin/env bash (oravirt#409)
+      - Documentation updates (oravirt#389)
+      - 'build(deps): bump ansible-core from 2.15.8 to 2.15.9 in /tools/dev (oravirt#408)'
+      - minor fixes for role separation in Oracle Restart (oravirt#409)
+      - 'oradb_manage_db: Assert SYS password in inventory before dbca (oravirt#409)'
+      security_fixes:
+      - 'orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)'
+      - 'orasw_meta: Removed default passwords from default_dbpass and dbpasswords
+        (oravirt#409)'
+      - 'oraswgi_install: Removed default password from default_gipass (oravirt#409)'
+    fragments:
+    - assert.yml
+    - bash.yml
+    - default_dbpass.yml
+    - default_dbpass_dbca.yml
+    - default_gipass.yml
+    - default_gipass2.yml
+    - dependabot_408.yml
+    - docs.yml
+    - hugepages.yml
+    - os_oracle.yml
+    - role_sparation.yml
+    release_date: '2024-02-24'

--- a/changelogs/fragments/assert.yml
+++ b/changelogs/fragments/assert.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orasw_meta: Removed warning from ansible (oravirt#409)"

--- a/changelogs/fragments/bash.yml
+++ b/changelogs/fragments/bash.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Change Shebang to /usr/bin/env bash (oravirt#409)"

--- a/changelogs/fragments/default_dbpass.yml
+++ b/changelogs/fragments/default_dbpass.yml
@@ -1,5 +1,0 @@
----
-breaking_changes:
-  - "orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)"
-security_fixes:
-  - "orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)"

--- a/changelogs/fragments/default_dbpass_dbca.yml
+++ b/changelogs/fragments/default_dbpass_dbca.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_manage_db: Assert SYS password in inventory before dbca (oravirt#409)"

--- a/changelogs/fragments/default_gipass.yml
+++ b/changelogs/fragments/default_gipass.yml
@@ -1,3 +1,0 @@
----
-breaking_changes:
-  - "Removed oracle_password - use default_gipass as replacement (oravirt#409)"

--- a/changelogs/fragments/default_gipass2.yml
+++ b/changelogs/fragments/default_gipass2.yml
@@ -1,5 +1,0 @@
----
-breaking_changes:
-  - "oraswgi_install: Removed default password from default_gipass (oravirt#409)"
-security_fixes:
-  - "oraswgi_install: Removed default password from default_gipass (oravirt#409)"

--- a/changelogs/fragments/dependabot_408.yml
+++ b/changelogs/fragments/dependabot_408.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "build(deps): bump ansible-core from 2.15.8 to 2.15.9 in /tools/dev (oravirt#408)"

--- a/changelogs/fragments/docs.yml
+++ b/changelogs/fragments/docs.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Documentation updates (oravirt#389)"

--- a/changelogs/fragments/hugepages.yml
+++ b/changelogs/fragments/hugepages.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost: fix for broken configure_hugepages=false (oravirt#412)"

--- a/changelogs/fragments/os_oracle.yml
+++ b/changelogs/fragments/os_oracle.yml
@@ -1,5 +1,0 @@
----
-breaking_changes:
-  - "orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)"
-security_fixes:
-  - "orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)"

--- a/changelogs/fragments/role_sparation.yml
+++ b/changelogs/fragments/role_sparation.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "minor fixes for role separation in Oracle Restart (oravirt#409)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.4.2
+version: 4.5.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.5.0
======

Minor Changes
-------------

- Change Shebang to /usr/bin/env bash (oravirt#409)
- Documentation updates (oravirt#389)
- build(deps): bump ansible-core from 2.15.8 to 2.15.9 in /tools/dev (oravirt#408)
- minor fixes for role separation in Oracle Restart (oravirt#409)
- oradb_manage_db: Assert SYS password in inventory before dbca (oravirt#409)

Breaking Changes / Porting Guide
--------------------------------

- Removed oracle_password - use default_gipass as replacement (oravirt#409)
- orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)
- orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)
- oraswgi_install: Removed default password from default_gipass (oravirt#409)

Security Fixes
--------------

- orahost: Removed fixed password for oracle and grid from defaults (oravirt#409)
- orasw_meta: Removed default passwords from default_dbpass and dbpasswords (oravirt#409)
- oraswgi_install: Removed default password from default_gipass (oravirt#409)

Bugfixes
--------

- orahost: fix for broken configure_hugepages=false (oravirt#412)
- orasw_meta: Removed warning from ansible (oravirt#409)
