### PR TITLE
Introduce a global handlers role

### DIFF
--- a/roles/global_handlers/.ansibledoctor.yml
+++ b/roles/global_handlers/.ansibledoctor.yml
@@ -1,0 +1,5 @@
+---
+logging:
+  level: warning
+template: readme
+force_overwrite: true

--- a/roles/global_handlers/README.md
+++ b/roles/global_handlers/README.md
@@ -6,7 +6,6 @@ Collection of handlers includeable by other roles
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
-  - [reboot_on_requirement](#reboot_on_requirement)
   - [restart_on_requirement](#restart_on_requirement)
 - [Dependencies](#dependencies)
 - [License](#license)
@@ -20,12 +19,12 @@ Collection of handlers includeable by other roles
 
 ## Default Variables
 
-### reboot_on_requirement
+### restart_on_requirement
 
 Controls if reboot handler actually reboots the host (true)
 or just displays a reboot advice (false)
 
-### restart_on_requirement
+**_Type:_** bool<br />
 
 #### Default value
 

--- a/roles/global_handlers/README.md
+++ b/roles/global_handlers/README.md
@@ -1,12 +1,39 @@
 # global_handlers
 
-Collection of handlers that should be available to other roles. Include them by role dependency within meta/main.yml of the affected role.
+sets up the host generic stuff
 
 ## Table of content
 
+- [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [reboot_on_requirement](#reboot_on_requirement)
+  - [restart_on_requirement](#restart_on_requirement)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
 ## Requirements
 
+- Minimum Ansible version: `2.14.0`
+
 ## Default Variables
+
+### reboot_on_requirement
+
+Controls if reboot handler actually reboots the host (true)
+or just displays a reboot advice (false)
+
+### restart_on_requirement
+
+#### Default value
+
+```YAML
+restart_on_requirement: true
+```
+
+
 
 ## Dependencies
 
@@ -18,4 +45,4 @@ license (MIT)
 
 ## Author
 
-[Thilo Solbrig]
+[Mikael Sandström]

--- a/roles/global_handlers/README.md
+++ b/roles/global_handlers/README.md
@@ -1,0 +1,21 @@
+# global_handlers
+
+Collection of handlers that should be available to other roles. Include them by role dependency within meta/main.yml of the affected role.
+
+## Table of content
+
+## Requirements
+
+## Default Variables
+
+## Dependencies
+
+None.
+
+## License
+
+license (MIT)
+
+## Author
+
+[Thilo Solbrig]

--- a/roles/global_handlers/README.md
+++ b/roles/global_handlers/README.md
@@ -1,6 +1,9 @@
 # global_handlers
 
-Collection of handlers includeable by other roles
+Collection of handlers includeable by other roles.
+
+Make them available to your role by including it into the
+dependency list in meta/main.yml of your role, for instance.
 
 ## Table of content
 

--- a/roles/global_handlers/README.md
+++ b/roles/global_handlers/README.md
@@ -1,6 +1,6 @@
 # global_handlers
 
-sets up the host generic stuff
+Collection of handlers includeable by other roles
 
 ## Table of content
 
@@ -45,4 +45,4 @@ license (MIT)
 
 ## Author
 
-[Mikael Sandström]
+[Thilo Solbrig]

--- a/roles/global_handlers/defaults/main.yml
+++ b/roles/global_handlers/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# @var reboot_on_requirement:description: >
+# @var restart_on_requirement:description: >
 # Controls if reboot handler actually reboots the host (true)
 # or just displays a reboot advice (false)
 # @end

--- a/roles/global_handlers/defaults/main.yml
+++ b/roles/global_handlers/defaults/main.yml
@@ -3,4 +3,4 @@
 # Controls if reboot handler actually reboots the host (true) 
 # or just displays a reboot advice (false)
 # @end
-restart_on_requirement: false
+restart_on_requirement: true

--- a/roles/global_handlers/defaults/main.yml
+++ b/roles/global_handlers/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # @var reboot_on_requirement:description: >
-# Controls if reboot handler actually reboots the host (true) 
+# Controls if reboot handler actually reboots the host (true)
 # or just displays a reboot advice (false)
 # @end
 restart_on_requirement: true

--- a/roles/global_handlers/defaults/main.yml
+++ b/roles/global_handlers/defaults/main.yml
@@ -3,4 +3,5 @@
 # Controls if reboot handler actually reboots the host (true)
 # or just displays a reboot advice (false)
 # @end
+# @var restart_on_requirement:type: bool
 restart_on_requirement: true

--- a/roles/global_handlers/defaults/main.yml
+++ b/roles/global_handlers/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# @var reboot_on_requirement:description: >
+# Controls if reboot handler actually reboots the host (true) 
+# or just displays a reboot advice (false)
+# @end
+restart_on_requirement: false

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: reboot if needed
+- name: Reboot concerning package updates
   ansible.builtin.command:
     "{%- if ansible_facts.os_family == 'RedHat' -%}
       yum needs-restarting -r

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -10,7 +10,7 @@
   register: _global_handlers_needs_restarting
   changed_when: _global_handlers_needs_restarting.rc > 0
   notify: restart server
-# @var dummy: description: foo
+
 - name: "restart server block (on behalf of 'restart server')"
   block:
     - name: Reboot

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+- name: reboot if needed
+  ansible.builtin.shell: "needs-restarting -r"
+  failed_when: false
+  register: _global_handlers_needs_restarting
+  changed_when: _global_handlers_needs_restarting.rc > 0
+  notify: restart server
+
+- name: "restart server block (on behalf of 'restart server')"
+  block:
+    - name: Reboot
+      when: restart_on_requirement
+      listen: restart server
+      ansible.builtin.reboot:
+    - name: Reboot recommendation
+      when: not restart_on_requirement
+      listen: restart server
+      ansible.builtin.debug:
+        msg: Please REBOOT {{ ansible_hostname }} for modifications to take effect.

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: reboot if needed
-  ansible.builtin.shell: 
+  ansible.builtin.command:
     "{%- if ansible_facts.os_family == 'RedHat' -%}
-      yum needs-restarting -r
+      yum needs-restarting -r\
     {%- elif ansible_facts.os_family == 'Suse' -%}
-      zypper needs-rebooting
+      zypper needs-rebooting\
     {%- endif -%}"
   failed_when: false
   register: _global_handlers_needs_restarting

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -1,6 +1,11 @@
 ---
 - name: reboot if needed
-  ansible.builtin.shell: "needs-restarting -r"
+  ansible.builtin.shell: 
+    "{%- if ansible_facts.os_family == 'RedHat' -%}
+      yum needs-restarting -r
+    {%- elif ansible_facts.os_family == 'Suse' -%}
+      zypper needs-rebooting
+    {%- endif -%}"
   failed_when: false
   register: _global_handlers_needs_restarting
   changed_when: _global_handlers_needs_restarting.rc > 0

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -2,9 +2,9 @@
 - name: reboot if needed
   ansible.builtin.command:
     "{%- if ansible_facts.os_family == 'RedHat' -%}
-      yum needs-restarting -r\
+      yum needs-restarting -r
     {%- elif ansible_facts.os_family == 'Suse' -%}
-      zypper needs-rebooting\
+      zypper needs-rebooting
     {%- endif -%}"
   failed_when: false
   register: _global_handlers_needs_restarting

--- a/roles/global_handlers/handlers/main.yml
+++ b/roles/global_handlers/handlers/main.yml
@@ -10,7 +10,7 @@
   register: _global_handlers_needs_restarting
   changed_when: _global_handlers_needs_restarting.rc > 0
   notify: restart server
-
+# @var dummy: description: foo
 - name: "restart server block (on behalf of 'restart server')"
   block:
     - name: Reboot

--- a/roles/global_handlers/meta/main.yml
+++ b/roles/global_handlers/meta/main.yml
@@ -1,6 +1,9 @@
 ---
 # @meta description: >
-# Collection of handlers includeable by other roles
+# Collection of handlers includeable by other roles.
+#
+# Make them available to your role by including it into the
+# dependency list in meta/main.yml of your role, for instance.
 # @end
 # @meta author: [Thilo Solbrig]
 galaxy_info:

--- a/roles/global_handlers/meta/main.yml
+++ b/roles/global_handlers/meta/main.yml
@@ -1,0 +1,28 @@
+---
+# @meta description: >
+# sets up the host generic stuff
+# @end
+# @meta author: [Mikael Sandström]
+galaxy_info:
+  role_name: global_handlers
+  author: Thilo Solbrig
+  description: Collection of handlers includeable by other roles (e.g., via meta dependencies)
+  company: ASPICON GmbH
+  license: license (MIT)
+
+  min_ansible_version: 2.14.0
+
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+        - "8"
+        - "9"
+    - name: SLES
+      versions:
+        - "15"
+
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/global_handlers/meta/main.yml
+++ b/roles/global_handlers/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 # @meta description: >
-# sets up the host generic stuff
+# Collection of handlers includeable by other roles
 # @end
-# @meta author: [Mikael Sandström]
+# @meta author: [Thilo Solbrig]
 galaxy_info:
   role_name: global_handlers
   author: Thilo Solbrig


### PR DESCRIPTION
* Introduce a new role to collect handlers needed by more than one role
* Introduces two handlers:
  * `Reboot concerning package updates`, which might be notified of package updates. Notifies `restart server` if reboot is recommended by package manager.
  * `restart server block...` which listens to `restart server` notifications and
    * reboots the system if `restart_on_requirement == true`
    * displays a reboot advisory, otherwise