### PR TITLE
orasw_meta: added assert for oracle_db_mem_totalmb in oracle_databases

### DIFF
--- a/changelogs/fragments/oracle_db_mem_totalmb.yml
+++ b/changelogs/fragments/oracle_db_mem_totalmb.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - "orasw_meta: added assert for oracle_db_mem_totalmb in oracle_databases (oravirt#414)"

--- a/example/beginner/ansible/inventory/group_vars/dbfs/database_DB1.yml
+++ b/example/beginner/ansible/inventory/group_vars/dbfs/database_DB1.yml
@@ -11,7 +11,6 @@ oracle_database_db1:
   # Example custom DBCA-Template, usable for CDB and nonCDB
   # dbca_templatename: 19c_custom_dbca.dbt
   storage_type: FS                                     # Database storage to be used. ASM or FS.
-  oracle_db_mem_totalmb: 1024                          # Amount of RAM to be used for SGA
   oracle_database_type: MULTIPURPOSE                   # MULTIPURPOSE|DATA_WAREHOUSING|OLTP
   redolog_size: 75M
   redolog_groups: 3
@@ -50,8 +49,8 @@ oracle_database_db1:
     #  - {name: use_large_pages ,value: 'ONLY', scope: spfile, state: present}
     - {name: log_archive_dest_1, value: 'location=USE_DB_RECOVERY_FILE_DEST', scope: both, state: present}
     - {name: log_buffer, value: '64M', scope: spfile, state: present}
-    - {name: pga_aggregate_target, value: '200M', scope: both, state: present, dbca: false}
-    - {name: sga_target, value: '1800M', scope: spfile, state: present, dbca: false}
+    - {name: pga_aggregate_target, value: '200M', scope: both, state: present}
+    - {name: sga_target, value: '1800M', scope: spfile, state: present}
     - {name: recyclebin, value: 'off', scope: spfile, state: present}
     - {name: standby_file_management, value: 'AUTO', scope: both, state: present}
     - {name: streams_pool_size, value: '152M', scope: spfile, state: present}

--- a/example/beginner_patching/ansible/inventory/host_vars/beginner-dbfs-patching-151-192-168-56-162.nip.io/databases.yml
+++ b/example/beginner_patching/ansible/inventory/host_vars/beginner-dbfs-patching-151-192-168-56-162.nip.io/databases.yml
@@ -34,7 +34,6 @@ oracle_databases:
     # Example custom DBCA-Template, usable for CDB and nonCDB
     # dbca_templatename: 19c_custom_dbca.dbt
     storage_type: FS
-    oracle_db_mem_totalmb: 2048  # this value is only valid during dbca - init.ora-parameters are used afterwards.
     oracle_database_type: MULTIPURPOSE
     redolog_size: 50M
     redolog_groups: 3
@@ -72,8 +71,8 @@ oracle_databases:
       - {name: log_archive_dest_1, value: 'location=USE_DB_RECOVERY_FILE_DEST', scope: both, state: present}
       - {name: log_buffer, value: '64M', scope: spfile, state: present}
       # - {name: pga_aggregate_target, value: '1024M', scope: both, state: present, dbca: false}
-      - {name: pga_aggregate_target, value: '1G', scope: both, state: present, dbca: false}
-      - {name: sga_target, value: '3096M', scope: spfile, state: present, dbca: false}
+      - {name: pga_aggregate_target, value: '1G', scope: both, state: present}
+      - {name: sga_target, value: '3096M', scope: spfile, state: present}
       - {name: recyclebin, value: 'off', scope: spfile, state: present}
       - {name: streams_pool_size, value: '152M', scope: spfile, state: present}
       # "_cursor_obsolete_threshold" for 12.2+

--- a/extensions/molecule/dbfs/side_effect.yml
+++ b/extensions/molecule/dbfs/side_effect.yml
@@ -57,3 +57,4 @@
             state: present
         init_parameters:
           - {name: recyclebin, value: 'off', scope: spfile, state: present}
+          - {name: sga_target, value: '1808M', scope: spfile, state: present}

--- a/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
+++ b/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
@@ -89,7 +89,6 @@ oracle_databases:
     oracle_db_type: SI
     is_container: true
     storage_type: FS
-    oracle_db_mem_totalmb: 1024
     oracle_database_type: MULTIPURPOSE
     redolog_size: 50M
     redolog_groups: 3
@@ -121,7 +120,7 @@ oracle_databases:
       - {name: db_create_online_log_dest_1, value: '/u01/app/oracle/oradata', scope: both, state: present}
       - {name: recyclebin, value: 'off', scope: spfile, state: present}
       - {name: pga_aggregate_target, value: '128M', scope: both, state: present}
