### PR TITLE
Enhancement#452 oracle script env

### DIFF
--- a/changelogs/fragments/orahost_meta_env.yml
+++ b/changelogs/fragments/orahost_meta_env.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "set custom environment for executables with oracle_script_env (oravirt#453)"
+  - "orahost_meta: added oracle_tmp_stage for hardened systems (oravirt#453)"

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -19,8 +19,10 @@ Meta role used by other roles to share variable defaults.
   - [oracle_group](#oracle_group)
   - [oracle_inventory_loc](#oracle_inventory_loc)
   - [oracle_rsp_stage](#oracle_rsp_stage)
+  - [oracle_script_env](#oracle_script_env)
   - [oracle_seclimits](#oracle_seclimits)
   - [oracle_stage](#oracle_stage)
+  - [oracle_tmp_stage](#oracle_tmp_stage)
   - [oracle_user](#oracle_user)
   - [oracle_user_home](#oracle_user_home)
   - [role_separation](#role_separation)
@@ -220,6 +222,21 @@ There is usually no need to change this variable.
 oracle_rsp_stage: '{{ oracle_stage }}/rsp'
 ```
 
+### oracle_script_env
+
+(Minimum) environment settings to pass to Oracle scripts.
+Usually passed to shell: or command: through "environment:" keyword
+
+#### Default value
+
+```YAML
+oracle_script_env:
+  TMPDIR: '{{ oracle_tmp_stage }}'
+  _JAVA_OPTIONS: -Djava.io.tmpdir={{ oracle_tmp_stage }}
+  CV_ASSUME_DISTID: |-
+    {{ (ansible_facts.os_family == 'RedHat') | ternary('OL7', omit) }}
+```
+
 ### oracle_seclimits
 
 ulimit definition for orahost role.
@@ -250,6 +267,19 @@ There is usually no need to change this variable.
 
 ```YAML
 oracle_stage: /u01/stage
+```
+
+### oracle_tmp_stage
+
+Defines the temporary directory to be used by Oracle scripts.
+(on hardened systems, /tmp usually is noexec-flagged and thus not usable to execute scripts)
+
+There is usually no need to change this variable.
+
+#### Default value
+
+```YAML
+oracle_tmp_stage: '{{ oracle_stage }}/tmp'
 ```
 
 ### oracle_user

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -70,6 +70,24 @@ oracle_stage: /u01/stage
 # @end
 oracle_rsp_stage: "{{ oracle_stage }}/rsp"
 
+# @var oracle_tmp_stage:description: >
+# Defines the temporary directory to be used by Oracle scripts.
+# (on hardened systems, /tmp usually is noexec-flagged and thus not usable to execute scripts)
+#
+# There is usually no need to change this variable.
+# @end
+oracle_tmp_stage: "{{ oracle_stage }}/tmp"
+
+# @var oracle_script_env:description: >
+# (Minimum) environment settings to pass to Oracle scripts.
+# Usually passed to shell: or command: through "environment:" keyword
+# 
+# @end
+oracle_script_env:
+  TMPDIR: "{{ oracle_tmp_stage }}"
+  _JAVA_OPTIONS: "-Djava.io.tmpdir={{ oracle_tmp_stage }}"
+  CV_ASSUME_DISTID: "OL7" # backward compatibility for GI < 19.7 on Linux 8/9
+
 # @var oracle_seclimits:description: ulimit definition for orahost role.
 oracle_seclimits:
   - {name: 'soft nproc', value: 16384}

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -86,7 +86,7 @@ oracle_tmp_stage: "{{ oracle_stage }}/tmp"
 oracle_script_env:
   TMPDIR: "{{ oracle_tmp_stage }}"
   _JAVA_OPTIONS: "-Djava.io.tmpdir={{ oracle_tmp_stage }}"
-  CV_ASSUME_DISTID: "OL7" # backward compatibility for GI < 19.7 on Linux 8/9
+  CV_ASSUME_DISTID: "OL7" # forward compatibility for GI < 19.7 on Linux 8/9
 
 # @var oracle_seclimits:description: ulimit definition for orahost role.
 oracle_seclimits:

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -81,12 +81,14 @@ oracle_tmp_stage: "{{ oracle_stage }}/tmp"
 # @var oracle_script_env:description: >
 # (Minimum) environment settings to pass to Oracle scripts.
 # Usually passed to shell: or command: through "environment:" keyword
-# 
+#
 # @end
 oracle_script_env:
   TMPDIR: "{{ oracle_tmp_stage }}"
   _JAVA_OPTIONS: "-Djava.io.tmpdir={{ oracle_tmp_stage }}"
-  CV_ASSUME_DISTID: "OL7" # forward compatibility for GI < 19.7 on Linux 8/9
+  # forward compatibility for GI < 19.7 on Linux 8/9
+  CV_ASSUME_DISTID: |-
+    {{ (ansible_facts.os_family == 'RedHat') | ternary('OL7', omit) }}
 
 # @var oracle_seclimits:description: ulimit definition for orahost role.
 oracle_seclimits:

--- a/roles/oraswdb_install/vars/main.yml
+++ b/roles/oraswdb_install/vars/main.yml
@@ -23,6 +23,7 @@ _oraswdb_install_oracle_sw_image_db:
 _oraswdb_install_oracle_directories:
   - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_rsp_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
+  - {name: "{{ oracle_tmp_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}/cfgtoollogs", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}/admin", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}

--- a/roles/oraswgi_install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi_install/tasks/19.3.0.0.yml
@@ -200,6 +200,7 @@
         __argvru:
           - -applyRU
           - "{{ __patchru_dir }}"
+      environment: "{{ oracle_script_env }}"
       become: true
       become_user: "{{ _grid_install_user }}"
       when:
@@ -227,6 +228,7 @@
   block:  # when: oracle_home_gi not in checkgiinstall.stdout
     - name: install_home_gi | Run oraInstroot script after installation
       ansible.builtin.command: "{{ oracle_inventory_loc }}/orainstRoot.sh"
+      environment: "{{ oracle_script_env }}"
       # noqa no-changed-when
       become: true
       tags:
@@ -239,6 +241,7 @@
 
     - name: install_home_gi | Run root script after installation (Master Node)
       ansible.builtin.command: "{{ oracle_home_gi }}/root.sh"
+      environment: "{{ oracle_script_env }}"
       # noqa no-changed-when
       become: true
       register: rootmaster
@@ -268,6 +271,7 @@
       # noqa no-changed-when
       args:
         executable: /usr/bin/bash
+      environment: "{{ oracle_script_env }}"
       become: true
       with_indexed_items: "{{ groups[orasw_meta_cluster_hostgroup] }}"
       tags:
@@ -285,6 +289,7 @@
 
     - name: install_home_gi | Execute ConfigTools
       ansible.builtin.command: "{{ oracle_home_gi }}/gridSetup.sh -executeConfigTools -responseFile {{ oracle_rsp_stage }}/{{ _oraswgi_install_oracle_grid_responsefile }} -silent"
+      environment: "{{ oracle_script_env }}"
       # noqa no-changed-when
       become: true
       become_user: "{{ _grid_install_user }}"

--- a/roles/oraswgi_install/tasks/runcluvfy.yml
+++ b/roles/oraswgi_install/tasks/runcluvfy.yml
@@ -14,18 +14,18 @@
       when:
         - _oraswgi_meta_configure_cluster
 
-    # GI < 19.11 + OL8 is not supported by Oracle!
-    # ansible-oracle supports no preinstall patching at the moment
-    # runcluvfy.sh is stuck during execution.
-    # => Golden-Image with 19.11+ is mandatory for installation
-    # => We do NOT look into the archive
-    - name: assert that OL8 is using Golden-Image during unzip
-      ansible.builtin.assert:
-        that: oracle_install_image_gi is defined
-      when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version | int == 8
-        - oracle_install_version_gi == "19.3.0.0"
+    # # GI < 19.11 + OL8 is not supported by Oracle!
+    # # ansible-oracle supports no preinstall patching at the moment
+    # # runcluvfy.sh is stuck during execution.
+    # # => Golden-Image with 19.11+ is mandatory for installation
+    # # => We do NOT look into the archive
+    # - name: assert that OL8 is using Golden-Image during unzip
+    #   ansible.builtin.assert:
+    #     that: oracle_install_image_gi is defined
+    #   when:
+    #     - ansible_os_family == 'RedHat'
+    #     - ansible_distribution_major_version | int == 8
+    #     - oracle_install_version_gi == "19.3.0.0"
 
     - name: install_home_gi | Execute cluvfy for Grid-Infrastructure
       ansible.builtin.import_role:
@@ -39,6 +39,7 @@
       register: cmdruncluvfygi
       become: true
       become_user: "{{ _grid_install_user }}"
+      environment: "{{ oracle_script_env }}"
       when:
         - _oraswgi_meta_configure_cluster
         - _orasw_meta_primary_node | bool
@@ -57,6 +58,7 @@
       register: cmdruncluvfy
       become: true
       become_user: "{{ _grid_install_user }}"
+      environment: "{{ oracle_script_env }}"
       when:
         - not _oraswgi_meta_configure_cluster
 

--- a/roles/oraswgi_install/vars/main.yml
+++ b/roles/oraswgi_install/vars/main.yml
@@ -8,6 +8,7 @@ _oraswgi_install_oracle_grid_responsefile: "grid-{{ oracle_cluster_name }}.rsp"
 _oraswgi_manage_patches_oracle_directories:
   - {name: "{{ oracle_stage }}", owner: "{{ _grid_install_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_rsp_stage }}", owner: "{{ _grid_install_user }}", group: "{{ oracle_group }}", mode: 775}
+  - {name: "{{ oracle_tmp_stage }}", owner: "{{ _grid_install_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ grid_base }}", owner: "{{ _grid_install_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_inventory_loc }}", owner: "{{ _grid_install_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ grid_base }}/cfgtoollogs", owner: "{{ _grid_install_user }}", group: "{{ oracle_group }}", mode: 775}


### PR DESCRIPTION
* Setting CV_ASSUME_DISTID enables forward compatibility for cluvfy, gridSetup etc to run on Linux 8 and 9, also with 19.3 base release. This might obsolete the need for Gold Images here.
* On hardened systems, the system's default tempdir (e.g. /tmp) usually is noexec flagged, which denies execution of java or shell code. To make GI setup more hardening-proof, temporary directory will be changed to /u01/stage/tmp.
