### PR TITLE
fix loops

### DIFF
--- a/changelogs/fragments/fix_loops.yml
+++ b/changelogs/fragments/fix_loops.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - "oradb_facts: Loop gathered facts only for first database from oracle_databases (oravirt#416)"
+  - "oradb_facts: Prevent re-using results from previous loop run when ignore_errors set to true (oravirt#416)"
+  - "oradb_manage_redo: Loop processed only first database from oracle_databases (oravirt#416)"
+  - "oradb_manage_statspack: Loops processed only first database/pdb from oracle_databases/oracle_pdbs (oravirt#416)"
+  - "oradb_rman: Loops processed only first database from oracle_databases (oravirt#416)"
+  - "orasw_meta_internal: replaced all odb[0]/opdb[0] with _odb_loop_helper/_opdb_loop_helper (oravirt#416)"
+  - "global: removed redundant flatten(levels=1) filter on oracle_database/oracle_pdbs (oravirt#416)"
+  - "global: replaced `match` filter fith `equalto` to prevent partial matches where not wanted (oravirt#416)"

--- a/roles/oradb_datapatch/tasks/main.yml
+++ b/roles/oradb_datapatch/tasks/main.yml
@@ -25,7 +25,7 @@
     state: started
   become: true
   become_user: "{{ oracle_user }}"
-  with_items: "{{ oracle_databases | selectattr('state', 'match', 'present') }}"
+  with_items: "{{ oracle_databases | selectattr('state', 'equalto', 'present') }}"
   loop_control:
     loop_var: odb
     label: >-
@@ -40,8 +40,8 @@
 - name: oradb_datapatch | Run datapatch
   opitzconsulting.ansible_oracle.oracle_datapatch:
     oracle_home: "{{ _oracle_home_db }}"
-    db_name: "{{ odb.0.oracle_db_name }}"
-    db_unique_name: "{{ odb.0.oracle_db_unique_name | default(omit) }}"
+    db_name: "{{ odb.oracle_db_name }}"
+    db_unique_name: "{{ odb.oracle_db_unique_name | default(omit) }}"
     sid: "{{ odb.oracle_db_instance_name | default(omit) }}"
     output: verbose
     fail_on_db_not_exist: "{{ oradb_datapatch_fail_on_db_not_exist }}"
@@ -50,17 +50,16 @@
     hostname: "{{ ansible_fqdn }}"
     service_name: "{{ _db_service_name }}"
     port: "{{ _listener_port_cdb }}"
-  loop:
-    - "{{ oracle_databases | selectattr('state', 'match', 'present') | flatten(levels=1) }}"
+  loop: "{{ oracle_databases | selectattr('state', 'equalto', 'present') }}"
   become: true
   become_user: "{{ oracle_user }}"
   loop_control:
     loop_var: odb
     label: >-
-      home: {{ odb.0.home | default('') }}
-      db_name: {{ odb.0.oracle_db_name | default('') }}"
+      home: {{ odb.home | default('') }}
+      db_name: {{ odb.oracle_db_name | default('') }}"
   when:
     - oracle_databases is defined
     - oracle_databases | list | length > 0
-    - odb.0.state == 'present'
+    - odb.state == 'present'
   tags: datapatch

--- a/roles/oradb_facts/tasks/db_facts.yml
+++ b/roles/oradb_facts/tasks/db_facts.yml
@@ -22,19 +22,19 @@
     cacheable: true
     oracledb_facts: "{{ oracledb_facts | default({}) | combine(_db_facts | items2dict) }}"
   when:
-    - ansible_facts['version'] is defined
+    - dbfactsreg.ansible_facts['version'] is defined
   vars:
     _db_facts:
-      - key: "{{ odb[0]['oracle_db_unique_name'] | default(odb[0]['oracle_db_name']) }}"
+      - key: "{{ odb['oracle_db_unique_name'] | default(odb['oracle_db_name']) }}"
         value:
-          version: "{{ ansible_facts['version'] }}"
-          database: "{{ ansible_facts['database'] }}"
-          instance: "{{ ansible_facts['instance'] }}"
-          pdb: "{{ ansible_facts['pdb'] }}"
-          parameter: "{{ ansible_facts['parameter'] }}"
-          rac: "{{ ansible_facts['rac'] }}"
-          redolog: "{{ ansible_facts['redolog'] }}"
-          tablespace: "{{ ansible_facts['tablespace'] }}"
-          temp_tablespace: "{{ ansible_facts['temp_tablespace'] }}"
-          userenv: "{{ ansible_facts['userenv'] }}"
-          option: "{{ ansible_facts['option'] }}"
+          version: "{{ dbfactsreg.ansible_facts['version'] }}"
+          database: "{{ dbfactsreg.ansible_facts['database'] }}"
+          instance: "{{ dbfactsreg.ansible_facts['instance'] }}"
+          pdb: "{{ dbfactsreg.ansible_facts['pdb'] }}"
+          parameter: "{{ dbfactsreg.ansible_facts['parameter'] }}"
+          rac: "{{ dbfactsreg.ansible_facts['rac'] }}"
+          redolog: "{{ dbfactsreg.ansible_facts['redolog'] }}"
+          tablespace: "{{ dbfactsreg.ansible_facts['tablespace'] }}"
+          temp_tablespace: "{{ dbfactsreg.ansible_facts['temp_tablespace'] }}"
+          userenv: "{{ dbfactsreg.ansible_facts['userenv'] }}"
+          option: "{{ dbfactsreg.ansible_facts['option'] }}"

