### PR TITLE
add oracle_sysctl_file and oracle_hugepages_sysctl_file variables

### DIFF
--- a/changelogs/fragments/sysctl.yml
+++ b/changelogs/fragments/sysctl.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "orahost: add oracle_sysctl_file and oracle_hugepages_sysctl_file variables (oravirt#432)"

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -42,10 +42,12 @@ Role to configure the hostsystem for ansible-oracle
   - [oracle_asm_packages_sles](#oracle_asm_packages_sles)
   - [oracle_groups](#oracle_groups)
   - [oracle_hugepages](#oracle_hugepages)
+  - [oracle_hugepages_sysctl_file](#oracle_hugepages_sysctl_file)
   - [oracle_ic_net](#oracle_ic_net)
   - [oracle_packages](#oracle_packages)
   - [oracle_packages_sles_multi](#oracle_packages_sles_multi)
   - [oracle_sysctl](#oracle_sysctl)
+  - [oracle_sysctl_file](#oracle_sysctl_file)
   - [oracle_users](#oracle_users)
   - [os_family_supported](#os_family_supported)
   - [os_min_supported_version](#os_min_supported_version)
@@ -65,6 +67,7 @@ Role to configure the hostsystem for ansible-oracle
 ## Requirements
 
 - Minimum Ansible version: `2.14.0`
+
 
 ## Default Variables
 
@@ -87,8 +90,7 @@ Name / Url for rpm oracleasm-support for RHEL6/OL6.
 #### Default value
 
 ```YAML
-asmlib_rpm_el6: 
-  http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.4-1.el6.x86_64.rpm
+asmlib_rpm_el6: http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.4-1.el6.x86_64.rpm
 ```
 
 ### asmlib_rpm_el7
@@ -98,8 +100,7 @@ Name / Url for rpm oracleasm-support for RHEL7/OL7.
 #### Default value
 
 ```YAML
-asmlib_rpm_el7: 
-  http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.12-1.el7.x86_64.rpm
+asmlib_rpm_el7: http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.12-1.el7.x86_64.rpm
 ```
 
 ### asmlib_rpm_el8
@@ -109,8 +110,7 @@ Name / Url for rpm oracleasm-support for RHEL8/OL8.
 #### Default value
 
 ```YAML
-asmlib_rpm_el8: 
-  https://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.17-1.el8.x86_64.rpm
+asmlib_rpm_el8: https://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.17-1.el8.x86_64.rpm
 ```
 
 ### asmlib_rpm_sles
@@ -120,8 +120,7 @@ Name / Url for rpm oracleasm-support for SLES.
 #### Default value
 
 ```YAML
-asmlib_rpm_sles: 
-  http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/sles12/amd64/2.1.8/oracleasm-support-2.1.8-1.SLE12.x86_64.rpm
+asmlib_rpm_sles: http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/sles12/amd64/2.1.8/oracleasm-support-2.1.8-1.SLE12.x86_64.rpm
 ```
 
 ### asmlibsupport_rpm
@@ -147,8 +146,7 @@ asmlibsupport_rpm: Value from `asmlibsupport_rpm_el6`, `asmlibsupport_rpm_el7` o
 #### Default value
 
 ```YAML
-asmlibsupport_rpm_el6: 
-  http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/rhel6/amd64/2.1.8/oracleasm-support-2.1.8-1.el6.x86_64.rpm
+asmlibsupport_rpm_el6: http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/rhel6/amd64/2.1.8/oracleasm-support-2.1.8-1.el6.x86_64.rpm
 ```
 
 ### asmlibsupport_rpm_el7
@@ -156,8 +154,7 @@ asmlibsupport_rpm_el6:
 #### Default value
 
 ```YAML
-asmlibsupport_rpm_el7: 
-  https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el7.x86_64.rpm
+asmlibsupport_rpm_el7: https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el7.x86_64.rpm
 ```
 
 ### asmlibsupport_rpm_el8
@@ -165,8 +162,7 @@ asmlibsupport_rpm_el7:
 #### Default value
 
 ```YAML
-asmlibsupport_rpm_el8: 
-  https://yum.oracle.com/repo/OracleLinux/OL8/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el8.x86_64.rpm
+asmlibsupport_rpm_el8: https://yum.oracle.com/repo/OracleLinux/OL8/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el8.x86_64.rpm
 ```
 
 ### configure_etc_hosts
@@ -291,8 +287,8 @@ Set IP to 2nd Interface on virtualbox and 1st for all otehr installations
 #### Default value
 
 ```YAML
-etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_all_ipv4_addresses[1]
-  }}{% else %}{{ ansible_default_ipv4.address }}{% endif %}"
+etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_all_ipv4_addresses[1]\
+  \ }}{% else %}{{ ansible_default_ipv4.address }}{% endif %}"
 ```
 
 ### extrarepos_disabled
@@ -310,8 +306,8 @@ extrarepos_disabled: '[]'
 #### Default value
 
 ```YAML
-extrarepos_enabled: "{%- if ansible_distribution == 'OracleLinux' -%}ol{{ ansible_distribution_major_version
-  }}_addons{%- else -%}{%- endif %}"
+extrarepos_enabled: "{%- if ansible_distribution == 'OracleLinux' -%}ol{{ ansible_distribution_major_version\
+  \ }}_addons{%- else -%}{%- endif %}"
 ```
 
 ### firewall_service
@@ -478,6 +474,24 @@ This is an internal variable. Do not change it!
 ```YAML
 oracle_hugepages:
   - {name: vm.nr_hugepages, value: '{{ nr_hugepages }}'}
+```
+
+### oracle_hugepages_sysctl_file
+
+Allows to specify the file in which sysctl settings for huge pages will be stored.
+When unspecified it will first fallback to be `oracle_sysctl_file`
+and then to module defaults (`/etc/sysctl.conf`) should that one also be not defined.
+
+#### Default value
+
+```YAML
+oracle_hugepages_sysctl_file: _unset_
+```
+
+#### Example usage
+
+```YAML
+oracle_hugepages_sysctl_file: '/etc/sysctl.d/oracle-hugepages.conf'
 ```
 
 ### oracle_ic_net
@@ -655,6 +669,23 @@ oracle_sysctl:
   - {name: vm.min_free_kbytes, value: 524288}
 ```
 
+### oracle_sysctl_file
+
+Allows to specify the file in which sysctl settings will be stored. When unspecified it will
+be put to `/etc/sysctl.conf` by the module defaults (omit)
+
+#### Default value
+
+```YAML
+oracle_sysctl_file: _unset_
+```
+
+#### Example usage
+
+```YAML
+oracle_sysctl_file: '/etc/sysctl.d/oracle.conf'
+```
+
 ### oracle_users
 
 oracle OS-User
@@ -677,8 +708,8 @@ Support is limited to RHE/OL and SuSE
 #### Default value
 
 ```YAML
-os_family_supported: "{% if ansible_os_family == 'Suse' %}Suse{% else %}RedHat{% endif
-  %}"
+os_family_supported: "{% if ansible_os_family == 'Suse' %}Suse{% else %}RedHat{% endif\
+  \ %}"
 ```
 
 ### os_min_supported_version
@@ -688,8 +719,8 @@ Minimum supported versions for SLES is 12.1 and RHEL/OL >= 6.4
 #### Default value
 
 ```YAML
-os_min_supported_version: "{% if ansible_os_family == 'Suse' %}12.1{% else %}6.4{%
-  endif %}"
+os_min_supported_version: "{% if ansible_os_family == 'Suse' %}12.1{% else %}6.4{%\
+  \ endif %}"
 ```
 
 ### percent_hugepages
@@ -765,6 +796,8 @@ transparent_hugepage_disable:
 
 **_hugepages_**
 
+**_iptables,firewalld_**
+
 **_molecule-idempotence-notest_**
 
 **_nozeroconf_**
@@ -790,6 +823,8 @@ transparent_hugepage_disable:
 **_sudoadd_**
 
 **_sysctl_**
+
+**_timezone_**
 
 **_tphnuma_**
 

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -68,7 +68,6 @@ Role to configure the hostsystem for ansible-oracle
 
 - Minimum Ansible version: `2.14.0`
 
-
 ## Default Variables
 
 ### asmlib_rpm
@@ -90,7 +89,8 @@ Name / Url for rpm oracleasm-support for RHEL6/OL6.
 #### Default value
 
 ```YAML
-asmlib_rpm_el6: http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.4-1.el6.x86_64.rpm
+asmlib_rpm_el6: 
+  http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.4-1.el6.x86_64.rpm
 ```
 
 ### asmlib_rpm_el7
@@ -100,7 +100,8 @@ Name / Url for rpm oracleasm-support for RHEL7/OL7.
 #### Default value
 
 ```YAML
-asmlib_rpm_el7: http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.12-1.el7.x86_64.rpm
+asmlib_rpm_el7: 
+  http://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.12-1.el7.x86_64.rpm
 ```
 
 ### asmlib_rpm_el8
@@ -110,7 +111,8 @@ Name / Url for rpm oracleasm-support for RHEL8/OL8.
 #### Default value
 
 ```YAML
-asmlib_rpm_el8: https://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.17-1.el8.x86_64.rpm
+asmlib_rpm_el8: 
+  https://download.oracle.com/otn_software/asmlib/oracleasmlib-2.0.17-1.el8.x86_64.rpm
 ```
 
 ### asmlib_rpm_sles
@@ -120,7 +122,8 @@ Name / Url for rpm oracleasm-support for SLES.
 #### Default value
 
 ```YAML
-asmlib_rpm_sles: http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/sles12/amd64/2.1.8/oracleasm-support-2.1.8-1.SLE12.x86_64.rpm
+asmlib_rpm_sles: 
+  http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/sles12/amd64/2.1.8/oracleasm-support-2.1.8-1.SLE12.x86_64.rpm
 ```
 
 ### asmlibsupport_rpm
@@ -146,7 +149,8 @@ asmlibsupport_rpm: Value from `asmlibsupport_rpm_el6`, `asmlibsupport_rpm_el7` o
 #### Default value
 
 ```YAML
-asmlibsupport_rpm_el6: http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/rhel6/amd64/2.1.8/oracleasm-support-2.1.8-1.el6.x86_64.rpm
+asmlibsupport_rpm_el6: 
+  http://oss.oracle.com/projects/oracleasm-support/dist/files/RPMS/rhel6/amd64/2.1.8/oracleasm-support-2.1.8-1.el6.x86_64.rpm
 ```
 
 ### asmlibsupport_rpm_el7
@@ -154,7 +158,8 @@ asmlibsupport_rpm_el6: http://oss.oracle.com/projects/oracleasm-support/dist/fil
 #### Default value
 
 ```YAML
-asmlibsupport_rpm_el7: https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el7.x86_64.rpm
+asmlibsupport_rpm_el7: 
+  https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el7.x86_64.rpm
 ```
 
 ### asmlibsupport_rpm_el8
@@ -162,7 +167,8 @@ asmlibsupport_rpm_el7: https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64
 #### Default value
 
 ```YAML
-asmlibsupport_rpm_el8: https://yum.oracle.com/repo/OracleLinux/OL8/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el8.x86_64.rpm
+asmlibsupport_rpm_el8: 
+  https://yum.oracle.com/repo/OracleLinux/OL8/latest/x86_64/getPackage/oracleasm-support-2.1.11-2.el8.x86_64.rpm
 ```
 
 ### configure_etc_hosts
@@ -287,8 +293,8 @@ Set IP to 2nd Interface on virtualbox and 1st for all otehr installations
 #### Default value
 
 ```YAML
-etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_all_ipv4_addresses[1]\
-  \ }}{% else %}{{ ansible_default_ipv4.address }}{% endif %}"
+etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_all_ipv4_addresses[1]
+  }}{% else %}{{ ansible_default_ipv4.address }}{% endif %}"
 ```
 
 ### extrarepos_disabled
@@ -306,8 +312,8 @@ extrarepos_disabled: '[]'
 #### Default value
 
 ```YAML
-extrarepos_enabled: "{%- if ansible_distribution == 'OracleLinux' -%}ol{{ ansible_distribution_major_version\
-  \ }}_addons{%- else -%}{%- endif %}"
+extrarepos_enabled: "{%- if ansible_distribution == 'OracleLinux' -%}ol{{ ansible_distribution_major_version
+  }}_addons{%- else -%}{%- endif %}"
 ```
 
 ### firewall_service
@@ -708,8 +714,8 @@ Support is limited to RHE/OL and SuSE
 #### Default value
 
 ```YAML
-os_family_supported: "{% if ansible_os_family == 'Suse' %}Suse{% else %}RedHat{% endif\
-  \ %}"
+os_family_supported: "{% if ansible_os_family == 'Suse' %}Suse{% else %}RedHat{% endif
+  %}"
 ```
 
 ### os_min_supported_version
@@ -719,8 +725,8 @@ Minimum supported versions for SLES is 12.1 and RHEL/OL >= 6.4
 #### Default value
 
 ```YAML
-os_min_supported_version: "{% if ansible_os_family == 'Suse' %}12.1{% else %}6.4{%\
-  \ endif %}"
+os_min_supported_version: "{% if ansible_os_family == 'Suse' %}12.1{% else %}6.4{%
+  endif %}"
 ```
 
 ### percent_hugepages
@@ -796,8 +802,6 @@ transparent_hugepage_disable:
 
 **_hugepages_**
 
-**_iptables,firewalld_**
-
 **_molecule-idempotence-notest_**
 
 **_nozeroconf_**
@@ -823,8 +827,6 @@ transparent_hugepage_disable:
 **_sudoadd_**
 
 **_sysctl_**
-
-**_timezone_**
 
 **_tphnuma_**
 

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -420,8 +420,27 @@ oracle_sysctl:
   - {name: kernel.panic_on_oops, value: 1}
   - {name: vm.min_free_kbytes, value: 524288}
 
+# @var oracle_sysctl_file:description: >
+# Allows to specify the file in which sysctl settings will be stored. When unspecified it will
+# be put to `/etc/sysctl.conf` by the module defaults (omit)
+# @end
+# @var oracle_sysctl_file: $ "_unset_"
+# @var oracle_sysctl_file:example: >
+# oracle_sysctl_file: '/etc/sysctl.d/oracle.conf'
+# @end
+
 # @var oracle_hugepages:description: >
 # This is an internal variable. Do not change it!
 # @end
 oracle_hugepages:
   - {name: vm.nr_hugepages, value: "{{ nr_hugepages }}"}
+
+# @var oracle_hugepages_sysctl_file:description: >
+# Allows to specify the file in which sysctl settings for huge pages will be stored.
+# When unspecified it will first fallback to be `oracle_sysctl_file`
+# and then to module defaults (`/etc/sysctl.conf`) should that one also be not defined.
+# @end
+# @var oracle_hugepages_sysctl_file: $ "_unset_"
+# @var oracle_hugepages_sysctl_file:example: >
+# oracle_hugepages_sysctl_file: '/etc/sysctl.d/oracle-hugepages.conf'
+# @end

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -361,7 +361,8 @@
   ansible.posix.sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
-    state: present
+    sysctl_file: "{{ item.sysctl_file | default(oracle_sysctl_file) | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
     reload: true
     ignoreerrors: true
   with_items: "{{ oracle_sysctl }}"
@@ -381,7 +382,8 @@
       ansible.posix.sysctl:
         name: "{{ item.name }}"
         value: "{{ item.value }}"
-        state: present
+        sysctl_file: "{{ item.sysctl_file | default(oracle_hugepages_sysctl_file) | default(oracle_sysctl_file) | default(omit) }}"
+        state: "{{ item.state | default('present') }}"
         reload: true
         ignoreerrors: true
       with_items: "{{ oracle_hugepages }}"
@@ -406,7 +408,8 @@
           ansible.posix.sysctl:
             name: "{{ item.name }}"
             value: "{{ item.value }}"
-            state: present
+            sysctl_file: "{{ item.sysctl_file | default(oracle_hugepages_sysctl_file) | default(oracle_sysctl_file) | default(omit) }}"
+            state: "{{ item.state | default('present') }}"
             reload: true
           with_items: "{{ oracle_hugepages }}"
 


### PR DESCRIPTION
This PR adds 2 parameters which allow to change the sysctl file in which oracle will write its main and hugepages settings:
* `oracle_sysctl_file`
* `oracle_hugepages_sysctl_file`

It also allows to specify an override directly in `oracle_sysctl`/`oracle_hugepages` by specifying one of those attributes:
* `state` - defaults to `present`, but can also accept `absent` in order to move settings from default to custom sysctl file
* `sysctl_file` - allows to change the location on per-element basis

Those additional attributes are not directly documentet as those 2 lists are considered internal and should not normally be tampered with. They are however needed should one want to move those settings from default `/etc/sysctl.conf` to for example a file under `/etc/sysctl.d/...`. Especially the `state`.

It is worth noting, that without additional variables in inventory this does not change the way this role operates in any way. It also allows to override default sysctl file location when such requirement is there.