### PR TITLE
This is a fix for #453 .

### DIFF
--- a/changelogs/fragments/molecule_image.yml
+++ b/changelogs/fragments/molecule_image.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "molecule: added MOLECULE_IMAGE for custom images and support for SuSE (oravirt#458)"

--- a/changelogs/fragments/orahost_meta_env.yml
+++ b/changelogs/fragments/orahost_meta_env.yml
@@ -2,3 +2,6 @@
 minor_changes:
   - "set custom environment for executables with oracle_script_env (oravirt#453)"
   - "orahost_meta: added oracle_tmp_stage for hardened systems (oravirt#453)"
+  - "bugfix set custom environment for executables with oracle_script_env (oravirt#458)"
+breaking_changes:
+  - "CV_ASSUME_DISTID: SLES15 when ansible_os_family == 'SuSE' (oravirt#458)"

--- a/extensions/molecule/dbfs/converge.yml
+++ b/extensions/molecule/dbfs/converge.yml
@@ -4,11 +4,25 @@
   gather_facts: true
   any_errors_fatal: true
   tasks:
+
     # install missing cron on rhel9 container
     - name: Install cron on RHEL/OL9
       ansible.builtin.package:
         name: cronie
-      when: ansible_distribution_major_version | int == 9
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | int == 9
+
+    # install missing packages for openSUSE
+    - name: Install packages on openSUSE
+      ansible.builtin.package:
+        name:
+          - cronie
+          - git
+          - lsof
+          - ssh-tools
+      when:
+        - ansible_os_family == 'Suse'
 
 - name: Converge os
   ansible.builtin.import_playbook: opitzconsulting.ansible_oracle.os

--- a/extensions/molecule/dbfs/molecule.yml
+++ b/extensions/molecule/dbfs/molecule.yml
@@ -7,7 +7,7 @@ driver:
   name: docker
 platforms:
   - name: ol
-    image: "quay.io/rendanic/docker-${MOLECULE_DISTRO:-ol8}-ansible:latest"
+    image: "${MOLECULE_IMAGE:-quay.io/rendanic/docker-ol8-ansible:latest}"
     pre_build_image: true
     # The following 4 lines are needed only for making systemd work
     command: ${MOLECULE_DOCKER_COMMAND:-""}

--- a/extensions/molecule/default/molecule.yml
+++ b/extensions/molecule/default/molecule.yml
@@ -33,6 +33,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
+  - name: opensuse
+    image: "geerlingguy/docker-opensuseleap15-ansible:latest"
+    pre_build_image: true
+    # The following 4 lines are needed only for making systemd work
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
     # - name: SLES-15-3
     #   image: "registry.suse.com/bci/bci-base-ansible:15.3"
     #   pre_build_image: true

--- a/roles/oracluvfy/tasks/execute_cluvfy.yml
+++ b/roles/oracluvfy/tasks/execute_cluvfy.yml
@@ -10,6 +10,8 @@
           - cluvfy_args | length > 2
         success_msg: >-
           Parameter: {{ cluvfy_args }}
+          oracle_script_env:
+          {{ oracle_script_env | ansible.utils.remove_keys(target=['CV_ASSUME_DISTID']) }}
 
     - name: execute_cluvfy | Check for executable
       ansible.builtin.stat:
@@ -21,6 +23,8 @@
       when:
         - not _oracluvfy_executable_stat.stat.exists
 
+    # most current versions of cluvfy is compatible against all supported distributions.
+    # => no need to set CV_ASSUME_DISTID during execution
     - name: execute_cluvfy | Execute cluvfy
       ansible.builtin.command: >-
         {{ _oracluvfy_executable }} {{ cluvfy_args }}
@@ -30,6 +34,8 @@
       changed_when: cluvfy_execute_res.rc == 0
       become: true
       become_user: "{{ _grid_install_user }}"
+      environment: |-
+        {{ oracle_script_env | ansible.utils.remove_keys(target=['CV_ASSUME_DISTID']) }}
 
   rescue:
     - name: execute_cluvfy | cluvfy failed

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -76,7 +76,52 @@ oracle_rsp_stage: "{{ oracle_stage }}/rsp"
 #
 # There is usually no need to change this variable.
 # @end
-oracle_tmp_stage: "{{ oracle_stage }}/tmp"
+oracle_tmp_stage: >-
+  {% if ansible_fips | default(false) %}{{ oracle_stage }}{%- endif %}/tmp
+
+# @var orahost_meta_cv_assume_distid:description: >
+# The variable is used by `oracle_script_env` and passed
+# to shell: or command: through "environment:" keyword
+#
+# Riles:
+#   - Redhat/OL and ansible_distribution_major_version <= 8
+#
+#     `OL{{ ansible_distribution_major_version }}`
+#
+#   - Redhat/OL and ansible_distribution_major_version = 9
+#
+#     `OL8`
+#
+#  - SuSE
+#
+#    `SLES15`
+#
+# @end
+orahost_meta_cv_assume_distid: |-
+  {% if ansible_os_family == 'RedHat' %}OL
+  {%- if ansible_distribution_major_version is version('8', '<=') %}{{ ansible_distribution_major_version }}
+  {%- elif ansible_distribution_major_version is version('9', '=') %}8
+  {%- endif %}
+  {%- elif ansible_os_family in ('SuSe', 'Suse') %}SUSE{{ ansible_distribution_major_version }}
+  {%- endif %}
+
+# @var orahost_meta_java_options:description: >
+# The variable is used by `oracle_script_env` and passed
+# to shell: or command: through "environment:" keyword
+#
+# `java.io.tmpdir` is needed for FIPS configured systems,
+# because starting tools from `/tmp` is forbidden.
+# @end
+orahost_meta_java_options: >-
+  {% if oracle_tmp_stage != '/tmp' -%}
+  -Djava.io.tmpdir={{ oracle_tmp_stage -}}
+  {% endif %}
+
+# @var orahost_meta_java_options:description: >
+# The variable is used by `oracle_script_env` and passed
+# to shell: or command: through "environment:" keyword
+# @end
+orahost_meta_tmpdir: "{{ oracle_tmp_stage }}"
 
 # @var oracle_script_env:description: >
 # (Minimum) environment settings to pass to Oracle scripts.