--- a/roles/oradb_facts/tasks/main.yml
+++ b/roles/oradb_facts/tasks/main.yml
@@ -14,15 +14,14 @@
     # overwrites ansible_facts from the previous one
     - name: Gather Facts from Database
       ansible.builtin.include_tasks: db_facts.yml
-      loop:
-        - "{{ oracle_databases }}"
+      loop: "{{ oracle_databases }}"
       loop_control:
         loop_var: odb
         label: >-
-          db_name: {{ odb[0]['oracle_db_name'] | default('') }}
-          db_unique_name: {{ odb[0]['oracle_db_unique_name'] | default('') }}
+          db_name: {{ odb['oracle_db_name'] | default('') }}
+          db_unique_name: {{ odb['oracle_db_unique_name'] | default('') }}
           port: {{ _listener_port_cdb }}
           service: {{ _db_service_name }}
-          state: {{ odb[0]['state'] | default('present') }}
+          state: {{ odb['state'] | default('present') }}
       when:
-        - odb[0]['state'] | default('present') == 'present'
+        - odb['state'] | default('present') == 'present'

--- a/roles/oradb_manage_db/tasks/assert.yml
+++ b/roles/oradb_manage_db/tasks/assert.yml
@@ -23,9 +23,10 @@
     quiet: true
     fail_msg: "Missing element with listener_name in listener_installed!"
     that:
-      - listener_installed | default([])
-          | selectattr('listener_name', 'match', odb.listener_name)
-          | list | length == 1
+      - >-
+        listener_installed | default([])
+        | selectattr('listener_name', 'equalto', odb.listener_name)
+        | list | length == 1
   with_items: "{{ oracle_databases | selectattr('listener_name', 'defined') }}"
   register: assert2
   loop_control:

--- a/roles/oradb_manage_grants/tasks/main.yml
+++ b/roles/oradb_manage_grants/tasks/main.yml
@@ -64,7 +64,7 @@
     - opdb.0.state == 'present'
     - (opdb.1.grants is defined or opdb.1.object_privs is defined)
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
       | map(attribute='state') | list | first == 'present'
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true
@@ -147,7 +147,7 @@
     - opdb.0.state == 'present'
     - (opdb.1.grants is defined or opdb.1.object_privs is defined)
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
       | map(attribute='state') | list | first == 'present'
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true

--- a/roles/oradb_manage_parameters/tasks/main.yml
+++ b/roles/oradb_manage_parameters/tasks/main.yml
@@ -65,7 +65,7 @@
     - opdb.0.state == 'present'
     - opdb.1 is defined
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
       | map(attribute='state') | list | first == 'present'
   become: true
   become_user: "{{ oracle_user }}"

--- a/roles/oradb_manage_profiles/tasks/main.yml
+++ b/roles/oradb_manage_profiles/tasks/main.yml
@@ -89,7 +89,7 @@
         - opdb.0.state == 'present'
         - opdb.1 is defined
         - >-
-          oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+          oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
           | map(attribute='state') | list | first == 'present'
       run_once: "{{ _oraswgi_meta_configure_cluster }}"
       become: true

--- a/roles/oradb_manage_redo/tasks/main.yml
+++ b/roles/oradb_manage_redo/tasks/main.yml
@@ -17,22 +17,21 @@
         user: "{{ db_user }}"
         password: "{{ _db_password_cdb }}"
         mode: "{{ db_mode }}"
-        size: "{{ odb.0.redolog_size }}"
-        groups: "{{ odb.0.redolog_groups }}"
+        size: "{{ odb.redolog_size }}"
+        groups: "{{ odb.redolog_groups }}"
       environment: "{{ _oracle_env }}"
       run_once: "{{ _oraswgi_meta_configure_cluster }}"
-      loop:
-        - "{{ oracle_databases | flatten(levels=1) }}"
+      loop: "{{ oracle_databases }}"
       when:
         - oracle_databases is defined
-        - odb.0.redolog_size is defined
-        - odb.0.redolog_groups is defined
-        - odb.0.state == 'present'
+        - odb.redolog_size is defined
+        - odb.redolog_groups is defined
+        - odb.state == 'present'
       become_user: "{{ oracle_user }}"
       become: true
       loop_control:
         loop_var: odb
         label: >-
           service: {{ _db_service_name }}:{{ _listener_port_cdb }}
