### PR TITLE
Enable calculation of several kernel parameters

### DIFF
--- a/changelogs/fragments/orahost_meta_kernel.yml
+++ b/changelogs/fragments/orahost_meta_kernel.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "orahost_meta: Enable calculation of several kernel parameters (oravirt#451)"

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -34,6 +34,7 @@ Role to configure the hostsystem for ansible-oracle
   - [host_fs_layout](#host_fs_layout)
   - [install_os_packages](#install_os_packages)
   - [keyfile](#keyfile)
+  - [max_size_in_gb_hugepages](#max_size_in_gb_hugepages)
   - [nr_hugepages](#nr_hugepages)
   - [nr_hugepages_memory](#nr_hugepages_memory)
   - [nr_hugepages_percent](#nr_hugepages_percent)
@@ -379,6 +380,16 @@ install_os_packages: true
 
 ```YAML
 keyfile: /tmp/known_hosts
+```
+
+### max_size_in_gb_hugepages
+
+Cap HugePages to 70% of physical memory to prevent overcomitting. Only valid when configure_hugepages_by: memory
+
+#### Default value
+
+```YAML
+max_size_in_gb_hugepages: '{{ ansible_memtotal_mb / 1024 * 0.7 }}'
 ```
 
 ### nr_hugepages

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -72,11 +72,15 @@ max_size_in_gb_hugepages: "{{ ansible_memtotal_mb / 1024 * 0.7 }}"
 
 # @var nr_hugepages_percent:description: This is an internal variable only. Do not define it!
 # @var nr_hugepages_percent: $ "_unset_"
-nr_hugepages_percent: "{{ ((((percent_hugepages / 100) * ansible_memtotal_mb) * 1024**2 / hugepage_size_bytes|int ) + (oracle_nr_instances|int * 2)) | round | int }}"
+nr_hugepages_percent: |-
+  {{ ((((percent_hugepages / 100) * ansible_memtotal_mb) * 1024**2 / hugepage_size_bytes | int)
+  + (oracle_nr_instances | int * 2)) | round | int }}
 
 # @var nr_hugepages_memory:description: This is an internal variable only. Do not define it!
 # @var nr_hugepages_memory: $ "_unset_"
-nr_hugepages_memory: "{{ ((([ size_in_gb_hugepages|int, max_size_in_gb_hugepages|int ] | min | int ) * 1024**3 / hugepage_size_bytes|int ) + (oracle_nr_instances|int * 2)) | int }}"
+nr_hugepages_memory: |-
+  {{ ((([ size_in_gb_hugepages | int, max_size_in_gb_hugepages | int ] | min | int ) * 1024**3 / hugepage_size_bytes | int)
+  + (oracle_nr_instances | int * 2)) | int }}
 
 # @var nr_hugepages:description: >
 # This is an internal variable only. Do not define it!

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -65,13 +65,18 @@ percent_hugepages: 50
 # @end
 size_in_gb_hugepages: 1
 
+# @var max_size_in_gb_hugepages:description: >
+# Cap HugePages to 70% of physical memory to prevent overcomitting. Only valid when configure_hugepages_by: memory
+# @end
+max_size_in_gb_hugepages: "{{ ansible_memtotal_mb / 1024 * 0.7 }}"
+
 # @var nr_hugepages_percent:description: This is an internal variable only. Do not define it!
 # @var nr_hugepages_percent: $ "_unset_"
-nr_hugepages_percent: "{{ ((((percent_hugepages / 100) * ansible_memtotal_mb) / 2) + 2) | round | int }}"
+nr_hugepages_percent: "{{ ((((percent_hugepages / 100) * ansible_memtotal_mb) * 1024**2 / hugepage_size_bytes|int ) + (oracle_nr_instances|int * 2)) | round | int }}"
 
 # @var nr_hugepages_memory:description: This is an internal variable only. Do not define it!
 # @var nr_hugepages_memory: $ "_unset_"
-nr_hugepages_memory: "{{ (((size_in_gb_hugepages * 1024) / 2) + 2) | round | int }}"
+nr_hugepages_memory: "{{ ((([ size_in_gb_hugepages|int, max_size_in_gb_hugepages|int ] | min | int ) * 1024**3 / hugepage_size_bytes|int ) + (oracle_nr_instances|int * 2)) | int }}"
 
 # @var nr_hugepages:description: >
 # This is an internal variable only. Do not define it!

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -18,12 +18,14 @@ Meta role used by other roles to share variable defaults.
   - [oper_group](#oper_group)
   - [oracle_group](#oracle_group)
   - [oracle_inventory_loc](#oracle_inventory_loc)
+  - [oracle_nr_bg_processes](#oracle_nr_bg_processes)
   - [oracle_rsp_stage](#oracle_rsp_stage)
   - [oracle_seclimits](#oracle_seclimits)
   - [oracle_stage](#oracle_stage)
   - [oracle_user](#oracle_user)
   - [oracle_user_home](#oracle_user_home)
   - [role_separation](#role_separation)
+  - [sysctl_kernel_sem_force](#sysctl_kernel_sem_force)
 - [Discovered Tags](#discovered-tags)
 - [Dependencies](#dependencies)
 - [License](#license)
@@ -208,6 +210,16 @@ Directory for central Oracle Inventory.
 oracle_inventory_loc: /u01/app/oraInventory
 ```
 
+### oracle_nr_bg_processes
+
+Estimated number of background processes of an Oracle instance. Used to calculate kernel SEMMNS
+
+#### Default value
+
+```YAML
+oracle_nr_bg_processes: 130
+```
+
 ### oracle_rsp_stage
 
 Defines the directory for response files for installation.
@@ -284,11 +296,24 @@ See `grid_user` and `oracle_user` for Grid-Infrastructure user.
 role_separation: false
 ```
 
+### sysctl_kernel_sem_force
+
+Force setting kernel.sem depending on configured instances
+(collections: oracle_databases, oracle_asm_instance), even if calculated values are lower than current ones
+
+#### Default value
+
+```YAML
+sysctl_kernel_sem_force: false
+```
+
 ## Discovered Tags
 
 **_always_**
 
 **_assert_ansible_oracle_**
+
+**_molecule-notest_**
 
 
 ## Dependencies

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -130,3 +130,11 @@ asm_diskgroups: []
 #    disk:
 #      - {device: /dev/sdg, asmlabel: fra01}
 # @end
+
+# @var oracle_nr_bg_processes:description: Estimated number of background processes of an Oracle instance. Used to calculate kernel SEMMNS
+oracle_nr_bg_processes: 130
+# @var sysctl_kernel_sem_force:description: >
+# Force setting kernel.sem depending on configured instances
+# (collections: oracle_databases, oracle_asm_instance), even if calculated values are lower than current ones
+sysctl_kernel_sem_force: false
+# @end

--- a/roles/orahost_meta/tasks/aggregate_processes.yml
+++ b/roles/orahost_meta/tasks/aggregate_processes.yml
@@ -1,12 +1,15 @@
 ---
-- name: Pick processes parameter
+- name: aggregate_processes | Pick processes parameter
   ansible.builtin.set_fact:
-     __orahost_oracle_database_processes: "{{ (__orahost_oracle_database.init_parameters | selectattr('name','equalto','processes'))[0].value }}"
+    __orahost_oracle_database_processes: |
+      {{ (__orahost_oracle_database.init_parameters | selectattr('name', 'equalto', 'processes'))[0].value }}
 
-- name: Sum up processes
+- name: aggregate_processes | Sum up processes
   ansible.builtin.set_fact:
-    oracle_databases_processes_sum: "{{ ( oracle_databases_processes_sum | default(0) | int ) + ( __orahost_oracle_database_processes | int ) }}"
+    oracle_databases_processes_sum: |
+      {{ (oracle_databases_processes_sum | default(0) | int) + (__orahost_oracle_database_processes | int) }}
 
-- name: Calc max processes
+- name: aggregate_processes | Calc max processes
   ansible.builtin.set_fact:
-    oracle_databases_processes_max: "{{ [( oracle_databases_processes_max | default(0) | int ),( __orahost_oracle_database_processes | int )] | max }}"
+    oracle_databases_processes_max: >-
+      {{ [(oracle_databases_processes_max | default(0) | int), (__orahost_oracle_database_processes | int)] | max }}

--- a/roles/orahost_meta/tasks/aggregate_processes.yml
+++ b/roles/orahost_meta/tasks/aggregate_processes.yml
@@ -1,0 +1,12 @@
+---
+- name: Pick processes parameter
+  ansible.builtin.set_fact:
+     __orahost_oracle_database_processes: "{{ (__orahost_oracle_database.init_parameters | selectattr('name','equalto','processes'))[0].value }}"
+
+- name: Sum up processes
+  ansible.builtin.set_fact:
+    oracle_databases_processes_sum: "{{ ( oracle_databases_processes_sum | default(0) | int ) + ( __orahost_oracle_database_processes | int ) }}"
+
+- name: Calc max processes
+  ansible.builtin.set_fact:
+    oracle_databases_processes_max: "{{ [( oracle_databases_processes_max | default(0) | int ),( __orahost_oracle_database_processes | int )] | max }}"

--- a/roles/orahost_meta/tasks/aggregate_sgas.yml
+++ b/roles/orahost_meta/tasks/aggregate_sgas.yml
@@ -1,24 +1,30 @@
 ---
-- name: Reset __orahost_oracle_database_sga
+- name: aggregate_sgas | Reset __orahost_oracle_database_sga
   ansible.builtin.set_fact:
     __orahost_oracle_database_sga: "0"
 
-- name: sga_max_size preceeds sga_target
+- name: aggregate_sgas | sga_max_size preceeds sga_target
   block:
-    - name: Derive SGA size from sga_max_size
+    - name: aggregate_sgas | Derive SGA size from sga_max_size
       ansible.builtin.set_fact:
-        __orahost_oracle_database_sga: "{{ (__orahost_oracle_database.init_parameters | selectattr('name','equalto','sga_max_size'))[0].value | default(0) | human_to_bytes }}"
+        __orahost_oracle_database_sga: |
+          {{ (__orahost_oracle_database.init_parameters
+          | selectattr('name','equalto', 'sga_max_size'))[0].value | default(0) | human_to_bytes }}
 
-    - name: Derive SGA size from sga_target
+    - name: aggregate_sgas | Derive SGA size from sga_target
       ansible.builtin.set_fact:
-        __orahost_oracle_database_sga: "{{ (__orahost_oracle_database.init_parameters | selectattr('name','equalto','sga_target'))[0].value | default(0) | human_to_bytes }}"
+        __orahost_oracle_database_sga: |
+          {{ (__orahost_oracle_database.init_parameters
+          | selectattr('name','equalto', 'sga_target'))[0].value | default(0) | human_to_bytes }}
       when:
         - __orahost_oracle_database_sga == "0"
 
-- name: Sum up SGAs
+- name: aggregate_sgas | Sum up SGAs
   ansible.builtin.set_fact:
-    oracle_databases_sga_sum: "{{ ( oracle_databases_sga_sum | default(0) | int ) + ( __orahost_oracle_database_sga | int ) }}"
+    oracle_databases_sga_sum: |
+      {{ (oracle_databases_sga_sum | default(0) | int) + (__orahost_oracle_database_sga | int) }}
 
-- name: Calc max SGA
+- name: aggregate_sgas | Calc max SGA
   ansible.builtin.set_fact:
-    oracle_databases_sga_max: "{{ [( oracle_databases_sga_max | default(0) | int ),( __orahost_oracle_database_sga | int )] | max }}"
+    oracle_databases_sga_max: |
+      {{ [(oracle_databases_sga_max | default(0) | int), (__orahost_oracle_database_sga | int)] | max }}"

--- a/roles/orahost_meta/tasks/aggregate_sgas.yml
+++ b/roles/orahost_meta/tasks/aggregate_sgas.yml
@@ -1,0 +1,24 @@
+---
+- name: Reset __orahost_oracle_database_sga
+  ansible.builtin.set_fact:
+    __orahost_oracle_database_sga: "0"
+
+- name: sga_max_size preceeds sga_target
+  block:
+    - name: Derive SGA size from sga_max_size
+      ansible.builtin.set_fact:
+        __orahost_oracle_database_sga: "{{ (__orahost_oracle_database.init_parameters | selectattr('name','equalto','sga_max_size'))[0].value | default(0) | human_to_bytes }}"
+
+    - name: Derive SGA size from sga_target
+      ansible.builtin.set_fact:
+        __orahost_oracle_database_sga: "{{ (__orahost_oracle_database.init_parameters | selectattr('name','equalto','sga_target'))[0].value | default(0) | human_to_bytes }}"
+      when:
+        - __orahost_oracle_database_sga == "0"
+
+- name: Sum up SGAs
+  ansible.builtin.set_fact:
+    oracle_databases_sga_sum: "{{ ( oracle_databases_sga_sum | default(0) | int ) + ( __orahost_oracle_database_sga | int ) }}"
+
+- name: Calc max SGA
+  ansible.builtin.set_fact:
+    oracle_databases_sga_max: "{{ [( oracle_databases_sga_max | default(0) | int ),( __orahost_oracle_database_sga | int )] | max }}"

--- a/roles/orahost_meta/tasks/calculate_kernel_semaphores.yml
+++ b/roles/orahost_meta/tasks/calculate_kernel_semaphores.yml
@@ -1,0 +1,45 @@
+---
+- name: Get current kernel.sem
+  ansible.builtin.command:
+    cmd: "sysctl kernel.sem"
+  changed_when: false
+  register: __orahost_current_kernel_sem
+
+- name: Split current kernel.sem into it's parts
+  ansible.builtin.set_fact:
+    __orahost_current_semmsl: "{{ (__orahost_current_kernel_sem.stdout | split())[2] }}"
+    __orahost_current_semmns: "{{ (__orahost_current_kernel_sem.stdout | split())[3] }}"
+    __orahost_current_semopm: "{{ (__orahost_current_kernel_sem.stdout | split())[4] }}"
+    __orahost_current_semmni: "{{ (__orahost_current_kernel_sem.stdout | split())[5] }}"
+
+- name: Calculate processes based semaphore values
+  # SEMMSL: largest processes value plus 10 Doc ID 187405.1
+  # SEMMNS: (processes * 2) + ( bg_processes * instances ) + system (10%)
+  ansible.builtin.set_fact:
+    __orahost_kernel_semmsl: "{{ oracle_databases_processes_max | int + 10 }}"
+    __orahost_kernel_semmns: "{{ ((( oracle_databases_processes_sum | int * 2 ) + ( oracle_nr_bg_processes * oracle_nr_instances | int )) * 1.1 ) | round(0,'ceil') | int }}"
+
+- name: Calculate semaphore value based semaphore values
+  # SEMOPM: min(SEMMSL,1000)
+  # SEMMNI: SEMMNS/SEMMSL rounded up to the nearest multiple of 1024
+  ansible.builtin.set_fact:
+    __orahost_kernel_semopm: "{{ [ __orahost_kernel_semmsl|int,1000 ] | min }}"
+    __orahost_kernel_semmni: "{{ (( __orahost_kernel_semmns | int / __orahost_kernel_semmsl | int / 1024 ) | round(0,'ceil') * 1024) | int }}"
+
+- name: Increase kernel.sem, if set too low
+  ansible.builtin.set_fact:
+    sysctl_kernel_sem:
+      "{{ [ __orahost_kernel_semmsl | int, __orahost_current_semmsl | int ] | max }}
+      {{ [ __orahost_kernel_semmns | int, __orahost_current_semmns | int ] | max }}
+      {{ [ __orahost_kernel_semopm | int, __orahost_current_semopm | int ] | max }}
+      {{ [ __orahost_kernel_semmni | int, __orahost_current_semmni | int ] | max }}"
+  when: not sysctl_kernel_sem_force
+
+- name: Force kernel.sem settings
+  ansible.builtin.set_fact:
+    sysctl_kernel_sem:
+      "{{ __orahost_kernel_semmsl }}
+      {{ __orahost_kernel_semmns }}
+      {{ __orahost_kernel_semopm }}
+      {{ __orahost_kernel_semmni }}"
+  when: sysctl_kernel_sem_force

--- a/roles/orahost_meta/tasks/calculate_kernel_semaphores.yml
+++ b/roles/orahost_meta/tasks/calculate_kernel_semaphores.yml
@@ -1,45 +1,51 @@
 ---
-- name: Get current kernel.sem
+- name: calculate_kernel_semaphores | Get current kernel.sem
   ansible.builtin.command:
     cmd: "sysctl kernel.sem"
   changed_when: false
   register: __orahost_current_kernel_sem
 
-- name: Split current kernel.sem into it's parts
+- name: calculate_kernel_semaphores | Split current kernel.sem into it's parts
   ansible.builtin.set_fact:
     __orahost_current_semmsl: "{{ (__orahost_current_kernel_sem.stdout | split())[2] }}"
     __orahost_current_semmns: "{{ (__orahost_current_kernel_sem.stdout | split())[3] }}"
     __orahost_current_semopm: "{{ (__orahost_current_kernel_sem.stdout | split())[4] }}"
     __orahost_current_semmni: "{{ (__orahost_current_kernel_sem.stdout | split())[5] }}"
 
-- name: Calculate processes based semaphore values
+- name: calculate_kernel_semaphores | Calculate processes based semaphore values
   # SEMMSL: largest processes value plus 10 Doc ID 187405.1
   # SEMMNS: (processes * 2) + ( bg_processes * instances ) + system (10%)
   ansible.builtin.set_fact:
-    __orahost_kernel_semmsl: "{{ oracle_databases_processes_max | int + 10 }}"
-    __orahost_kernel_semmns: "{{ ((( oracle_databases_processes_sum | int * 2 ) + ( oracle_nr_bg_processes * oracle_nr_instances | int )) * 1.1 ) | round(0,'ceil') | int }}"
+    __orahost_kernel_semmsl: >-
+      {{ oracle_databases_processes_max is defined
+      | ternary((oracle_databases_processes_max | int + 10), omit) }}
+    __orahost_kernel_semmns: >-
+      {{ (((oracle_databases_processes_sum | int * 2)
+      + (oracle_nr_bg_processes * oracle_nr_instances | int)) * 1.1) | round(0, 'ceil') | int }}
 
-- name: Calculate semaphore value based semaphore values
+- name: calculate_kernel_semaphores | Calculate semaphore value based semaphore values
   # SEMOPM: min(SEMMSL,1000)
   # SEMMNI: SEMMNS/SEMMSL rounded up to the nearest multiple of 1024
   ansible.builtin.set_fact:
-    __orahost_kernel_semopm: "{{ [ __orahost_kernel_semmsl|int,1000 ] | min }}"
-    __orahost_kernel_semmni: "{{ (( __orahost_kernel_semmns | int / __orahost_kernel_semmsl | int / 1024 ) | round(0,'ceil') * 1024) | int }}"
+    __orahost_kernel_semopm: |
+      {{ [__orahost_kernel_semmsl | int, 1000] | min }}
+    __orahost_kernel_semmni: |
+      {{ ((__orahost_kernel_semmns | int / __orahost_kernel_semmsl | int / 1024) | round(0, 'ceil') * 1024) | int }}
 
-- name: Increase kernel.sem, if set too low
+- name: calculate_kernel_semaphores | Increase kernel.sem, if set too low
   ansible.builtin.set_fact:
-    sysctl_kernel_sem:
-      "{{ [ __orahost_kernel_semmsl | int, __orahost_current_semmsl | int ] | max }}
-      {{ [ __orahost_kernel_semmns | int, __orahost_current_semmns | int ] | max }}
-      {{ [ __orahost_kernel_semopm | int, __orahost_current_semopm | int ] | max }}
-      {{ [ __orahost_kernel_semmni | int, __orahost_current_semmni | int ] | max }}"
+    sysctl_kernel_sem: >-
+      {{ [__orahost_kernel_semmsl | int, __orahost_current_semmsl | int] | max }}
+      {{ [__orahost_kernel_semmns | int, __orahost_current_semmns | int] | max }}
+      {{ [__orahost_kernel_semopm | int, __orahost_current_semopm | int] | max }}
+      {{ [__orahost_kernel_semmni | int, __orahost_current_semmni | int] | max }}
   when: not sysctl_kernel_sem_force
 
-- name: Force kernel.sem settings
+- name: calculate_kernel_semaphores | Force kernel.sem settings
   ansible.builtin.set_fact:
-    sysctl_kernel_sem:
-      "{{ __orahost_kernel_semmsl }}
+    sysctl_kernel_sem: >-
+      {{ __orahost_kernel_semmsl }}
       {{ __orahost_kernel_semmns }}
       {{ __orahost_kernel_semopm }}
-      {{ __orahost_kernel_semmni }}"
+      {{ __orahost_kernel_semmni }}
   when: sysctl_kernel_sem_force

--- a/roles/orahost_meta/tasks/main.yml
+++ b/roles/orahost_meta/tasks/main.yml
@@ -27,36 +27,44 @@
 - name: Determine kernel.panic setting
   block:
     - name: Get kdump state
-      ansible.builtin.command:
-        cmd: "systemctl is-active kdump"
-      failed_when: false
-      changed_when: false
+      ansible.builtin.systemd:
+        name: kdump
       register: __orahost_kdump_state
 
     - name: Set/unset kernel.panic according to kdump state
       ansible.builtin.set_fact:
-        sysctl_kernel_panic: "{{ (__orahost_kdump_state.stdout=='active') | ternary(0,1) }}"
+        sysctl_kernel_panic: |
+          {{ (__orahost_kdump_state.status.ActiveState == 'active') | ternary(0, 1) }}
 
 - name: Calculate SGA aggregates
   ansible.builtin.include_tasks: aggregate_sgas.yml
-  loop: "{{ (( oracle_databases | default ([]) | selectattr('init_parameters','defined') ) + ( oracle_asm_instance | default ([]) )) | lower }}"
+  loop: |
+    {{ (( oracle_databases | default ([]) | selectattr('init_parameters','defined') )
+    + ( oracle_asm_instance | default ([]) )) | lower }}
   loop_control:
     loop_var: __orahost_oracle_database
+    label: >-
+      oracle_db_name: {{ __orahost_oracle_database.oracle_db_name | default('') }}
   when:
     "'sga_target' in __orahost_oracle_database.init_parameters | map(attribute='name') or
     'sga_max_size' in __orahost_oracle_database.init_parameters | map(attribute='name') "
 
 - name: Calculate processes aggregates
   ansible.builtin.include_tasks: aggregate_processes.yml
-  loop: "{{ (( oracle_databases | default ([]) | selectattr('init_parameters','defined') ) + ( oracle_asm_instance | default ([]) )) | lower }}"
+  loop: |
+    {{ (( oracle_databases | default ([]) | selectattr('init_parameters','defined') )
+    + ( oracle_asm_instance | default ([]) )) | lower }}
   loop_control:
     loop_var: __orahost_oracle_database
+    label: >-
+      oracle_db_name: {{ __orahost_oracle_database.oracle_db_name | default('') }}
   when:
     "'processes' in __orahost_oracle_database.init_parameters | map(attribute='name')"
 
 - name: Count number of instances (including ASM)
   ansible.builtin.set_fact:
-    oracle_nr_instances: "{{ oracle_databases | default({}) | length + oracle_asm_instance | default({}) | length }}"
+    oracle_nr_instances: |
+      {{ oracle_databases | default({}) | length + oracle_asm_instance | default({}) | length }}
 
 - name: Get system's pagesize
   block:
@@ -82,5 +90,8 @@
       ansible.builtin.set_fact:
         hugepage_size_bytes: "{{ (__orahost_hugepagesize_result.stdout | split())[1] | int * 1024 }}"
 
+# Kernelsettings are not availible in molecule
 - name: Calculate kernel.sem
   ansible.builtin.include_tasks: calculate_kernel_semaphores.yml
+  tags:
+    - molecule-notest

--- a/roles/orahost_meta/tasks/main.yml
+++ b/roles/orahost_meta/tasks/main.yml
@@ -21,3 +21,66 @@
     _orasw_meta_primary_node: "{{ groups[orasw_meta_cluster_hostgroup][0] == inventory_hostname }}"
   when:
     - oracle_install_option_gi == 'CRS_CONFIG'
+
+### Determine kernel.panic according to Doc ID 2821641.1
+# kdump state cannot savely be retrieved from service_facts
+- name: Determine kernel.panic setting
+  block:
+    - name: Get kdump state
+      ansible.builtin.command:
+        cmd: "systemctl is-active kdump"
+      failed_when: false
+      changed_when: false
+      register: __orahost_kdump_state
+
+    - name: Set/unset kernel.panic according to kdump state
+      ansible.builtin.set_fact:
+        sysctl_kernel_panic: "{{ (__orahost_kdump_state.stdout=='active') | ternary(0,1) }}"
+
+- name: Calculate SGA aggregates
+  ansible.builtin.include_tasks: aggregate_sgas.yml
+  loop: "{{ (( oracle_databases | default ([]) | selectattr('init_parameters','defined') ) + ( oracle_asm_instance | default ([]) )) | lower }}"
+  loop_control:
+    loop_var: __orahost_oracle_database
+  when:
+    "'sga_target' in __orahost_oracle_database.init_parameters | map(attribute='name') or
+    'sga_max_size' in __orahost_oracle_database.init_parameters | map(attribute='name') "
+
+- name: Calculate processes aggregates
+  ansible.builtin.include_tasks: aggregate_processes.yml
+  loop: "{{ (( oracle_databases | default ([]) | selectattr('init_parameters','defined') ) + ( oracle_asm_instance | default ([]) )) | lower }}"
+  loop_control:
+    loop_var: __orahost_oracle_database
+  when:
+    "'processes' in __orahost_oracle_database.init_parameters | map(attribute='name')"
+
+- name: Count number of instances (including ASM)
+  ansible.builtin.set_fact:
+    oracle_nr_instances: "{{ oracle_databases | default({}) | length + oracle_asm_instance | default({}) | length }}"
+
+- name: Get system's pagesize
+  block:
+    - name: Read PAGE_SIZE
+      ansible.builtin.command:
+        cmd: "getconf PAGE_SIZE"
+      changed_when: false
+      register: __orahost_pagesize_result
+
+    - name: Provide PAGE_SIZE variable
+      ansible.builtin.set_fact:
+        page_size_bytes: "{{ __orahost_pagesize_result.stdout }}"
+
+- name: Get system's Hugepagesize
+  block:
+    - name: Read Hugepagesize
+      ansible.builtin.command:
+        cmd: 'grep -Pi "\bHugepagesize\b" /proc/meminfo'
+      changed_when: false
+      register: __orahost_hugepagesize_result
+
+    - name: Provide hugepagesize variable
+      ansible.builtin.set_fact:
+        hugepage_size_bytes: "{{ (__orahost_hugepagesize_result.stdout | split())[1] | int * 1024 }}"
+
+- name: Calculate kernel.sem
+  ansible.builtin.include_tasks: calculate_kernel_semaphores.yml


### PR DESCRIPTION
Changes:
* `max_size_in_gb_hugepages`: When `configure_hugepages_by: memory`, limit GB of hugepages to a percentage of physical memory to prevent overallocating
* `nr_hugepages_percent`: Replace fixed hugepage size (2MB) by system's actual hugepage size (just in case it changes) and add two pages *per instance*, which is empirically better than just two pages overall
* `nr_hugepages_memory': Same as `nr_hugepages_percent`, plus hugepages cap `max_size_in_gb_hugepages`

Enhancements:
* Provides a few aggregates man can use to calculate kernel parameters, i.e.
  * `oracle_databases_processes_sum`: Sum of processes init-Parameter over all databases
  * `oracle_databases_processes_max`: Largest processes init-Parameter over all databases
  * `oracle_databases_sga_sum`: Sum of max(sga_target, sga_max_size) init-Parameter over all databases
  * `oracle_databases_sga_max`: Largest max(sga_target, sga_max_size) init-Parameter over all databases
  * `sysctl_kernel_sem`: kernel.sem based on processes init-Parameters (increases values only, unless `sysctl_kernel_sem_force==true`
  * `sysctl_kernel_panic`:  0 or 1, according to system's kdump state

*Note (1)*: Kernel paramers are no actually set by these changes. Aggregates rather can be used to e.g. configure `oracle_sysctl` list or `size_in_gb_hugepages`.

Example:
```yaml
size_in_gb_hugepages: "{{ oracle_databases_sga_sum | default(0) | int / 1024**3 }}"
oracle_sysctl:
  - name: kernel.panic # sysctl_kernel_panic defined by orahost_meta
    value: "{{ sysctl_kernel_panic }}"
  - name: kernel.sem
    value: "{{ sysctl_kernel_sem }}"
  - name: kernel.shmall # Doc ID 301830.1
    value: "{{ (( oracle_databases_sga_sum | default(0) | int ) / ( page_size_bytes | int )) | int }}"
```

*Note (2)*: ASM instance should be described if it's forced to use hugepages:
```yaml
oracle_asm_instance:
  - init_parameters:
      - name: sga_target
        value: 4G
      - name: processes
        value: "{{ (oracle_databases | default([])) | length * 450 + 50 }}"
```