### PR TITLE
bug: extra indents in yaml blocks produce unwanted newlines

### DIFF
--- a/changelogs/fragments/420_yaml_indents.yml
+++ b/changelogs/fragments/420_yaml_indents.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "oradb_rman: Removed unwanted newlines from rman_backup.sh command line (oravirt#420)"
+  - "reviewed entire roles/ code basis and removed unwanted indents from yaml multiline blocks (oravirt#420)"

--- a/roles/oradb_rman/tasks/main.yml
+++ b/roles/oradb_rman/tasks/main.yml
@@ -311,10 +311,10 @@
   # noqa risky-shell-pipe no-changed-when
   ansible.builtin.shell: >-
     {{ oracle_base }}/bin/rman_backup.sh
-      -a {{ odb.1.name }}
-      -s {{ odb.0.oracle_db_instance_name | default(odb.0.oracle_db_name) }}
-      -r {{ oradb_rman_script_dir }}
-      -l {{ oradb_rman_log_dir }} | tee -a {{ rman_cron_logdir }}/rman_{{ odb.1.name }}.log
+    -a {{ odb.1.name }}
+    -s {{ odb.0.oracle_db_instance_name | default(odb.0.oracle_db_name) }}
+    -r {{ oradb_rman_script_dir }}
+    -l {{ oradb_rman_log_dir }} | tee -a {{ rman_cron_logdir }}/rman_{{ odb.1.name }}.log
   environment:
     PATH: /bin:/usr/bin
   become: true

--- a/roles/orasw_meta/tasks/assert_oracle_sw_patches.yml
+++ b/roles/orasw_meta/tasks/assert_oracle_sw_patches.yml
@@ -16,14 +16,14 @@
               - osp_loop.filename is defined
               - >-
                   oracle_sw_patches
-                    | selectattr('unique_patchid', 'defined')
-                    | selectattr('unique_patchid', 'equalto', osp_loop.unique_patchid | default(0))
-                    | list | length <= 1
+                  | selectattr('unique_patchid', 'defined')
+                  | selectattr('unique_patchid', 'equalto', osp_loop.unique_patchid | default(0))
+                  | list | length <= 1
               - >-
                   oracle_sw_patches
-                    | selectattr('unique_patchid', 'undefined')
-                    | selectattr('patchid', 'equalto', osp_loop.patchid)
-                    | list | length <= 1
+                  | selectattr('unique_patchid', 'undefined')
+                  | selectattr('patchid', 'equalto', osp_loop.patchid)
+                  | list | length <= 1
           with_items:
             - "{{ oracle_sw_patches }}"
           loop_control:

--- a/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
@@ -79,7 +79,7 @@
   with_items:
     - >-
       gi_patches[oracle_install_version_gi]['opatch']
-        | selectattr('state', 'equalto', 'present')
+      | selectattr('state', 'equalto', 'present')
     - ""  # loop with dummy list due to needed structure for autopatch
   loop_control:
     loop_var: gip_opatch


### PR DESCRIPTION
It showed particulary in oradb_rman role, where due to additional indents in `>-` block unwanted newlines were produced by builtin.shell command line, which caused the task to fail. Due to the syntax of commandline produced this however did not produce exitcode != 0 and was not recognised as failed by ansible.

Here is how a command looked like:

cmd: "/u01/app/oracle/bin/rman_backup.sh\\**n**  -a parameter\\**n**  -s CDB1\\**n**  -r /u01/app/oracle/rman\n  -l /u01/app/oracle/rman/log | tee -a /var/log/oracle/rman/log/rman_parameter.log"

This of course produced following output:
stdout: "Missing parameter for ORACLE_SID\n \nUsage:\n  rman_backup.sh -a <action> -s <ORACLE_SID|DB_NAME> [-r <Directory>]\n            [-l <Directory>] [-c <CATALOGCONNECT>] [-t <TARGETCONNECT>]\n            [--service <Servicename in GI/Restart>]\n  rman_backup.sh -h",

Similar problems, yet rather optical than functional have been corrected over entire roles/ code basis. Only where extra indenting was done inside {{ ... }} blocks, it has not been removed, as it did not introduce any unexpected newlines.