-      - {name: sga_target, value: '1808M', scope: spfile, state: present, dbca: false}
+      - {name: sga_target, value: '1808M', scope: spfile, state: present}
 
 oracle_pdbs:
   - cdb: DB1

--- a/roles/orasw_meta/README.md
+++ b/roles/orasw_meta/README.md
@@ -58,6 +58,7 @@ There are a lot of variables who are used by `orasw_meta`
   - [oracle_sw_patches](#oracle_sw_patches)
   - [oracle_sw_source_local](#oracle_sw_source_local)
   - [oracle_sw_source_www](#oracle_sw_source_www)
+  - [orasw_meta_assert_oracle_databases](#orasw_meta_assert_oracle_databases)
   - [shell_aliases](#shell_aliases)
   - [shell_ps1](#shell_ps1)
 - [Discovered Tags](#discovered-tags)
@@ -446,7 +447,6 @@ oracle_databases:
     oracle_db_type: SI
     is_container: true
     storage_type: FS
-    oracle_db_mem_totalmb: 1024
     oracle_database_type: MULTIPURPOSE
     redolog_size: 100M
     redolog_groups: 3
@@ -846,6 +846,18 @@ server during software installation and patching.
 
 ```YAML
 oracle_sw_source_www: http://www/orasw
+```
+
+### orasw_meta_assert_oracle_databases
+
+Switch for enable/disable assert on `oracle_databases`.
+
+Please change the state only when really needed!
+
+#### Default value
+
+```YAML
+orasw_meta_assert_oracle_databases: true
 ```
 
 ### shell_aliases

--- a/roles/orasw_meta/defaults/main.yml
+++ b/roles/orasw_meta/defaults/main.yml
@@ -472,7 +472,6 @@ oracle_ee_options_213:
 #     oracle_db_type: SI
 #     is_container: true
 #     storage_type: FS
-#     oracle_db_mem_totalmb: 1024
 #     oracle_database_type: MULTIPURPOSE
 #     redolog_size: 100M
 #     redolog_groups: 3
@@ -599,3 +598,10 @@ default_dbpass: >-
 #       PDBADMIN: Oracle_789
 # @end
 dbpasswords: {}
+
+# @var orasw_meta_assert_oracle_databases:description: >
+# Switch for enable/disable assert on `oracle_databases`.
+#
+# Please change the state only when really needed!
+# @end
+orasw_meta_assert_oracle_databases: true

--- a/roles/orasw_meta/tasks/assert_oracle_databases.yml
+++ b/roles/orasw_meta/tasks/assert_oracle_databases.yml
@@ -70,7 +70,16 @@
       when:
         - db_homes_installed is defined
 
+    - name: Check switch for  orasw_meta_assert_oracle_databases
+      ansible.builtin.debug:
+        msg: >-
+          WARNING!!! Assert for oracle_databases has been disabled!
+      when:
+        - not orasw_meta_assert_oracle_databases | bool
+
     - name: assert oracle_databases
+      when:
+        - orasw_meta_assert_oracle_databases | bool
       block:
         - name: assert oracle_databases
           ansible.builtin.assert:
@@ -95,6 +104,15 @@
               - ass_odb.users | default([]) | type_debug == 'list'
               - ass_odb.oracle_db_type | default('SI2') in ('SI', 'RAC', 'RACONENODE')
               - ass_odb.storage_type | default('FS') in ('FS', 'ASM')
+              - (ass_odb.oracle_db_mem_totalmb is defined
+                  and ass_odb.init_parameters | default([])
+                      | selectattr ('name', 'match', 'sga_target') | list | length == 0
+                )
+                or
+                (ass_odb.oracle_db_mem_totalmb is not defined
+                  and ass_odb.init_parameters | default([]) | list
+                       | selectattr ('name', 'match', 'sga_target') | list | length > 0
+                )
           with_items:
             - "{{ oracle_databases }}"
           loop_control:


### PR DESCRIPTION
The attribute oracle_db_mem_totalmb should not be used in oracle_databases anymore. Use sga_target and pga_aggregate_target in oracle_databases.init_parameters as replacement.

The assert checks, if oracle_db_mem_totalmb is defined without sga_target or oracle_db_mem_totalmb is not used with an entry for sga_target in oracle_databases.init_parameters.

The assert of oracle_database is enabled by default. This could be disabled by setting:

orasw_meta_assert_oracle_databases: false