### PR TITLE
Release 4.8.0 - 10th Beta Release of ansible-oracle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.8.0
+======
+
+Minor Changes
+-------------
+
+- oradb_manage_pdb: added missing defaults for pdbadmin_user and pdbadmin_password (oravirt#426)
+
 v4.7.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -157,4 +157,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 4.7.0
+version: 4.8.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -829,3 +829,11 @@ releases:
     - rac_known_issue.yml
     - run_once.yml
     release_date: '2024-04-08'
+  4.8.0:
+    changes:
+      minor_changes:
+      - 'oradb_manage_pdb: added missing defaults for pdbadmin_user and pdbadmin_password
+        (oravirt#426)'
+    fragments:
+    - pdbadmin.yml
+    release_date: '2024-04-16'

--- a/changelogs/fragments/pdbadmin.yml
+++ b/changelogs/fragments/pdbadmin.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_manage_pdb: added missing defaults for pdbadmin_user and pdbadmin_password (oravirt#426)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.7.0
+version: 4.8.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.8.0
======

Minor Changes
-------------

- oradb_manage_pdb: added missing defaults for pdbadmin_user and pdbadmin_password (oravirt#426)