-          groups: {{ odb.0.redolog_groups }}
-          size: {{ odb.0.redolog_size }}
+          groups: {{ odb.redolog_groups | default('') }}
+          size: {{ odb.redolog_size | default('') }}

--- a/roles/oradb_manage_roles/tasks/main.yml
+++ b/roles/oradb_manage_roles/tasks/main.yml
@@ -54,7 +54,7 @@
     - opdb.0.state == 'present'
     - opdb.1 is defined
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
       | map(attribute='state') | list | first == 'present'
   loop_control:
     loop_var: opdb

--- a/roles/oradb_manage_statspack/tasks/main.yml
+++ b/roles/oradb_manage_statspack/tasks/main.yml
@@ -26,17 +26,16 @@
         _sid:
           ORACLE_SID: "{{ _oracle_db_instance_name }}"
       environment: "{{ _oracle_env | combine(_sid) }}"
-      loop:
-        - "{{ oracle_databases | flatten(levels=1) }}"
+      loop: "{{ oracle_databases }}"
       loop_control:
         loop_var: odb
-        label: "{{ odb.0.oracle_db_name }}"
+        label: "{{ odb.oracle_db_name }}"
       register: statspackdropcmd
       become: true
       become_user: "{{ oracle_user }}"
       when:
-        - odb.0.statspack is defined
-        - odb.0.statspack.state | default('present') == 'absent'
+        - odb.statspack is defined
+        - odb.statspack.state | default('present') == 'absent'
       changed_when:
         - '"Statspack dropped" in statspackdropcmd.stdout'
 
@@ -74,27 +73,26 @@
             ORACLE_HOME: "{{ _oracle_home_db }}"
             ORACLE_SID: "{{ _oracle_db_instance_name }}"
             perfstat_password: "{{ _db_password_cdb }}"
-            temporary_tablespace: "{{ odb.0.statspack.tablespace_temp | default('temp') }}"
-            default_tablespace: "{{ odb.0.statspack.tablespace | default('sysaux') }}"
-            purgedates: "{{ odb.0.statspack.purgedays | default(35) }}"
-            snaplevel: "{{ odb.0.statspack.snaplevel | default(7) }}"
+            temporary_tablespace: "{{ odb.statspack.tablespace_temp | default('temp') }}"
+            default_tablespace: "{{ odb.statspack.tablespace | default('sysaux') }}"
+            purgedates: "{{ odb.statspack.purgedays | default(35) }}"
+            snaplevel: "{{ odb.statspack.snaplevel | default(7) }}"
           vars:
             # db_user is needed for _db_password_cdb to point to PERFSTAT
             db_user: PERFSTAT
-          loop:
-            - "{{ oracle_databases | flatten(levels=1) }}"
+          loop: "{{ oracle_databases }}"
           loop_control:
             loop_var: odb
-            label: "{{ odb.0.oracle_db_name | default('') }}"
+            label: "{{ odb.oracle_db_name | default('') }}"
           register: statspackcmd
           become: true
           become_user: "{{ oracle_user }}"
           changed_when:
             - '"Installation of Statspack completed." in statspackcmd.stdout'
           when:
-            - odb.0.state == 'present'
-            - odb.0.statspack is defined
-            - odb.0.statspack.state == 'present'
+            - odb.state == 'present'
+            - odb.statspack is defined
+            - odb.statspack.state == 'present'
 
       rescue:
         - name: fail
@@ -128,21 +126,20 @@
     job_type: "plsql_block"
     job_action: "PERFSTAT.STATSPACK.PURGE({{ odb.statspack.purgedays | default(purgedays) }});"
     logging_level: "runs"
-    repeat_interval: "{{ odb.0.statspack.purgeinterval | default(purgeinterval) }}"
+    repeat_interval: "{{ odb.statspack.purgeinterval | default(purgeinterval) }}"
     state: "present"
   environment: "{{ _oracle_env }}"
-  loop:
-    - "{{ oracle_databases | flatten(levels=1) }}"
+  loop: "{{ oracle_databases }}"
   when:
     - oracle_databases is defined
-    - odb.0.state == 'present'
-    - odb.0.statspack is defined
-    - odb.0.statspack.state == 'present'
+    - odb.state == 'present'
+    - odb.statspack is defined
+    - odb.statspack.state == 'present'
   become: true
   become_user: "{{ oracle_user }}"
   loop_control:
     loop_var: odb
-    label: "{{ odb.0.oracle_db_name }}"
+    label: "{{ odb.oracle_db_name }}"
   tags:
     - spjob
     - statspack
@@ -160,21 +157,20 @@
     job_type: "plsql_block"
     job_action: "PERFSTAT.STATSPACK.SNAP(i_snap_level => {{ odb.statspack.snaplevel | default(snaplevel) }});"
     logging_level: "runs"
