### PR TITLE
oradb_facts_ignore_unreachable in oracle_databases

### DIFF
--- a/changelogs/fragments/assert_pdbs.yml
+++ b/changelogs/fragments/assert_pdbs.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - "orasw_meta: assert that cdb from oracle_pdbs is in oracle_databases (oravirt#417)"

--- a/changelogs/fragments/molecule.yml
+++ b/changelogs/fragments/molecule.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "molecule: Added 2nd database to tests (oravirt#417)"

--- a/changelogs/fragments/oradb_facts.yml
+++ b/changelogs/fragments/oradb_facts.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_facts: add attribute oradb_facts_ignore_unreachable to oracle_databases (oravirt#417)"

--- a/changelogs/fragments/oradb_facts2.yml
+++ b/changelogs/fragments/oradb_facts2.yml
@@ -1,0 +1,12 @@
+---
+minor_changes:
+  - "oradb_manage_grants: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_parameters: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_pdb: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_profiles: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_redo: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_roles: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_services: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_statspack: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_tablespace: check state from oracledb_facts during execution (oravirt#417)"
+  - "oradb_manage_users: check state from oracledb_facts during execution (oravirt#417)"

--- a/changelogs/fragments/oradb_facts3.yml
+++ b/changelogs/fragments/oradb_facts3.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_manage_db: Ignore errors during create/manage db when oradb_facts_ignore_unreachable=true (oravirt#417)"

--- a/extensions/molecule/dbfs/side_effect.yml
+++ b/extensions/molecule/dbfs/side_effect.yml
@@ -58,3 +58,24 @@
         init_parameters:
           - {name: recyclebin, value: 'off', scope: spfile, state: present}
           - {name: sga_target, value: '1808M', scope: spfile, state: present}
+
+    oracle_pdbs:
+      - cdb: DB1
+        home: db19-si-ee
+        pdb_name: ORCLPDB
+        listener_port: 1521
+        state: present
+        datafile_dest: /u01/app/oracle/oradata
+        statspack:
+          purgedays: 14
+          snaplevel: 7
+          tablespace: PERFSTAT
+          state: present
+        tablespaces:
+          - name: PERFSTAT
+            size: 10M
+            autoextend: true
+            next: 50M
+            maxsize: 4G
+            content: permanent
+            state: present

--- a/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
+++ b/extensions/molecule/shared_config/inventory/group_vars/all/oracle_db.yml
@@ -85,6 +85,7 @@ listener_installed:
 
 oracle_databases:
   - home: db19-si-ee
+    oradb_facts_ignore_unreachable: true
     oracle_db_name: &oracle_db_name DB1
     oracle_db_type: SI
     is_container: true
@@ -121,6 +122,39 @@ oracle_databases:
       - {name: recyclebin, value: 'off', scope: spfile, state: present}
       - {name: pga_aggregate_target, value: '128M', scope: both, state: present}
       - {name: sga_target, value: '1808M', scope: spfile, state: present}
+  - home: db19-si-ee
+    oradb_facts_ignore_unreachable: true
+    oracle_db_name: &oracle_db_name2 DB2
+    oracle_db_type: SI
+    is_container: true
+    storage_type: FS
+    oracle_database_type: MULTIPURPOSE
+    redolog_size: 50M
+    redolog_groups: 3
+    datafile_dest: /u01/app/oracle/oradata
+    recoveryfile_dest: /u01/app/oracle//fra
+    listener_name: LISTENER
+    listener_port: *cdb_listener_port
+    # *local_listener is used in initparam as an achor
+    local_listener: *local_listener
+    archivelog: false
+    flashback: false
+    force_logging: false
+    state: present
+    tablespaces:
+      - name: TEST
+        size: 10M
+        autoextend: true
+        next: 50M
+        maxsize: 4G
+        content: permanent
+        state: present
+    init_parameters:
+      - {name: db_create_file_dest, value: '/u01/app/oracle/oradata', scope: both, state: present}
+      - {name: db_create_online_log_dest_1, value: '/u01/app/oracle/oradata', scope: both, state: present}
+      - {name: recyclebin, value: 'off', scope: spfile, state: present}
+      - {name: pga_aggregate_target, value: '128M', scope: both, state: present}
+      - {name: sga_target, value: '1808M', scope: spfile, state: present}
 
 oracle_pdbs:
   - cdb: DB1
@@ -142,6 +176,24 @@ oracle_pdbs:
         maxsize: 4G
         content: permanent
         state: present
+  - cdb: DB2
+    home: db19-si-ee
+    pdb_name: ORCLPDB1
+    listener_port: 1521
+    state: present
+    datafile_dest: /u01/app/oracle/oradata
+  - cdb: DB2
+    home: db19-si-ee
+    pdb_name: ORCLPDB2
+    listener_port: 1521
+    state: present
+    datafile_dest: /u01/app/oracle/oradata
+  - cdb: DB2
+    home: db19-si-ee
+    pdb_name: ORCLPDB3
+    listener_port: 1521
+    state: present
+    datafile_dest: /u01/app/oracle/oradata
 
 _tnsnames_config_pdb_helper:
   - key: "{{ oracle_pdbs[0]['pdb_name'] }}"

--- a/roles/oradb_facts/tasks/db_facts.yml
+++ b/roles/oradb_facts/tasks/db_facts.yml
@@ -1,40 +1,63 @@
 ---
 # @todo bug: parameter user, password and sysdba needs a refactoring
-- name: Gather Facts from Database
-  opitzconsulting.ansible_oracle.oracle_facts:
-    hostname: "{{ oracle_hostname }}"
-    port: "{{ _listener_port_cdb }}"
-    service_name: "{{ _db_service_name }}"
-    user: "{{ db_user }}"
-    password: "{{ _db_password_cdb }}"
-    mode: sysdba
-  environment: "{{ _oracle_env }}"
-  register: dbfactsreg
-  vars:
-    # set db_user for _db_password_cdb
-    db_user: "{{ oradb_facts_db_user }}"
+- name: Gather Facts
+  block:
+    - name: Gather Facts from Database (rescue failures in later task)
+      opitzconsulting.ansible_oracle.oracle_facts:
+        hostname: "{{ oracle_hostname }}"
+        port: "{{ _listener_port_cdb }}"
+        service_name: "{{ _db_service_name }}"
+        user: "{{ db_user }}"
+        password: "{{ _db_password_cdb }}"
+        mode: sysdba
+      environment: "{{ _oracle_env }}"
+      register: dbfactsreg
+      vars:
+        # set db_user for _db_password_cdb
+        db_user: "{{ oradb_facts_db_user }}"
 
+    # 2nd execution of oracle_facts will overwrite data of last execution.
+    # => Store facts from oracle_facts in structure
+    - name: Write facts to oracledb.db_unique_name
+      ansible.builtin.set_fact:
+        cacheable: true
+        oracledb_facts: "{{ oracledb_facts | default({}) | combine(_db_facts | items2dict) }}"
+      when:
+        - dbfactsreg.ansible_facts['version'] is defined
+      vars:
+        _db_facts:
+          - key: "{{ odb['oracle_db_unique_name'] | default(odb['oracle_db_name']) }}"
+            value:
+              state: present
+              version: "{{ ansible_facts['version'] }}"
+              database: "{{ ansible_facts['database'] }}"
+              instance: "{{ ansible_facts['instance'] }}"
+              pdb: "{{ ansible_facts['pdb'] }}"
+              parameter: "{{ ansible_facts['parameter'] }}"
+              rac: "{{ ansible_facts['rac'] }}"
+              redolog: "{{ ansible_facts['redolog'] }}"
+              tablespace: "{{ ansible_facts['tablespace'] }}"
+              temp_tablespace: "{{ ansible_facts['temp_tablespace'] }}"
+              userenv: "{{ ansible_facts['userenv'] }}"
+              option: "{{ ansible_facts['option'] }}"
 
-# 2nd execution of oracle_factswill overwrite data of last execution.
-# => Store facts from oracle_facts in structure
-- name: Write facts to oracledb.db_unique_name
-  ansible.builtin.set_fact:
-    cacheable: true
-    oracledb_facts: "{{ oracledb_facts | default({}) | combine(_db_facts | items2dict) }}"
-  when:
-    - dbfactsreg.ansible_facts['version'] is defined
-  vars:
-    _db_facts:
-      - key: "{{ odb['oracle_db_unique_name'] | default(odb['oracle_db_name']) }}"
-        value:
-          version: "{{ dbfactsreg.ansible_facts['version'] }}"
-          database: "{{ dbfactsreg.ansible_facts['database'] }}"
-          instance: "{{ dbfactsreg.ansible_facts['instance'] }}"
-          pdb: "{{ dbfactsreg.ansible_facts['pdb'] }}"
-          parameter: "{{ dbfactsreg.ansible_facts['parameter'] }}"
-          rac: "{{ dbfactsreg.ansible_facts['rac'] }}"
-          redolog: "{{ dbfactsreg.ansible_facts['redolog'] }}"
-          tablespace: "{{ dbfactsreg.ansible_facts['tablespace'] }}"
-          temp_tablespace: "{{ dbfactsreg.ansible_facts['temp_tablespace'] }}"
-          userenv: "{{ dbfactsreg.ansible_facts['userenv'] }}"
-          option: "{{ dbfactsreg.ansible_facts['option'] }}"
+  rescue:
+    # default is
+    # => Fail execution of Playbook
+    - name: Fail execution of oradb_facts
+      ansible.builtin.fail:
+        msg: >-
+          Set oradb_facts_ignore_unreachable=false in oracle_databases
+          to disable this fail task.
+      when:
+        - not _odb_loop_helper.oradb_facts_ignore_unreachable | default(false)
+
+    - name: Write empty facts to oracledb.db_unique_name (rescue from failure above)
+      ansible.builtin.set_fact:
+        cacheable: true
+        oracledb_facts: "{{ oracledb_facts | default({}) | combine(_db_facts | items2dict) }}"
+      vars:
+        _db_facts:
+          - key: "{{ odb['oracle_db_unique_name'] | default(odb['oracle_db_name']) }}"
+            value:
+              state: unreachable

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -103,30 +103,41 @@
   when: odb.state == 'present'
 
 - name: manage_db | create/manage database
-  opitzconsulting.ansible_oracle.oracle_db:
-    oracle_home: "{{ _oracle_home_db }}"
-    port: "{{ listener_port_template }}"
-    sys_password: "{{ _oradb_manage_db_dbca_sys_pass }}"
-    db_name: "{{ odb.oracle_db_name }}"
-    db_unique_name: "{{ odb.oracle_db_unique_name | default(omit) }}"
-    sid: "{{ odb.oracle_db_instance_name | default(omit) }}"
-    responsefile: "{{ oracle_rsp_stage }}/{{ _oradb_manage_db_oracle_dbca_rsp }}"
-    archivelog: "{{ odb.archivelog | default(omit) }}"
-    flashback: "{{ odb.flashback | default(omit) }}"
-    force_logging: "{{ odb.force_logging | default(omit) }}"
-    initparams: "{{ _oradb_manage_db_init_params_list | default(omit) }}"
-    output: verbose
-    state: "{{ odb.state }}"
-  run_once: "{{ _oraswgi_meta_configure_cluster }}"
-  become: true
-  become_user: "{{ oracle_user }}"
-  when: odb.state == 'present'
-  register: dbca_create
   tags:
     - molecule-idempotence-notest
     - create_db
     - manage_db
     - dbca
+  block:
+    - name: manage_db | create/manage database
+      opitzconsulting.ansible_oracle.oracle_db:
+        oracle_home: "{{ _oracle_home_db }}"
+        port: "{{ listener_port_template }}"
+        sys_password: "{{ _oradb_manage_db_dbca_sys_pass }}"
+        db_name: "{{ odb.oracle_db_name }}"
+        db_unique_name: "{{ odb.oracle_db_unique_name | default(omit) }}"
+        sid: "{{ odb.oracle_db_instance_name | default(omit) }}"
+        responsefile: "{{ oracle_rsp_stage }}/{{ _oradb_manage_db_oracle_dbca_rsp }}"
+        archivelog: "{{ odb.archivelog | default(omit) }}"
+        flashback: "{{ odb.flashback | default(omit) }}"
+        force_logging: "{{ odb.force_logging | default(omit) }}"
+        initparams: "{{ _oradb_manage_db_init_params_list | default(omit) }}"
+        output: verbose
+        state: "{{ odb.state }}"
+      run_once: "{{ _oraswgi_meta_configure_cluster }}"
+      become: true
+      become_user: "{{ oracle_user }}"
+      when: odb.state == 'present'
+      register: dbca_create
+
+  rescue:
+    - name: manage_db | fail create/manage database
+      ansible.builtin.fail:
+        msg: >-
+          Set oradb_facts_ignore_unreachable=false in oracle_databases
+          to disable this fail task.qq
+      when:
+        - not _odb_loop_helper.oradb_facts_ignore_unreachable | default(false)
 
 - name: manage_db | Customize oratab for autostart
   ansible.builtin.lineinfile:

--- a/roles/oradb_manage_grants/tasks/main.yml
+++ b/roles/oradb_manage_grants/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - oracle_databases is defined
     - odb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - (odb.1.grants is defined or odb.1.object_privs is defined)
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true
@@ -30,10 +31,12 @@
   loop_control:
     loop_var: odb
     label: >-
+      db_name: {{ odb.0.oracle_db_name | default('') }}
       service: {{ _db_service_name }}:{{ _listener_port_cdb }}
       role: {{ odb.1.name | default('') }}
       grants: {{ odb.1.grants | default('') }}
       state: {{ odb.1.state | default('') }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags:
     - users
     - grants
@@ -62,6 +65,7 @@
     - oracle_pdbs is defined
     - opdb.0 is defined
     - opdb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - (opdb.1.grants is defined or opdb.1.object_privs is defined)
     - >-
       oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
@@ -72,11 +76,13 @@
   loop_control:
     loop_var: opdb
     label: >-
+      cdb: {{ opdb.0.cdb | default('') }}
       port: {{ _listener_port_pdb }},
       pdb: {{ opdb.0.pdb_name }},
       role: {{ opdb.1.name | default('none') }},
       grants: {{ opdb.1.grants | default(omit) }},
       state: {{ opdb.1.state }}
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags:
     - users
     - grants2
@@ -106,6 +112,7 @@
   when:
     - oracle_databases is defined
     - odb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - (odb.1.grants is defined or odb.1.object_privs is defined)
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true
@@ -113,10 +120,12 @@
   loop_control:
     loop_var: odb
     label: >-
+      db_name: {{ odb.0.oracle_db_name | default('') }}
       service: {{ _db_service_name }}:{{ _listener_port_cdb }}
       schema: {{ odb.1.schema | default('') }}
       grants: {{ odb.1.grants | default('') }}
       state: {{ odb.1.state | default('') }}"
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags:
     - users
     - grants
@@ -145,6 +154,7 @@
     - oracle_pdbs is defined
     - opdb.0 is defined
     - opdb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - (opdb.1.grants is defined or opdb.1.object_privs is defined)
     - >-
       oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
@@ -155,11 +165,13 @@
   loop_control:
     loop_var: opdb
     label: >-
+      cdb: {{ opdb.0.cdb | default('') }}
       port: {{ _listener_port_pdb }},
       pdb: {{ opdb.0.pdb_name }},
       schema: {{ opdb.1.schema | default('none') }},
       grants: {{ opdb.1.grants | default(omit) }},
       state: {{ opdb.1.state }}
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags:
     - users
     - grants4

--- a/roles/oradb_manage_parameters/tasks/main.yml
+++ b/roles/oradb_manage_parameters/tasks/main.yml
@@ -23,18 +23,21 @@
   when:
     - oracle_databases is defined
     - odb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - odb.1 is defined
   become: true
   become_user: "{{ oracle_user }}"
   loop_control:
     loop_var: odb
     label: >-
+      db_name: {{ odb.0.oracle_db_name | default('') }}
       port: {{ _listener_port_cdb }}
       service: {{ _db_service_name }}
       name: {{ odb.1.name }}
       value: {{ odb.1.value }}
       scope: {{ odb.1.scope | default ('both') }}
       state:{{ odb.1.state }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   register: param_change_cdb
   tags:
     - initparams
@@ -63,6 +66,7 @@
   when:
     - oracle_pdbs is defined
     - opdb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - opdb.1 is defined
     - >-
       oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
@@ -72,12 +76,14 @@
   loop_control:
     loop_var: opdb
     label: >-
+      cdb: {{ opdb.0.cdb | default('') }}
       port: {{ _listener_port_pdb }}
       service: {{ opdb.0.pdb_name }}
       name: {{ opdb.1.name }}
       value: {{ opdb.1.value }}
       scope: {{ opdb.1.scope | default ('both') }}
       state:{{ opdb.1.state }}"
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   register: param_change_pdb
   tags:
     - initparams
@@ -99,12 +105,14 @@
     - ""  # dummy to force odb.0 instead of item.
   when:
     - odb.0.restart_spparameter_changed | default(true)
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - restart_spparameter_changed
   loop_control:
     loop_var: odb
     label: >-
-      dbname: {{ odb.0.oracle_db_name | d('') }}
-      - {{ param_change_reboot.msg | default('restart_spparameter_changed is false') }}"
+      db_name: {{ odb.0.oracle_db_name | d('') }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
+      parameter: {{ param_change_reboot.msg | default('restart_spparameter_changed is false') }}"
   become: true
   become_user: "{{ oracle_user }}"
   register: param_change_reboot

--- a/roles/oradb_manage_pdb/tasks/main.yml
+++ b/roles/oradb_manage_pdb/tasks/main.yml
@@ -36,6 +36,7 @@
           CDB: {{ odb[1].cdb | default('') }},
           PDB: {{ odb[1].pdb_name | default('') }},
           state: {{ odb[1].state | default('') }}
+          db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
         loop_var: odb
       when:
         - oracle_databases is defined
@@ -45,3 +46,4 @@
         - odb[0].state|upper == 'PRESENT'
         - odb[1].cdb == odb[0].oracle_db_name
         - odb[0].is_container
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'

--- a/roles/oradb_manage_profiles/tasks/main.yml
+++ b/roles/oradb_manage_profiles/tasks/main.yml
@@ -30,13 +30,16 @@
       loop_control:
         loop_var: odb
         label: >-
+          db_name: {{ odb.0.oracle_db_name | default('') }}
           service: {{ _db_service_name }}:{{ _listener_port_cdb }}
           db_name: {{ odb.0.oracle_db_name }}
           Profile: {{ odb.1.name }}
           attributes: {{ odb.1.attributes }}
+          db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
       when:
         - oracle_databases is defined
         - odb.0.state == 'present'
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
         - odb.1 is defined
       run_once: "{{ _oraswgi_meta_configure_cluster }}"
       become: true
@@ -83,10 +86,12 @@
           PDB: {{ opdb.0.pdb_name }}
           Profile: {{ opdb.1.name }}
           attributes: {{ opdb.1.attributes }}
+          cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
       when:
         - oracle_pdbs is defined
         - opdb.0 is defined
         - opdb.0.state == 'present'
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
         - opdb.1 is defined
         - >-
           oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)

--- a/roles/oradb_manage_redo/tasks/main.yml
+++ b/roles/oradb_manage_redo/tasks/main.yml
@@ -27,11 +27,14 @@
         - odb.redolog_size is defined
         - odb.redolog_groups is defined
         - odb.state == 'present'
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
       become_user: "{{ oracle_user }}"
       become: true
       loop_control:
         loop_var: odb
         label: >-
+          db_name: {{ odb.oracle_db_name | default('') }}
           service: {{ _db_service_name }}:{{ _listener_port_cdb }}
-          groups: {{ odb.redolog_groups | default('') }}
-          size: {{ odb.redolog_size | default('') }}
+          groups: {{ odb.redolog_groups }}
+          size: {{ odb.redolog_size }}
+          db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}

--- a/roles/oradb_manage_roles/tasks/main.yml
+++ b/roles/oradb_manage_roles/tasks/main.yml
@@ -19,14 +19,17 @@
   when:
     - oracle_databases is defined
     - odb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - odb.1 is defined
   loop_control:
     loop_var: odb
     label: >-
+      db_name: {{ odb.0.oracle_db_name | default('') }}
       port {{ _listener_port_cdb }}
       service {{ _db_service_name }}
       role {{ odb.1.name }}
       state {{ odb.1.state }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true
   become_user: "{{ oracle_user }}"
@@ -52,6 +55,7 @@
     - oracle_pdbs is defined
     - opdb.0 is defined
     - opdb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - opdb.1 is defined
     - >-
       oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
@@ -59,10 +63,12 @@
   loop_control:
     loop_var: opdb
     label: >-
+      cdb: {{ opdb.0.cdb | default('') }}
       port: {{ _listener_port_pdb }},
       service: {{ _db_service_pdb }},
       role: {{ opdb.1.name }},
       state: {{ opdb.1.state }}
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true
   become_user: "{{ oracle_user }}"

--- a/roles/oradb_manage_services/tasks/main.yml
+++ b/roles/oradb_manage_services/tasks/main.yml
@@ -27,9 +27,11 @@
     label: >-
       database_name {{ odb.0.oracle_db_name | default('') }}
       name {{ odb.1.name | default('') }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   when:
     - oracle_databases is defined
     - odb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - odb.1 is defined
     - (odb.1.state == 'present' or odb.1.state == 'started')
   become: true

--- a/roles/oradb_manage_statspack/tasks/main.yml
+++ b/roles/oradb_manage_statspack/tasks/main.yml
@@ -29,13 +29,16 @@
       loop: "{{ oracle_databases }}"
       loop_control:
         loop_var: odb
-        label: "{{ odb.oracle_db_name }}"
+        label: >-
+          db_name: {{ odb.oracle_db_name | default('') }}
+          db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
       register: statspackdropcmd
       become: true
       become_user: "{{ oracle_user }}"
       when:
         - odb.statspack is defined
         - odb.statspack.state | default('present') == 'absent'
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
       changed_when:
         - '"Statspack dropped" in statspackdropcmd.stdout'
 
@@ -83,7 +86,9 @@
           loop: "{{ oracle_databases }}"
           loop_control:
             loop_var: odb
-            label: "{{ odb.oracle_db_name | default('') }}"
+            label: >-
+              db_name: {{ odb.oracle_db_name | default('') }}
+              db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
           register: statspackcmd
           become: true
           become_user: "{{ oracle_user }}"
@@ -93,6 +98,7 @@
             - odb.state == 'present'
             - odb.statspack is defined
             - odb.statspack.state == 'present'
+            - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
 
       rescue:
         - name: fail
@@ -133,13 +139,16 @@
   when:
     - oracle_databases is defined
     - odb.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - odb.statspack is defined
     - odb.statspack.state == 'present'
   become: true
   become_user: "{{ oracle_user }}"
   loop_control:
     loop_var: odb
-    label: "{{ odb.oracle_db_name }}"
+    label: >-
+      db_name: {{ odb.oracle_db_name | default('') }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags:
     - spjob
     - statspack
@@ -164,13 +173,16 @@
   when:
     - oracle_databases is defined
     - odb.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - odb.statspack is defined
     - odb.statspack.state == 'present'
   become: true
   become_user: "{{ oracle_user }}"
   loop_control:
     loop_var: odb
-    label: "{{ odb.oracle_db_name }}"
+    label: >-
+      db_name: {{ odb.oracle_db_name | default('') }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags:
     - spjob
     - statspack
@@ -192,8 +204,9 @@
       loop_control:
         loop_var: opdb
         label: >-
-          {{ opdb.cdb | default('') }}
-          {{ opdb.pdb_name | default('') }}
+          cdb: {{ opdb.cdb | default('') }}
+          pdb: {{ opdb.pdb_name | default('') }}
+          cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
       register: statspackdropcmd
       become: true
       become_user: "{{ oracle_user }}"
@@ -203,6 +216,7 @@
         - statspackdropcmd.rc != 0
       when:
         - oracle_pdbs is defined
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
         - opdb.statspack is defined
         - opdb.statspack.state == 'absent'
 
@@ -243,8 +257,9 @@
       loop_control:
         loop_var: opdb
         label: >-
-          {{ opdb.cdb | default('') }}
-          {{ opdb.pdb_name | default('') }}
+          cdb: {{ opdb.cdb | default('') }}
+          pdb: {{ opdb.pdb_name | default('') }}
+          cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
       register: statspackcmd
       become: true
       become_user: "{{ oracle_user }}"
@@ -253,6 +268,7 @@
       when:
         - oracle_pdbs is defined
         - opdb.cdb is defined
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
         - opdb.state == 'present'
         - opdb.statspack is defined
         - opdb.statspack.state == 'present'
@@ -292,11 +308,13 @@
   loop_control:
     loop_var: opdb
     label: >-
-      {{ opdb.cdb | default('') }}
-      {{ opdb.pdb_name | default('') }}
+      cdb: {{ opdb.cdb | default('') }}
+      pdb: {{ opdb.pdb_name | default('') }}
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   when:
     - oracle_pdbs is defined
     - opdb.cdb is defined
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - opdb.pdb_name is defined
     - opdb.state == 'present'
     - opdb.statspack is defined
@@ -330,10 +348,12 @@
   loop_control:
     loop_var: opdb
     label: >-
-      {{ opdb.cdb | default('') }}
-      {{ opdb.pdb_name | default('') }}
+      cdb: {{ opdb.cdb | default('') }}
+      pdb: {{ opdb.pdb_name | default('') }}
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   when:
     - oracle_pdbs is defined
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - opdb.cdb is defined
     - opdb.pdb_name is defined
     - opdb.state == 'present'

--- a/roles/oradb_manage_tablespace/tasks/main.yml
+++ b/roles/oradb_manage_tablespace/tasks/main.yml
@@ -37,12 +37,15 @@
       loop_control:
         loop_var: odb
         label: >-
+          db_name: {{ odb.0.oracle_db_name | default('') }}
           service: {{ _db_service_name }}:{{ _listener_port_cdb }}
           tablespace: {{ odb.1.name }}
           content: {{ odb.1.content | default(omit) }}
           state: {{ odb.1.state | default('present') }}
+          db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
       when:
         - oracle_databases is defined
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('absent') == 'present'
         - odb.1 is defined
         - odb.0.state | upper == 'PRESENT'
 
@@ -75,13 +78,16 @@
         - oracle_pdbs is defined
         - opdb.1 is defined
         - opdb.0.state == 'present'
+        - oracledb_facts[_oracle_db_unique_name]['state'] | default('absent') == 'present'
         - >-
           oracle_databases | selectattr('oracle_db_name', 'equalto', opdb.0.cdb)
           | map(attribute='state') | list | first == 'present'
       loop_control:
         loop_var: opdb
         label: >-
+          cdb: {{ opdb.0.cdb | default('') }}
           pdb: {{ opdb.0.pdb_name }}:{{ _listener_port_pdb }}
           tablespace: {{ opdb.1.name }}
           content: {{ opdb.1.content | default(omit) }}
           state: {{ opdb.1.state | default('present') }}
+          cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}

--- a/roles/oradb_manage_users/tasks/main.yml
+++ b/roles/oradb_manage_users/tasks/main.yml
@@ -28,6 +28,7 @@
   when:
     - oracle_databases is defined
     - odb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - odb.1 is defined
   run_once: "{{ _oraswgi_meta_configure_cluster }}"
   become: true
@@ -35,9 +36,11 @@
   loop_control:
     loop_var: odb
     label: >-
+      db_name: {{ odb.0.oracle_db_name | default('') }}
       service: {{ _db_service_name }}:{{ _listener_port_cdb }}
       schema: {{ odb.1.schema }}
       state: {{ odb.1.state }}
+      db_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
   tags: users
   vars:
     __user_cdb_password: >-
@@ -70,6 +73,7 @@
   when:
     - oracle_pdbs is defined
     - opdb.0.state == 'present'
+    - oracledb_facts[_oracle_db_unique_name]['state'] | default('') == 'present'
     - opdb.1 is defined
     - opdb.1.schema is defined
     - opdb.1.state is defined
@@ -81,9 +85,11 @@
   become_user: "{{ oracle_user }}"
   loop_control:
     label: >-
+      cdb: {{ opdb.0.cdb | default('') }}
       service: {{ _db_service_pdb }}
       schema: {{ opdb.1.schema }}
       state: {{ opdb.1.state }}
+      cdb_state: {{ oracledb_facts[_oracle_db_unique_name]['state'] | default('') }}
     loop_var: opdb
   tags: users
   vars:

--- a/roles/orasw_meta/tasks/assert_oracle_databases.yml
+++ b/roles/orasw_meta/tasks/assert_oracle_databases.yml
@@ -153,6 +153,8 @@
               - ass_pdb.state in ['absent', 'present']
               - ass_pdb.home is defined
               - db_homes_config[ass_pdb.home] is defined
+              - oracle_databases | selectattr('oracle_db_name', 'match', ass_pdb.cdb)
+                  | list | length == 1
           with_items:
             - "{{ oracle_pdbs }}"
           loop_control:

--- a/roles/orasw_meta_internal/README.md
+++ b/roles/orasw_meta_internal/README.md
@@ -22,6 +22,7 @@ This will create issues and problems in `ansible-oracle` and is not supported.
   - [_opdb_home](#_opdb_home)
   - [_opdb_loop_helper](#_opdb_loop_helper)
   - [_oracle_db_instance_name](#_oracle_db_instance_name)
+  - [_oracle_db_unique_name](#_oracle_db_unique_name)
   - [_oracle_ee_opiton_dict](#_oracle_ee_opiton_dict)
   - [_oracle_env](#_oracle_env)
   - [_oracle_env_pdb](#_oracle_env_pdb)
@@ -209,6 +210,18 @@ Do not set it in inventory!
 
 ```YAML
 _oracle_db_instance_name: _internal_used_
+```
+
+### _oracle_db_unique_name
+
+The variable is internal used only.
+
+Do not set it in inventory!
+
+#### Default value
+
+```YAML
+_oracle_db_unique_name: _internal_used_
 ```
 
 ### _oracle_ee_opiton_dict

--- a/roles/orasw_meta_internal/defaults/main.yml
+++ b/roles/orasw_meta_internal/defaults/main.yml
@@ -120,6 +120,20 @@ _oracle_db_instance_name: >-
     {%- endfor -%}
   {%- endif -%}
 
+# @var _oracle_db_unique_name:description: >
+# The variable is internal used only.
+#
+# Do not set it in inventory!
+# @end
+# @var _oracle_db_unique_name: $ "_internal_used_"
+_oracle_db_unique_name: >-
+  {%- if _odb_loop_helper.oracle_db_name is defined -%}
+    {{- _odb_loop_helper.oracle_db_unique_name
+      | default(_odb_loop_helper.oracle_db_name) -}}
+  {%- elif _opdb_loop_helper.cdb is defined -%}
+    {{- _db_unique_name_for_pdb -}}
+  {%- endif -%}
+
 # @var _listener_port_cdb:description: >
 # The variable is internal used only.
 #


### PR DESCRIPTION
The role oradb_facts ignores failures during fact gathering for the database, when `oradb_facts_ignore_unreachable: true` is used in item of `oracle_databases`.
The fact result is used in all other `oradb_manage_`-roles to ignore a unreachable database.

This allow an execution of roles from ansible-oracle when the database is not reachable for changes without aborting the play.