### PR TITLE
Fix for Issue #428: default_gipass is not required if sysasmpassword and asmmonitorpassword are set

### DIFF
--- a/changelogs/fragments/gipass.yml
+++ b/changelogs/fragments/gipass.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "default_gipass is not required if sysasmpassword and asmmonitorpassword are set (oravirt#433)"
+  

--- a/roles/oraswgi_install/tasks/assert.yml
+++ b/roles/oraswgi_install/tasks/assert.yml
@@ -3,7 +3,8 @@
   ansible.builtin.assert:
     quiet: true
     that:
-      - default_gipass | length > 0
+      - default_gipass | length > 0 or sysasmpassword | default('',true) | length > 0
+      - default_gipass | length > 0 or asmmonitorpassword | default('',true) | length > 0
       - oracle_install_version_gi is defined
       - oracle_gi_cluster_type in ('STANDARD', 'STANDALONE')
   tags: always


### PR DESCRIPTION
default_gipass is a default for sysasmpassword or asmmonitorpassword. If both, sysasmpassword and asmmonitorpassword are set, it's not required to set default_gipass too. Thus missing default_gipass shouldn't fail assertion in that case.