### PR TITLE
End of Life for Oracle Linux 7 and RHEL7

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,6 @@ Read link:doc/featurelist.adoc[here] for a detailed list of features of `ansible
 
 
 ## Pre-requisites
-* Ansible Version >= 2.9.   (Version 2.12 or newer of Ansible is recommended)
-* Oracle Linux (or any RHEL-based Linux System) >= 7
+* Ansible Version >= 2.14.
+* Oracle Linux (or any RHEL-based Linux System) >= 8
 * Oracle Database/Grid Infrastructure 21.3.0.0, 19.3.0.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # ansible-oracle
 
-
-_IMPORTANT_
-
-*This an a beta release of `ansible-oracle`.* Use Version 3.x for production instead of this version.
-
-
 * Automated installation of
    * Oracle RAC databases
    * RAC One Node database and
@@ -15,15 +9,18 @@ _IMPORTANT_
 # Documentation
 
 ## Features
+
 1. Full list of features of ansible-oracle <https://github.com/oravirt/ansible-oracle/blob/master/doc/featurelist.adoc>
 1. More details <https://github.com/oravirt/ansible-oracle>
 
 
 ## Getting Started
+
 1. Vagrant setup on Windows <https://github.com/oravirt/ansible-oracle/blob/master/doc/vagrant.adoc>
 1. Beginner <https://github.com/oravirt/ansible-oracle/blob/master/doc/guides/beginner.adoc>
 
 ### Next Steps
+
 1. Read the full documentation <https://github.com/oravirt/ansible-oracle/tree/master/doc>
 1. How to develop in ansible-oracle <https://github.com/oravirt/ansible-oracle/blob/master/doc/development.adoc>
 1. List of roles in ansible-oracle <https://github.com/oravirt/ansible-oracle/blob/master/doc/roles.adoc>
@@ -34,5 +31,5 @@ _IMPORTANT_
 * Ansible Version >= 2.14
 
   Version 2.14 or newer of Ansible is recommended
-* Oracle Linux (or any RHEL-based Linux System) >= 7
+* Oracle Linux (or any RHEL-based Linux System) >= 8
 * Oracle Database/Grid Infrastructure 21.3.0.0, 19.3.0.0

--- a/changelogs/fragments/rhel_ol7.yaml
+++ b/changelogs/fragments/rhel_ol7.yaml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - "End of Life for Oracle Linux 7 and RHEL7 ()"

--- a/doc/featurelist.adoc
+++ b/doc/featurelist.adoc
@@ -33,7 +33,7 @@ See documentation from Oracle for differences between Enterprise and Standard Ed
 |OracleLinux +
 Redhat Enterprise Linux
 |6 <<table1footnote,^[1]^>> +
-7 +
+7 <<table1footnote,^[1]^>> +
 8 +
 9 (experimental!) <<table1footnote,^[5]^>>
 

--- a/example/beginner/vagrant/Vagrantfile
+++ b/example/beginner/vagrant/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.disk :disk, size: "150GB", name: "#{vm_name}_oracle"
 
-  config.vm.box =  "Rendanic/oraclelinux-7.x"
+  config.vm.box =  "Rendanic/oraclelinux-8.x"
   config.vm.box_check_update = false
 
   config.vm.network :private_network, ip: lanip

--- a/example/rac/vagrant/Vagrantfile
+++ b/example/rac/vagrant/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.ssh.insert_key = false
-  config.vm.box = "Rendanic/oraclelinux-7.x"
+  config.vm.box = "Rendanic/oraclelinux-8.x"
 
   (1..num_DB_INSTANCES).each do |i|
     # this is to start machines higher to lower

--- a/extensions/molecule/default/molecule.yml
+++ b/extensions/molecule/default/molecule.yml
@@ -6,15 +6,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ol7
-    image: "quay.io/rendanic/docker-ol7-ansible:latest"
-    pre_build_image: true
-    # The following 4 lines are needed only for making systemd work
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
   - name: ol8
     image: "quay.io/rendanic/docker-ol8-ansible:latest"
     pre_build_image: true

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -338,7 +338,8 @@ Url for epel-release-latest-7.noarch.rpm
 #### Default value
 
 ```YAML
-epel7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel7_rpm: 
+  https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
 ```
 
 ### epel8_rpm

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,7 +8,7 @@ epel9_rpm: oracle-epel-release-el9
 epel8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 # @var epel7_rpm:description: Url for epel-release-latest-7.noarch.rpm
-epel7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel7_rpm: https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
 
 # @var epel6_rpm:description: Url for epel-release-latest-6.noarch.rpm
 epel6_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm


### PR DESCRIPTION
The support for OL/RHEL7 will be stopped, because EPEL archived all RPMs on their official repositories. No more bugfixes or security updates for RPMs anymore.

`ansible-oracle` depends on some RPMs from that repository.

The maintenance support for RHEL7 has been ended on 30 June 2024.

The Premiere Support for OL7 will end 31 Decembre 2024.

The code  from `ansible-oracle` may work with OL/RHEL7 but all tests won't be done against this OS anymore.