### PR TITLE
oracle_opatch.py needs to support configurable temp directory

### DIFF
--- a/changelogs/fragments/opatch_tmpdir.yml
+++ b/changelogs/fragments/opatch_tmpdir.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oracle_opatch.py needs to support configurable temp directory  (oravirt#462)"

--- a/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
@@ -55,6 +55,7 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ gip_opatch.0.state }}"
+    script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': '-Djava.io.tmpdir=' + orahost_meta_java_options} }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', grid_user) }}"
   vars:


### PR DESCRIPTION
* Supports configurable temp directories other than /tmp, which usually is noexec flagged on hardened systems
* passes orahost_meta_tmpdir and orahost_meta_java_options introduced with #452 into oracle_opatch.py