### PR TITLE
Add task/entry to set vm.hugetlb_shm_group

### DIFF
--- a/changelogs/fragments/hugepages.yml
+++ b/changelogs/fragments/hugepages.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "orahost: set vm.hugetlb_shm_group to oracle user GID (oravirt#461)"

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -506,6 +506,8 @@ This is an internal variable. Do not change it!
 ```YAML
 oracle_hugepages:
   - {name: vm.nr_hugepages, value: '{{ nr_hugepages }}'}
+  - {name: vm.hugetlb_shm_group, value: "{{ oracle_user_getent['ansible_facts']['getent_passwd'][oracle_user][2]
+      }}"}
 ```
 
 ### oracle_hugepages_sysctl_file

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -451,6 +451,7 @@ oracle_sysctl:
 # @end
 oracle_hugepages:
   - {name: vm.nr_hugepages, value: "{{ nr_hugepages }}"}
+  - {name: vm.hugetlb_shm_group, value: "{{ oracle_user_getent['ansible_facts']['getent_passwd'][oracle_user][2] }}"}
 
 # @var oracle_hugepages_sysctl_file:description: >
 # Allows to specify the file in which sysctl settings for huge pages will be stored.

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -397,6 +397,13 @@
     - hugepages
     - molecule-idempotence-notest
   block:
+    - name: Lookup oracle user GID for hugepages
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ oracle_user }}"
+        split: ":"
+      register: oracle_user_getent
+
     - name: Oracle hugepages
       ansible.posix.sysctl:
         name: "{{ item.name }}"


### PR DESCRIPTION
This PR will make `orahost` role to set `vm.hugetlb_shm_group` to the current GID or `oracle_user` when setting up huge_pages.
This is [recommended by Oracle](https://support.oracle.com/epmos/faces/DocContentDisplay?id=3010862.1) and in some new Distributions (like SLES 15.4 or RHEL9) even mandatory.
See Doc ID 2491966.1, 3010862.1, 1519770.1 and similar for more Details from Oracle on this topic.