@@ -84,11 +129,9 @@ oracle_tmp_stage: "{{ oracle_stage }}/tmp"
 #
 # @end
 oracle_script_env:
-  TMPDIR: "{{ oracle_tmp_stage }}"
-  _JAVA_OPTIONS: "-Djava.io.tmpdir={{ oracle_tmp_stage }}"
-  # forward compatibility for GI < 19.7 on Linux 8/9
-  CV_ASSUME_DISTID: |-
-    {{ (ansible_facts.os_family == 'RedHat') | ternary('OL7', omit) }}
+  CV_ASSUME_DISTID: "{{ orahost_meta_cv_assume_distid }}"
+  TMPDIR: "{{ orahost_meta_tmpdir }}"
+  "_JAVA_OPTIONS": "{{ orahost_meta_java_options }}"
 
 # @var oracle_seclimits:description: ulimit definition for orahost role.
 oracle_seclimits:

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -1,12 +1,6 @@
 ---
 - name: install_home_db | Install Oracle Database Server
   ansible.builtin.shell: >-
-    {% if ansible_os_family == 'RedHat' %}
-    {% if ansible_distribution_major_version | int == 8 %}
-    CV_ASSUME_DISTID=OL7{% endif %}
-    {% if ansible_distribution_major_version | int == 9 %}
-    CV_ASSUME_DISTID=OL8{% endif %}
-    {% endif %}
     {{ oracle_home_db }}/runInstaller
     -responseFile {{ oracle_rsp_stage }}/{{ _oraswdb_install_db_responsefile }}
     -ignorePrereq
@@ -23,6 +17,14 @@
     - oradbinstall
   register: oradbinstall
   failed_when: oradbinstall.rc not in [0, 6]
+  environment: "{{ oracle_script_env }}"
+  vars:
+    orahost_meta_cv_assume_distid: >-
+      {% if ansible_os_family == 'RedHat' -%}
+      {% if ansible_distribution_major_version | int == 8 %}OL7{% endif -%}
+      {% if ansible_distribution_major_version | int == 9 %}OL8{% endif -%}
+      {% elif ansible_os_family in ('SuSe', 'Suse') %}SUSE{{ ansible_distribution_major_version -}}
+      {% endif %}
 
 - ansible.builtin.debug:  # noqa name[missing] ignore-errors
     var: oradbinstall.stdout_lines

--- a/roles/oraswdb_install/vars/main.yml
+++ b/roles/oraswdb_install/vars/main.yml
@@ -23,7 +23,7 @@ _oraswdb_install_oracle_sw_image_db:
 _oraswdb_install_oracle_directories:
   - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_rsp_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
-  - {name: "{{ oracle_tmp_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
+  - {name: "{{ oracle_tmp_stage }}", owner: root, group: root, mode: "u+rwx,g+rwx,o+rwxt"}
   - {name: "{{ oracle_base }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}/cfgtoollogs", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}/admin", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}

--- a/roles/oraswgi_install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi_install/tasks/19.3.0.0.yml
@@ -169,6 +169,7 @@
           - "oracle_home_gi: {{ oracle_home_gi }}"
           - "apply RU before configuration: {{ patch_before_rootsh }}"
           - "{{ patch_before_rootsh | bool | ternary('patchru_dir: ' + __patchru_dir, '') }}"
+          - "oracle_script_env:   {{ oracle_script_env | default({}) }}"
       when:
         - _orasw_meta_primary_node | bool
 


### PR DESCRIPTION
This is a fix for #453 .

`_JAVA_OPTIONS` is only set when `oracle_tmp_stage` != /tmp due to issues with `GridSetup.sh -applyRU` for 21c.
The default for `oracle_tmp_stage` is /tmp when `ansible-fips` is disabled or `{{ oracle_stage }}/tmp` when enabled.

The owner, group and priviledges for `oracle_tmp_stage` are set to same values as `/tmp` on normal linux servers.

The `CV_ASSUME_DISTID` is set to `OL{{ ansible_distribution_major_version }}` for RHEL/OL when not RHEL9/OL9 and set to `OL8` when RHEL9/OL9.

`SLES15` is default for SuSE at the moment. This could be changed in next PRs.

`cluvfy` is always executed without `CV_ASSUME_DISTID`, because the tool is compatible for all supported plattforms when most current version is used.