-    repeat_interval: "{{ odb.0.statspack.snapinterval | default(snapinterval) }}"
+    repeat_interval: "{{ odb.statspack.snapinterval | default(snapinterval) }}"
     state: "present"
   environment: "{{ _oracle_env }}"
-  loop:
-    - "{{ oracle_databases | flatten(levels=1) }}"
+  loop: "{{ oracle_databases }}"
   when:
     - oracle_databases is defined
-    - odb.0.state == 'present'
-    - odb.0.statspack is defined
-    - odb.0.statspack.state == 'present'
+    - odb.state == 'present'
+    - odb.statspack is defined
+    - odb.statspack.state == 'present'
   become: true
   become_user: "{{ oracle_user }}"
   loop_control:
     loop_var: odb
-    label: "{{ odb.0.oracle_db_name }}"
+    label: "{{ odb.oracle_db_name }}"
   tags:
     - spjob
     - statspack
@@ -191,14 +187,13 @@
       environment:
         ORACLE_HOME: "{{ _oracle_home_pdb }}"
         ORACLE_SID: "{{ _oracle_db_instance_name }}"
-        pdb_name: "{{ opdb.0.pdb_name }}"
-      loop:
-        - "{{ oracle_pdbs | flatten(levels=1) }}"
+        pdb_name: "{{ opdb.pdb_name }}"
+      loop: "{{ oracle_pdbs }}"
       loop_control:
         loop_var: opdb
         label: >-
-          {{ opdb.0.cdb | default('') }}
-          {{ opdb.0.pdb_name | default('') }}
+          {{ opdb.cdb | default('') }}
+          {{ opdb.pdb_name | default('') }}
       register: statspackdropcmd
       become: true
       become_user: "{{ oracle_user }}"
@@ -208,8 +203,8 @@
         - statspackdropcmd.rc != 0
       when:
         - oracle_pdbs is defined
-        - opdb.0.statspack is defined
-        - opdb.0.statspack.state == 'absent'
+        - opdb.statspack is defined
+        - opdb.statspack.state == 'absent'
 
     - name: Output  # noqa no-handler
       ansible.builtin.debug:
@@ -240,17 +235,16 @@
         default_tablespace: "{{ opdb.statspack.tablespace | default('sysaux') }}"
         purgedates: "{{ opdb.statspack.purgedays | default(35) }}"
         snaplevel: "{{ opdb.statspack.snaplevel | default(7) }}"
-        pdb_name: "{{ opdb.0.pdb_name }}"
+        pdb_name: "{{ opdb.pdb_name }}"
       vars:
         # db_user is needed for _db_password_pdb to point to PERFSTAT
         db_user: PERFSTAT
-      loop:
-        - "{{ oracle_pdbs | flatten(levels=1) }}"
+      loop: "{{ oracle_pdbs }}"
       loop_control:
         loop_var: opdb
         label: >-
-          {{ opdb.0.cdb | default('') }}
-          {{ opdb.0.pdb_name | default('') }}
+          {{ opdb.cdb | default('') }}
+          {{ opdb.pdb_name | default('') }}
       register: statspackcmd
       become: true
       become_user: "{{ oracle_user }}"
@@ -258,12 +252,12 @@
         - '"Installation of Statspack completed." in statspackcmd.stdout'
       when:
         - oracle_pdbs is defined
-        - opdb.0.cdb is defined
-        - opdb.0.state == 'present'
-        - opdb.0.statspack is defined
-        - opdb.0.statspack.state == 'present'
+        - opdb.cdb is defined
+        - opdb.state == 'present'
+        - opdb.statspack is defined
+        - opdb.statspack.state == 'present'
         - >-
-          oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+          oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.cdb)
           | map(attribute='state') | list | first == 'present'
 
     - name: Output
@@ -291,25 +285,24 @@
     job_type: "plsql_block"
     job_action: "PERFSTAT.STATSPACK.PURGE({{ pdb.statspack.purgedays | default(purgedays) }});"
     logging_level: "runs"
-    repeat_interval: "{{ opdb.0.statspack.purgeinterval | default(purgeinterval) }}"
+    repeat_interval: "{{ opdb.statspack.purgeinterval | default(purgeinterval) }}"
     state: "present"
   environment: "{{ _oracle_env_pdb }}"
-  loop:
-    - "{{ oracle_pdbs | flatten(levels=1) }}"
+  loop: "{{ oracle_pdbs }}"
   loop_control:
     loop_var: opdb
     label: >-
-      {{ opdb.0.cdb | default('') }}
-      {{ opdb.0.pdb_name | default('') }}
+      {{ opdb.cdb | default('') }}
+      {{ opdb.pdb_name | default('') }}
   when:
     - oracle_pdbs is defined
