### PR TITLE
Release 4.9.0 - 1st production Release of ansible-oracle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,53 @@ opitzconsulting.ansible_oracle Release Notes
 .. contents:: Topics
 
 
+v4.9.0
+======
+
+Release Summary
+---------------
+
+This is the 1st production release of ansible-oracle 4.x.
+The RAC support was the last missing option in 4.x compared to 3.12.0.
+A documentation for migration from 3.12.0 to 4.x is work in progress.
+
+Minor Changes
+-------------
+
+- added option to disable transparent hugepages in grub (oravirt#460)
+- bugfix set custom environment for executables with oracle_script_env (oravirt#458)
+- global_handlers: Introduce a global handlers role (oravirt#455)
+- global_handlers: Reboot handler improvements, restart_on_requirement=false, ansible-lint (oravirt#457)
+- molecule: added MOLECULE_IMAGE for custom images and support for SuSE (oravirt#458)
+- oracle_opatch.py needs to support configurable temp directory  (oravirt#462)
+- orahost: Add a list of additional hosts to /etc/hosts (oravirt#447)
+- orahost: add oracle_sysctl_file and oracle_hugepages_sysctl_file variables (oravirt#432)
+- orahost: set vm.hugetlb_shm_group to oracle user GID (oravirt#461)
+- orahost_logrotate: logrotate setup for oracle files should be optional (oravirt#449)
+- orahost_meta: Enable calculation of several kernel parameters (oravirt#451)
+- orahost_meta: added oracle_tmp_stage for hardened systems (oravirt#453)
+- oraswdb_manage_patches: make role compatible with oraswgi_manage_patches (oravirt#464)
+- oraswgi_install: Next refactoring of role for RAC (oravirt#464)
+- set custom environment for executables with oracle_script_env (oravirt#453)
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- CV_ASSUME_DISTID: SLES15 when ansible_os_family == 'SuSE' (oravirt#458)
+- oraswgi_manage_patches: python-module xmltodict needed on ansible-controller (oravirt#464)
+
+Bugfixes
+--------
+
+- Consider home was removed earlier, leaving REMOVED=T (oravirt#437)
+- bugfix: added apply_patches_gi to some tasks with patch_before_rootsh (oravirt#464)
+- default_gipass is not required if sysasmpassword and asmmonitorpassword are set (oravirt#433)
+- fixed jinja spacing warning (oravirt#463)
+- oracluvfy did not fail when error was detected (oravirt#464)
+- orasw_meta: grid_base != oracle_base only required if role_separation=true (oravirt#439)
+- oraswdb_install: Configure systemd only for Single Instance without GI/Restart (oravirt#431)
+- oraswgi_install: honour deploy_ocenv setting (oravirt#443)
+
 v4.8.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -6,6 +6,7 @@ plugins:
   callback: {}
   cliconf: {}
   connection: {}
+  filter: {}
   httpapi: {}
   inventory: {}
   lookup: {}
@@ -156,5 +157,6 @@ plugins:
   netconf: {}
   shell: {}
   strategy: {}
+  test: {}
   vars: {}
-version: 4.8.0
+version: 4.9.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -837,3 +837,70 @@ releases:
     fragments:
     - pdbadmin.yml
     release_date: '2024-04-16'
+  4.9.0:
+    changes:
+      breaking_changes:
+      - 'CV_ASSUME_DISTID: SLES15 when ansible_os_family == ''SuSE'' (oravirt#458)'
+      - 'oraswgi_manage_patches: python-module xmltodict needed on ansible-controller
+        (oravirt#464)'
+      bugfixes:
+      - Consider home was removed earlier, leaving REMOVED=T (oravirt#437)
+      - 'bugfix: added apply_patches_gi to some tasks with patch_before_rootsh (oravirt#464)'
+      - default_gipass is not required if sysasmpassword and asmmonitorpassword are
+        set (oravirt#433)
+      - fixed jinja spacing warning (oravirt#463)
+      - oracluvfy did not fail when error was detected (oravirt#464)
+      - 'orasw_meta: grid_base != oracle_base only required if role_separation=true
+        (oravirt#439)'
+      - 'oraswdb_install: Configure systemd only for Single Instance without GI/Restart
+        (oravirt#431)'
+      - 'oraswgi_install: honour deploy_ocenv setting (oravirt#443)'
+      minor_changes:
+      - added option to disable transparent hugepages in grub (oravirt#460)
+      - bugfix set custom environment for executables with oracle_script_env (oravirt#458)
+      - 'global_handlers: Introduce a global handlers role (oravirt#455)'
+      - 'global_handlers: Reboot handler improvements, restart_on_requirement=false,
+        ansible-lint (oravirt#457)'
+      - 'molecule: added MOLECULE_IMAGE for custom images and support for SuSE (oravirt#458)'
+      - oracle_opatch.py needs to support configurable temp directory  (oravirt#462)
+      - 'orahost: Add a list of additional hosts to /etc/hosts (oravirt#447)'
+      - 'orahost: add oracle_sysctl_file and oracle_hugepages_sysctl_file variables
+        (oravirt#432)'
+      - 'orahost: set vm.hugetlb_shm_group to oracle user GID (oravirt#461)'
+      - 'orahost_logrotate: logrotate setup for oracle files should be optional (oravirt#449)'
+      - 'orahost_meta: Enable calculation of several kernel parameters (oravirt#451)'
+      - 'orahost_meta: added oracle_tmp_stage for hardened systems (oravirt#453)'
+      - 'oraswdb_manage_patches: make role compatible with oraswgi_manage_patches
+        (oravirt#464)'
+      - 'oraswgi_install: Next refactoring of role for RAC (oravirt#464)'
+      - set custom environment for executables with oracle_script_env (oravirt#453)
+      release_summary: 'This is the 1st production release of ansible-oracle 4.x.
+
+        The RAC support was the last missing option in 4.x compared to 3.12.0.
+
+        A documentation for migration from 3.12.0 to 4.x is work in progress.'
+    fragments:
+    - 4.9.0.yml
+    - apply_patches_gi.yml
+    - cluvfy.yml
+    - etc_hosts.yml
+    - gipass.yml
+    - global_handler_lint.yml
+    - global_handlers.yml
+    - home_state.yml
+    - hugepages.yml
+    - hugepages_grub.yml
+    - lint-hosts.yml
+    - logrotate.yml
+    - molecule_image.yml
+    - ocenv.yml
+    - opatch_tmpdir.yml
+    - orahost_meta_env.yml
+    - orahost_meta_kernel.yml
+    - oraswdb_manage_patches.yml
+    - oraswgi_install_refactor.yml
+    - oraswgi_manage_patches.yml
+    - role_separation.yml
+    - sysctl.yml
+    - systemd.yml
+    release_date: '2024-07-21'

--- a/changelogs/fragments/apply_patches_gi.yml
+++ b/changelogs/fragments/apply_patches_gi.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "bugfix: added apply_patches_gi to some tasks with patch_before_rootsh ()"

--- a/changelogs/fragments/cluvfy.yml
+++ b/changelogs/fragments/cluvfy.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oracluvfy did not fail when error was detected ()"

--- a/changelogs/fragments/etc_hosts.yml
+++ b/changelogs/fragments/etc_hosts.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "orahost: Add a list of additional hosts to /etc/hosts (oravirt#447)"

--- a/changelogs/fragments/gipass.yml
+++ b/changelogs/fragments/gipass.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "default_gipass is not required if sysasmpassword and asmmonitorpassword are set (oravirt#433)"
-  

--- a/changelogs/fragments/global_handler_lint.yml
+++ b/changelogs/fragments/global_handler_lint.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "global_handlers: Reboot handler improvements, restart_on_requirement=false, ansible-lint (oravirt#457)"

--- a/changelogs/fragments/global_handlers.yml
+++ b/changelogs/fragments/global_handlers.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "global_handlers: Introduce a global handlers role (oravirt#455)"

--- a/changelogs/fragments/home_state.yml
+++ b/changelogs/fragments/home_state.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "Consider home was removed earlier, leaving REMOVED=T (oravirt#437)"

--- a/changelogs/fragments/hugepages.yml
+++ b/changelogs/fragments/hugepages.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "orahost: set vm.hugetlb_shm_group to oracle user GID (oravirt#461)"

--- a/changelogs/fragments/hugepages_grub.yml
+++ b/changelogs/fragments/hugepages_grub.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "added option to disable transparent hugepages in grub (oravirt#460)"

--- a/changelogs/fragments/lint-hosts.yml
+++ b/changelogs/fragments/lint-hosts.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "fixed jinja spacing warning (oravirt#463)"

--- a/changelogs/fragments/logrotate.yml
+++ b/changelogs/fragments/logrotate.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "orahost_logrotate: logrotate setup for oracle files should be optional (oravirt#449)"

--- a/changelogs/fragments/molecule_image.yml
+++ b/changelogs/fragments/molecule_image.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: added MOLECULE_IMAGE for custom images and support for SuSE (oravirt#458)"

--- a/changelogs/fragments/ocenv.yml
+++ b/changelogs/fragments/ocenv.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswgi_install: honour deploy_ocenv setting (oravirt#443)"

--- a/changelogs/fragments/opatch_tmpdir.yml
+++ b/changelogs/fragments/opatch_tmpdir.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oracle_opatch.py needs to support configurable temp directory  (oravirt#462)"

--- a/changelogs/fragments/orahost_meta_env.yml
+++ b/changelogs/fragments/orahost_meta_env.yml
@@ -1,7 +1,0 @@
----
-minor_changes:
-  - "set custom environment for executables with oracle_script_env (oravirt#453)"
-  - "orahost_meta: added oracle_tmp_stage for hardened systems (oravirt#453)"
-  - "bugfix set custom environment for executables with oracle_script_env (oravirt#458)"
-breaking_changes:
-  - "CV_ASSUME_DISTID: SLES15 when ansible_os_family == 'SuSE' (oravirt#458)"

--- a/changelogs/fragments/orahost_meta_kernel.yml
+++ b/changelogs/fragments/orahost_meta_kernel.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "orahost_meta: Enable calculation of several kernel parameters (oravirt#451)"

--- a/changelogs/fragments/oraswdb_manage_patches.yml
+++ b/changelogs/fragments/oraswdb_manage_patches.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraswdb_manage_patches: make role compatible with oraswgi_manage_patches ()"

--- a/changelogs/fragments/oraswgi_install_refactor.yml
+++ b/changelogs/fragments/oraswgi_install_refactor.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraswgi_install: Next refactoring of role for RAC ()"

--- a/changelogs/fragments/oraswgi_manage_patches.yml
+++ b/changelogs/fragments/oraswgi_manage_patches.yml
@@ -1,3 +1,0 @@
----
-breaking_changes:
-  - "oraswgi_manage_patches: python-module xmltodict needed on ansible-controller ()"

--- a/changelogs/fragments/role_separation.yml
+++ b/changelogs/fragments/role_separation.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orasw_meta: grid_base != oracle_base only required if role_separation=true (oravirt#439)"

--- a/changelogs/fragments/sysctl.yml
+++ b/changelogs/fragments/sysctl.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "orahost: add oracle_sysctl_file and oracle_hugepages_sysctl_file variables (oravirt#432)"

--- a/changelogs/fragments/systemd.yml
+++ b/changelogs/fragments/systemd.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_install: Configure systemd only for Single Instance without GI/Restart (oravirt#431)"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,8 +1,8 @@
 ---
 namespace: opitzconsulting
 name: ansible_oracle
-description: "Impoartant! This is a beta release! This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.8.0
+description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
+version: 4.9.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.9.0
======

Release Summary
---------------

This is the 1st production release of ansible-oracle 4.x. The RAC support was the last missing option in 4.x compared to 3.12.0. A documentation for migration from 3.12.0 to 4.x is work in progress.

Minor Changes
-------------

- added option to disable transparent hugepages in grub (oravirt#460)
- bugfix set custom environment for executables with oracle_script_env (oravirt#458)
- global_handlers: Introduce a global handlers role (oravirt#455)
- global_handlers: Reboot handler improvements, restart_on_requirement=false, ansible-lint (oravirt#457)
- molecule: added MOLECULE_IMAGE for custom images and support for SuSE (oravirt#458)
- oracle_opatch.py needs to support configurable temp directory  (oravirt#462)
- orahost: Add a list of additional hosts to /etc/hosts (oravirt#447)
- orahost: add oracle_sysctl_file and oracle_hugepages_sysctl_file variables (oravirt#432)
- orahost: set vm.hugetlb_shm_group to oracle user GID (oravirt#461)
- orahost_logrotate: logrotate setup for oracle files should be optional (oravirt#449)
- orahost_meta: Enable calculation of several kernel parameters (oravirt#451)
- orahost_meta: added oracle_tmp_stage for hardened systems (oravirt#453)
- oraswdb_manage_patches: make role compatible with oraswgi_manage_patches (oravirt#464)
- oraswgi_install: Next refactoring of role for RAC (oravirt#464)
- set custom environment for executables with oracle_script_env (oravirt#453)

Breaking Changes / Porting Guide
--------------------------------

- CV_ASSUME_DISTID: SLES15 when ansible_os_family == 'SuSE' (oravirt#458)
- oraswgi_manage_patches: python-module xmltodict needed on ansible-controller (oravirt#464)

Bugfixes
--------

- Consider home was removed earlier, leaving REMOVED=T (oravirt#437)
- bugfix: added apply_patches_gi to some tasks with patch_before_rootsh (oravirt#464)
- default_gipass is not required if sysasmpassword and asmmonitorpassword are set (oravirt#433)
- fixed jinja spacing warning (oravirt#463)
- oracluvfy did not fail when error was detected (oravirt#464)
- orasw_meta: grid_base != oracle_base only required if role_separation=true (oravirt#439)
- oraswdb_install: Configure systemd only for Single Instance without GI/Restart (oravirt#431)
- oraswgi_install: honour deploy_ocenv setting (oravirt#443)