### PR TITLE
Add a list of additional hosts to /etc/hosts

### DIFF
--- a/changelogs/fragments/etc_hosts.yml
+++ b/changelogs/fragments/etc_hosts.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "orahost: Add a list of additional hosts to /etc/hosts (oravirt#447)"

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -26,6 +26,7 @@ Role to configure the hostsystem for ansible-oracle
   - [disable_firewall](#disable_firewall)
   - [disable_numa_boot](#disable_numa_boot)
   - [disable_selinux](#disable_selinux)
+  - [etc_hosts_entries](#etc_hosts_entries)
   - [etc_hosts_ip](#etc_hosts_ip)
   - [extrarepos_disabled](#extrarepos_disabled)
   - [extrarepos_enabled](#extrarepos_enabled)
@@ -282,6 +283,31 @@ disable_numa_boot: true
 
 ```YAML
 disable_selinux: true
+```
+
+### etc_hosts_entries
+
+List of additional entries, optionally along with aliases, to be put into /etc/hosts. E.g. on non-DNS environments or if we don't rely on DNS
+
+#### Default value
+
+```YAML
+etc_hosts_entries: []
+```
+
+#### Example usage
+
+```YAML
+etc_hosts_entries:
+  - fqdn: clusternode1.example.com
+    ip: 192.168.1.1
+  - fqdn: clusternode2.example.com
+    ip: 192.168.1.2
+    aliases:
+      - myalias.example.com
+would create following entries in /etc/hosts:
+192.168.1.1 clusternode1  clusternode1.example.com
+192.168.1.2 clusternode2  clusternode2.example.com  myalias.example.com
 ```
 
 ### etc_hosts_ip

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -139,6 +139,23 @@ sudoers_template: sudoers.j2
 # @end
 etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_all_ipv4_addresses[1] }}{% else %}{{ ansible_default_ipv4.address }}{% endif %}"
 
+# @var etc_hosts_entries:description: >
+# List of additional entries, optionally along with aliases, to be put into /etc/hosts. E.g. on non-DNS environments or if we don't rely on DNS
+# @end
+# @var etc_hosts_entries:example: >
+# etc_hosts_entries:
+#   - fqdn: clusternode1.example.com
+#     ip: 192.168.1.1
+#   - fqdn: clusternode2.example.com
+#     ip: 192.168.1.2
+#     aliases:
+#       - myalias.example.com
+# would create following entries in /etc/hosts:
+# 192.168.1.1 clusternode1  clusternode1.example.com
+# 192.168.1.2 clusternode2  clusternode2.example.com  myalias.example.com
+# @end
+etc_hosts_entries: []
+
 # Extra repositories that should be enabled
 extrarepos_enabled: "{%- if ansible_distribution == 'OracleLinux' -%}\
                           ol{{ ansible_distribution_major_version }}_addons\

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -45,6 +45,25 @@
   when: configure_etc_hosts
   tags: etchosts
 
+- name: Add manually defined hosts to /etc/hosts
+  # e.g. on non-DNS environments or if we don't rely on DNS
+  ansible.builtin.lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ __orahost_etc_hosts_entry.fqdn }}$'
+    line:
+      "{{ __orahost_etc_hosts_entry.ip }}
+      {{ (__orahost_etc_hosts_entry.fqdn|split('.'))[0] }}
+      {{ __orahost_etc_hosts_entry.fqdn is search('\\.') | ternary(__orahost_etc_hosts_entry.fqdn, '') }}\
+      {% for alias in __orahost_etc_hosts_entry.aliases|default([]) %} {{ alias }}{% endfor %} # ANSIBLE managed"
+    state: present
+  loop: "{{ etc_hosts_entries }}"
+  loop_control:
+    loop_var: __orahost_etc_hosts_entry
+  when:
+    - configure_etc_hosts
+    - etc_hosts_entries|type_debug == "list"
+  tags: etchosts
+
 #  - name: Add local node's ip & hostname to /etc/hosts
 #    lineinfile: dest=/etc/hosts line="{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }} " state=present
 #    when: configure_etc_hosts and ansible_default_ipv4.address is defined


### PR DESCRIPTION
Adds  manually configured host entires to /etc/hosts, optionally along with host aliases 