-    - opdb.0.cdb is defined
-    - opdb.0.pdb_name is defined
-    - opdb.0.state == 'present'
-    - opdb.0.statspack is defined
-    - opdb.0.statspack.state == 'present'
+    - opdb.cdb is defined
+    - opdb.pdb_name is defined
+    - opdb.state == 'present'
+    - opdb.statspack is defined
+    - opdb.statspack.state == 'present'
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.cdb)
       | map(attribute='state') | list | first == 'present'
   become: true
   become_user: "{{ oracle_user }}"
@@ -330,25 +323,24 @@
     job_type: "plsql_block"
     job_action: "PERFSTAT.STATSPACK.SNAP(i_snap_level => {{ pdb.0.statspack.snaplevel | default(snaplevel) }});"
     logging_level: "runs"
-    repeat_interval: "{{ opdb.0.statspack.snapinterval | default(snapinterval) }}"
+    repeat_interval: "{{ opdb.statspack.snapinterval | default(snapinterval) }}"
     state: "present"
   environment: "{{ _oracle_env_pdb }}"
-  loop:
-    - "{{ oracle_pdbs | flatten(levels=1) }}"
+  loop: "{{ oracle_pdbs }}"
   loop_control:
     loop_var: opdb
     label: >-
-      {{ opdb.0.cdb | default('') }}
-      {{ opdb.0.pdb_name | default('') }}
+      {{ opdb.cdb | default('') }}
+      {{ opdb.pdb_name | default('') }}
   when:
     - oracle_pdbs is defined
-    - opdb.0.cdb is defined
-    - opdb.0.pdb_name is defined
-    - opdb.0.state == 'present'
-    - opdb.0.statspack is defined
-    - opdb.0.statspack.state == 'present'
+    - opdb.cdb is defined
+    - opdb.pdb_name is defined
+    - opdb.state == 'present'
+    - opdb.statspack is defined
+    - opdb.statspack.state == 'present'
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.cdb)
       | map(attribute='state') | list | first == 'present'
   become: true
   become_user: "{{ oracle_user }}"

--- a/roles/oradb_manage_tablespace/tasks/main.yml
+++ b/roles/oradb_manage_tablespace/tasks/main.yml
@@ -76,7 +76,7 @@
         - opdb.1 is defined
         - opdb.0.state == 'present'
         - >-
-          oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+          oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
           | map(attribute='state') | list | first == 'present'
       loop_control:
         loop_var: opdb

--- a/roles/oradb_manage_users/tasks/main.yml
+++ b/roles/oradb_manage_users/tasks/main.yml
@@ -74,7 +74,7 @@
     - opdb.1.schema is defined
     - opdb.1.state is defined
     - >-
-      oracle_databases | selectattr('oracle_db_name', 'match', opdb.0.cdb)
+      oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
       | map(attribute='state') | list | first == 'present'
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true

--- a/roles/oradb_rman/tasks/main.yml
+++ b/roles/oradb_rman/tasks/main.yml
@@ -60,11 +60,10 @@
     state: directory
     mode: '0755'
     owner: "{{ oracle_user }}"
-  loop:
-    - "{{ oracle_databases | flatten(1) }}"
+  loop: "{{ oracle_databases }}"
   loop_control:
     loop_var: odb
-    label: "oracle_db_name {{ odb.0.oracle_db_name | default('') }}"
+    label: "oracle_db_name {{ odb.oracle_db_name | default('') }}"
   tags:
     - rmancopy
 
@@ -75,11 +74,10 @@
     state: "directory"
     mode: '0755'
     owner: "{{ oracle_user }}"
-  loop:
-    - "{{ oracle_databases | flatten(1) }}"
+  loop: "{{ oracle_databases }}"
   loop_control:
     loop_var: odb
-    label: "oracle_db_name {{ odb.0.oracle_db_name | default('') }}"
+    label: "oracle_db_name {{ odb.oracle_db_name | default('') }}"
   tags:
     - rmancopy
 
@@ -118,11 +116,10 @@
     state: directory
     owner: "{{ oracle_user }}"
     mode: '0755'
-  with_items:
-    - "{{ oracle_databases | selectattr('rman_tnsalias', 'defined') | map(attribute='oracle_db_name') }}"
+  loop: "{{ oracle_databases | selectattr('rman_tnsalias', 'defined') | map(attribute='oracle_db_name') }}"
   loop_control:
     loop_var: odb
-    label: "oracle_db_name {{ odb.0.oracle_db_name | default('') }}"
+    label: "oracle_db_name {{ oracle_db_name | default('') }}"
   tags:
     - tns
 

--- a/roles/orasw_meta/tasks/assert_oracle_databases.yml
+++ b/roles/orasw_meta/tasks/assert_oracle_databases.yml
@@ -104,14 +104,15 @@
               - ass_odb.users | default([]) | type_debug == 'list'
               - ass_odb.oracle_db_type | default('SI2') in ('SI', 'RAC', 'RACONENODE')
               - ass_odb.storage_type | default('FS') in ('FS', 'ASM')
