### PR TITLE
Release 4.7.0 - 9th Beta Release of ansible-oracle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,31 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.7.0
+======
+
+Minor Changes
+-------------
+
+- Replace run_once: _oraswgi_meta_configure_cluster with when condition (oravirt#422)
+- molecule: download for current cluvfy added (oravirt#423)
+- oracluvfy: New role for managing cluvfy (oravirt#423)
+- orahost_meta: increase defaults for memlock limits from 0.90 to 0.91 for cluvfy (oravirt#423)
+- oraswgi_install: use role oracluvfy for cluvfy during installation (oravirt#423)
+
+Bugfixes
+--------
+
+- oradb_rman: Removed unwanted newlines from rman_backup.sh command line (oravirt#420)
+- orahost: fix wrong permissions in filesystem | Create directories (oravirt#424)
+- oraswdb_install: fix broken Transfer oracle installfiles to server (oravirt#421)
+- reviewed entire roles/ code basis and removed unwanted indents from yaml multiline blocks (oravirt#420)
+
+Known Issues
+------------
+
+- RAC installation with oracle_sw_copy=true not working
+
 v4.6.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -157,4 +157,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 4.6.0
+version: 4.7.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -801,3 +801,31 @@ releases:
     - release.yml
     - ssh.yml
     release_date: '2024-03-08'
+  4.7.0:
+    changes:
+      bugfixes:
+      - 'oradb_rman: Removed unwanted newlines from rman_backup.sh command line (oravirt#420)'
+      - 'orahost: fix wrong permissions in filesystem | Create directories (oravirt#424)'
+      - 'oraswdb_install: fix broken Transfer oracle installfiles to server (oravirt#421)'
+      - reviewed entire roles/ code basis and removed unwanted indents from yaml multiline
+        blocks (oravirt#420)
+      known_issues:
+      - RAC installation with oracle_sw_copy=true not working
+      minor_changes:
+      - 'Replace run_once: _oraswgi_meta_configure_cluster with when condition (oravirt#422)'
+      - 'molecule: download for current cluvfy added (oravirt#423)'
+      - 'oracluvfy: New role for managing cluvfy (oravirt#423)'
+      - 'orahost_meta: increase defaults for memlock limits from 0.90 to 0.91 for
+        cluvfy (oravirt#423)'
+      - 'oraswgi_install: use role oracluvfy for cluvfy during installation (oravirt#423)'
+    fragments:
+    - 420_yaml_indents.yml
+    - cluvfy_oraswgi_install.yml
+    - cluvy.yml
+    - oracluvfy.yml
+    - orahost_dir.yml
+    - orahost_meta_limits.yml
+    - oraswdb_install.yml
+    - rac_known_issue.yml
+    - run_once.yml
+    release_date: '2024-04-08'

--- a/changelogs/fragments/420_yaml_indents.yml
+++ b/changelogs/fragments/420_yaml_indents.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - "oradb_rman: Removed unwanted newlines from rman_backup.sh command line (oravirt#420)"
-  - "reviewed entire roles/ code basis and removed unwanted indents from yaml multiline blocks (oravirt#420)"

--- a/changelogs/fragments/cluvfy_oraswgi_install.yml
+++ b/changelogs/fragments/cluvfy_oraswgi_install.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraswgi_install: use role oracluvfy for cluvfy during installation (oravirt#423)"

--- a/changelogs/fragments/cluvy.yml
+++ b/changelogs/fragments/cluvy.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: download for current cluvfy added (oravirt#423)"

--- a/changelogs/fragments/oracluvfy.yml
+++ b/changelogs/fragments/oracluvfy.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oracluvfy: New role for managing cluvfy (oravirt#423)"

--- a/changelogs/fragments/orahost_dir.yml
+++ b/changelogs/fragments/orahost_dir.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost: fix wrong permissions in filesystem | Create directories (oravirt#424)"

--- a/changelogs/fragments/orahost_meta_limits.yml
+++ b/changelogs/fragments/orahost_meta_limits.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "orahost_meta: increase defaults for memlock limits from 0.90 to 0.91 for cluvfy (oravirt#423)"

--- a/changelogs/fragments/oraswdb_install.yml
+++ b/changelogs/fragments/oraswdb_install.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_install: fix broken Transfer oracle installfiles to server (oravirt#421)"

--- a/changelogs/fragments/run_once.yml
+++ b/changelogs/fragments/run_once.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Replace run_once: _oraswgi_meta_configure_cluster with when condition ()"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.6.0
+version: 4.7.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.7.0
======

Minor Changes
-------------

- Replace run_once: _oraswgi_meta_configure_cluster with when condition (oravirt#422)
- molecule: download for current cluvfy added (oravirt#423)
- oracluvfy: New role for managing cluvfy (oravirt#423)
- orahost_meta: increase defaults for memlock limits from 0.90 to 0.91 for cluvfy (oravirt#423)
- oraswgi_install: use role oracluvfy for cluvfy during installation (oravirt#423)

Bugfixes
--------

- oradb_rman: Removed unwanted newlines from rman_backup.sh command line (oravirt#420)
- orahost: fix wrong permissions in filesystem | Create directories (oravirt#424)
- oraswdb_install: fix broken Transfer oracle installfiles to server (oravirt#421)
- reviewed entire roles/ code basis and removed unwanted indents from yaml multiline blocks (oravirt#420)

Known Issues
------------

- RAC installation with oracle_sw_copy=true not working