-              - (ass_odb.oracle_db_mem_totalmb is defined
+              - >-
+                (ass_odb.oracle_db_mem_totalmb is defined
                   and ass_odb.init_parameters | default([])
-                      | selectattr ('name', 'match', 'sga_target') | list | length == 0
+                      | selectattr ('name', 'equalto', 'sga_target') | list | length == 0
                 )
                 or
                 (ass_odb.oracle_db_mem_totalmb is not defined
                   and ass_odb.init_parameters | default([]) | list
-                       | selectattr ('name', 'match', 'sga_target') | list | length > 0
+                       | selectattr ('name', 'equalto', 'sga_target') | list | length > 0
                 )
           with_items:
             - "{{ oracle_databases }}"

--- a/roles/orasw_meta_internal/README.md
+++ b/roles/orasw_meta_internal/README.md
@@ -183,7 +183,7 @@ _odb_loop_helper: _internal_used_
 #### Default value
 
 ```YAML
-_opdb_home: "{{ (oracle_databases | selectattr('oracle_db_name', 'match', opdb[0]['cdb']))[0]['home']
+_opdb_home: "{{ (oracle_databases | selectattr('oracle_db_name', 'equalto', _opdb_loop_helper['cdb']))[0]['home']
   }}"
 ```
 

--- a/roles/orasw_meta_internal/defaults/main.yml
+++ b/roles/orasw_meta_internal/defaults/main.yml
@@ -6,7 +6,7 @@
 # @end
 # @var _db_password_cdb: $ "_internal_used_"
 _db_password_cdb: >-
-  {{ dbpasswords[odb.0.oracle_db_name][db_user]
+  {{ dbpasswords[_odb_loop_helper['oracle_db_name']][db_user]
      | default(default_dbpass | mandatory) }}
 
 # @var _db_password_pdb:description: >
@@ -16,7 +16,7 @@ _db_password_cdb: >-
 # @end
 # @var _db_password_pdb: $ "_internal_used_"
 _db_password_pdb: >-
-  {{ dbpasswords[opdb[0]['cdb']][opdb[0]['pdb_name']][db_user]
+  {{ dbpasswords[_opdb_loop_helper['cdb']][_opdb_loop_helper['pdb_name']][db_user]
      | default(default_dbpass | mandatory) }}
 
 # @var _db_service_name:description: >
@@ -46,8 +46,8 @@ _db_service_name: "{% if _odb_loop_helper.oracle_db_name is defined -%}
 # @var _db_unique_name_for_pdb: $ "_internal_used_"
 _db_unique_name_for_pdb: >-
   {{ (oracle_databases
-    | selectattr('oracle_db_name', 'match', opdb[0]['cdb'])
-    | map(attribute='oracle_db_unique_name', default=opdb[0]['cdb']))[0]
+    | selectattr('oracle_db_name', 'equalto', _opdb_loop_helper['cdb'])
+    | map(attribute='oracle_db_unique_name', default=_opdb_loop_helper['cdb']))[0]
   }}
 
 # @var _db_service_pdb:description: >
@@ -62,10 +62,10 @@ _db_unique_name_for_pdb: >-
 # @var _db_service_pdb: $ "_internal_used_"
 _db_service_pdb: >-
   {%- set __db_domain_pdb = oracledb_facts[_db_unique_name_for_pdb]['parameter']['db_domain']['value'] -%}
-  {%- if __db_domain_pdb is defined and __db_domain_pdb is string and __db_domain_pdb | length > 0 -%}{{ opdb[0]['pdb_name'] }}.{{ __db_domain_pdb }}{%- else -%}
-  {{ opdb[0]['pdb_name'] }}{% endif %}
+  {%- if __db_domain_pdb is defined and __db_domain_pdb is string and __db_domain_pdb | length > 0 -%}{{ _opdb_loop_helper['pdb_name'] }}.{{ __db_domain_pdb }}{%- else -%}
+  {{ _opdb_loop_helper['pdb_name'] }}{% endif %}
 
-_opdb_home: "{{ (oracle_databases | selectattr('oracle_db_name', 'match', opdb[0]['cdb']))[0]['home'] }}"
+_opdb_home: "{{ (oracle_databases | selectattr('oracle_db_name', 'equalto', _opdb_loop_helper['cdb']))[0]['home'] }}"
 
 # @var _oracle_home_db:description: >
 # This is an internal variable in `ansible-oracle`.
@@ -76,7 +76,7 @@ _opdb_home: "{{ (oracle_databases | selectattr('oracle_db_name', 'match', opdb[0
 _oracle_home_db: "{%- if _odb_loop_helper is defined -%}\
                     {{ db_homes_config[_odb_loop_helper.home]['oracle_home'] | \
                        default(oracle_base + '/' + db_homes_config[_odb_loop_helper.home]['version'] + '/' + _odb_loop_helper.home) }}\
-                  {%- elif opdb[0] is defined -%}\
+                  {%- elif _opdb_loop_helper is defined -%}\
                     {{ db_homes_config[_opdb_home]['oracle_home'] | \
                        default(oracle_base + '/' + db_homes_config[_opdb_home]['version'] + '/' + _opdb_home) }}\
                   {%- endif -%}"

--- a/roles/oraswdb_install/tasks/install-home-db.yml
+++ b/roles/oraswdb_install/tasks/install-home-db.yml
@@ -53,7 +53,7 @@
         copy: false
         creates: "{{ oracle_home_db }}/{{ item[0].creates }}"
       with_nested:
-        - "{{ _oraswdb_install_oracle_sw_image_db | selectattr('version', 'match', db_homes_config[dbh.home]['version']) }}"
+        - "{{ _oraswdb_install_oracle_sw_image_db | selectattr('version', 'equalto', db_homes_config[dbh.home]['version']) }}"
         - ""  # dummy to force item.0 instead of item.
       become: true
       become_user: "{{ oracle_user }}"
@@ -73,7 +73,7 @@
         copy: false
         creates: "{{ oracle_home_db }}/{{ item[0].creates }}"
       with_nested:
-        - "{{ _oraswdb_install_oracle_sw_image_db | selectattr('version', 'match', db_homes_config[dbh.home]['version']) }}"
+        - "{{ _oraswdb_install_oracle_sw_image_db | selectattr('version', 'equalto', db_homes_config[dbh.home]['version']) }}"
         - ""  # dummy to force item.0 instead of item.
       become: true
       become_user: "{{ oracle_user }}"

--- a/roles/oraswdb_install/vars/main.yml
+++ b/roles/oraswdb_install/vars/main.yml
@@ -37,12 +37,12 @@ _oraswdb_install_choptcheck: "{% if oraswdb_install_forcechopt | bool %}dochopt{
 
 _oraswdb_install_dbh_stat: >-
   {{ stat_dbh_installed.results
-      | selectattr('invocation.module_args.path', 'match', db_homes_config[dbh.home]['oracle_home'])
+      | selectattr('invocation.module_args.path', 'equalto', db_homes_config[dbh.home]['oracle_home'])
       | first }}
 
 _local_oracle_sw_image_db: >-
   {{ db_homes_config[dbh.home].imagename
       | default((_oraswdb_install_oracle_sw_image_db
-        | selectattr('version', 'match', db_homes_config[dbh.home]['version'])
+        | selectattr('version', 'equalto', db_homes_config[dbh.home]['version'])
         | list)[0]['filename']
       ) }}

--- a/roles/oraswdb_manage_patches/tasks/loop_db-home-patch.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_db-home-patch.yml
@@ -50,7 +50,7 @@
     output: verbose
     state: "{{ item.state }}"
   with_items:
-    - "{{ db_homes_config[dbh.home]['opatch'] | selectattr('state', 'match', 'absent') }}"
+    - "{{ db_homes_config[dbh.home]['opatch'] | selectattr('state', 'equalto', 'absent') }}"
   become: true
   become_user: "{{ oracle_user }}"
   tags:

--- a/roles/oraswdb_manage_patches/tasks/opatch-upgrade.yml
+++ b/roles/oraswdb_manage_patches/tasks/opatch-upgrade.yml
@@ -25,7 +25,7 @@
         dest: "{{ oracle_stage }}"
         mode: "0644"
         force: true
-      with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', db_version) }}"
+      with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
       loop_control:
         loop_var: oop_loop
         label: >-
@@ -45,7 +45,7 @@
         dest: "{{ oracle_stage }}"
         mode: "0644"
         force: true
-      with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', db_version) }}"
+      with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
       when:
         - oracle_sw_copy
         - is_sw_source_local
@@ -60,7 +60,7 @@
     #     dest: "{{ oracle_stage }}"
     #     mode: "0644"
     #     force: true
-    #   with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', db_version) }}"
+    #   with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
     #   loop_control:
     #     loop_var: oop_loop
     #     label: >-
@@ -81,7 +81,7 @@
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
       become: true
-      with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', db_version) }}"
+      with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
       when:
         - oracle_sw_copy
       tags:
@@ -95,7 +95,7 @@
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
       become: true
-      with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', db_version) }}"
+      with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
       when:
         - not oracle_sw_copy
       tags:

--- a/roles/oraswgi_install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi_install/tasks/19.3.0.0.yml
@@ -20,7 +20,7 @@
         src: "{{ _oraswgi_install_oracle_gi_image }}"
         dest: "{{ oracle_home_gi }}"
         copy: false
-      with_items: "{{ oracle_sw_image_gi | selectattr('version', 'match', oracle_install_version_gi) }}"
+      with_items: "{{ oracle_sw_image_gi | selectattr('version', 'equalto', oracle_install_version_gi) }}"
       loop_control:
         label: "{{ _oraswgi_install_oracle_gi_image | default('') }}"
       args:
@@ -120,7 +120,7 @@
     # get 1st opatchauto patch with state=present
     __applyruopatchauto: |-
       {{ gi_patches[oracle_install_version_gi]['opatchauto']
-        | selectattr('state', 'match', 'present') | list | first }}
+        | selectattr('state', 'equalto', 'present') | list | first }}
     __patchru_dir: |-
       {{ oracle_sw_copy | bool | ternary(oracle_stage, oracle_stage_remote) }}/patches/{{ oracle_install_version_gi }}/
       {{- __applyruopatchauto['path'] | default(__applyruopatchauto['patchid']) }}

--- a/roles/oraswgi_install/tasks/main.yml
+++ b/roles/oraswgi_install/tasks/main.yml
@@ -70,7 +70,7 @@
     group: "{{ oracle_group }}"
     state: directory
   become: true
-  with_items: "{{ oracle_sw_image_gi | selectattr('version', 'match', oracle_install_version_gi) }}"
+  with_items: "{{ oracle_sw_image_gi | selectattr('version', 'equalto', oracle_install_version_gi) }}"
   tags:
     - directories
 

--- a/roles/oraswgi_install/tasks/main_install.yml
+++ b/roles/oraswgi_install/tasks/main_install.yml
@@ -23,7 +23,7 @@
     dest: "{{ oracle_stage }}"
     mode: "0775"
     force: false
-  with_items: "{{ oracle_sw_image_gi | selectattr('version', 'match', oracle_install_version_gi) }}"
+  with_items: "{{ oracle_sw_image_gi | selectattr('version', 'equalto', oracle_install_version_gi) }}"
   become: true
   become_user: "{{ _grid_install_user }}"
   tags:

--- a/roles/oraswgi_manage_patches/tasks/opatch-upgrade.yml
+++ b/roles/oraswgi_manage_patches/tasks/opatch-upgrade.yml
@@ -27,7 +27,7 @@
     owner: "{{ _grid_install_user }}"
     group: "{{ oracle_group }}"
   become: true
-  with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', oracle_install_version_gi) }}"
+  with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', oracle_install_version_gi) }}"
   when:
     - apply_patches_gi
     - oracle_sw_copy
@@ -46,7 +46,7 @@
     owner: "{{ _grid_install_user }}"
     group: "{{ oracle_group }}"
   become: true
-  with_items: "{{ oracle_opatch_patch | selectattr('version', 'match', oracle_install_version_gi) }}"
+  with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', oracle_install_version_gi) }}"
   when:
     - apply_patches_gi
     - item.version == oracle_install_version_gi

--- a/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
@@ -13,7 +13,7 @@
 - name: post_install_patch | Remove opatch apply patches from GI 19c+
   ansible.builtin.include_tasks: loop_remove_single_opatch.yml
   with_items:
-    - "{{ gi_patches[oracle_install_version_gi]['opatch'] | selectattr('state', 'match', 'absent') }}"
+    - "{{ gi_patches[oracle_install_version_gi]['opatch'] | selectattr('state', 'equalto', 'absent') }}"
   loop_control:
     loop_var: gip_opatch
     label: >-
@@ -42,7 +42,7 @@
     output: verbose
     state: absent
   with_items:
-    - "{{ gi_patches[oracle_install_version_gi]['opatchauto'] | selectattr('state', 'match', 'absent') }}"
+    - "{{ gi_patches[oracle_install_version_gi]['opatchauto'] | selectattr('state', 'equalto', 'absent') }}"
   loop_control:
     loop_var: gip_opatch
     label: >-
@@ -79,7 +79,7 @@
   with_items:
     - >-
       gi_patches[oracle_install_version_gi]['opatch']
-        | select('state', 'match', 'present')
+        | selectattr('state', 'equalto', 'present')
     - ""  # loop with dummy list due to needed structure for autopatch
   loop_control:
     loop_var: gip_opatch
@@ -98,7 +98,7 @@
 - name: post_install_patch | Manage opatch apply patches for GI 19c+
   ansible.builtin.include_tasks: loop_apply_single_opatch.yml
   with_items:
-    - "{{ gi_patches[oracle_install_version_gi]['opatch'] | selectattr('state', 'match', 'present') }}"
+    - "{{ gi_patches[oracle_install_version_gi]['opatch'] | selectattr('state', 'equalto', 'present') }}"
   # run_once: "{{ _oraswgi_meta_configure_cluster }}"
   loop_control:
     label: >-


### PR DESCRIPTION
This PR fixes many roles where `loop:` caused to evaluate only first element from `oracle_databases` / `oracle_pdbs`.
It also changes the `match` filter in probably all `selectattr()` calls as there exact match is needed, and `match` filter actually matches only beginning of the string/line thus creating a possibility to include also partial matches which would cause problems.
One last touch is change in oradb_facts role, as it used global fact variables and not those from registered variable, which (when using for example ignore_errors) might led to a situation where facts for one failed database would be set to those from previous loop element. It may never occur, yet this way it is just safer.