### PR TITLE
Release 4.10.0

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install antsibull-changelog
+          python -m pip install antsibull-changelog==0.29.0
 
       - name: antsibull-changelog lint (own changelog fragments)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       # - id: shfmt
 
   - repo: https://github.com/ansible-community/antsibull-changelog.git
-    rev: 0.23.0
+    rev: 0.29.0
     hooks:
       - id: antsibull-changelog-lint
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,44 @@
-============================================
-opitzconsulting.ansible_oracle Release Notes
-============================================
+=============================================
+opitzconsulting.ansible\_oracle Release Notes
+=============================================
 
 .. contents:: Topics
 
+v4.10.0
+=======
+
+Release Summary
+---------------
+
+`ansible-oracle` 4.10.0 supports OL9/RHEL9 without the need to install the software
+from a golden image. The exmples for beginner_patching and RAC have been fixed to
+use the new pre-patching support in `oraswdb_install`.
+
+Minor Changes
+-------------
+
+- added missing collection dependencies (oravirt#469)
+- ansible-builder: moved to new base image (oravirt#470)
+- ansible-lint: Update ansible-lint to 24.7.0 (oravirt#471)
+- ansible-lint: fqcn[action-core] for ansible.builtin.yum due to OL7 compatibility (oravirt#471)
+- antsibull-changelog: Upgrade version 0.29.0 (oravirt#472)
+- beginner_patching: updated example to ansible-oracle 4.x (oravirt#469)
+- molecule: changes to dbfs for new dbfs-ol9 szenario (oravirt#469)
+- molecule: dbfs-ol9 for RDBMS prepatch testing (oravirt#469)
+- ocenv: version 2024-08-23 of ocenv environment script (oravirt#468)
+- oraswdb_install: Added support for prepatching in runInstaller for 19c (oravirt#469)
+- oraswdb_manage_patches: added parameter oraswdb_manage_patches_force_opatch_upgrade for applyRU in runInstaller (oravirt#469)
+- tools: changed requirements_dev.txt for venv (oravirt#470)
+
+Deprecated Features
+-------------------
+
+- End of Life for Oracle Linux 7 and RHEL7 (oravirt#466)
+
+Bugfixes
+--------
+
+- orahost_meta: Added default for oracle_install_option_gi to limit dependency to other roles (oravirt#467)
 
 v4.9.0
 ======
@@ -325,7 +360,6 @@ Please make sure, that furture Pull-Requests have updated README.md included, wh
 A new github Action will check for it.
 Some variable defaults have been changed.
 
-
 Minor Changes
 -------------
 
@@ -510,7 +544,6 @@ Release Summary
 This is ansible-oracle 3.8.0.
 The target database server must have Python3 installaed which is automatically done with role `orahost`.
 It is mandatory for the module `oracle_db` which is used in `oradb_manage_db`.
-
 
 Minor Changes
 -------------
@@ -731,7 +764,6 @@ Release Summary
 
 ansible-oracle has been converted into a collection.
 This release starts using antsibull-changelog for managing the CHANGELOG.rst.
-
 
 Major Changes
 -------------

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.9.0
+version: 4.10.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -590,6 +590,51 @@ releases:
     - release_410.yml
     - statspack.yml
     release_date: '2023-11-08'
+  4.10.0:
+    changes:
+      bugfixes:
+      - 'orahost_meta: Added default for oracle_install_option_gi to limit dependency
+        to other roles (oravirt#467)'
+      deprecated_features:
+      - End of Life for Oracle Linux 7 and RHEL7 (oravirt#466)
+      minor_changes:
+      - added missing collection dependencies (oravirt#469)
+      - 'ansible-builder: moved to new base image (oravirt#470)'
+      - 'ansible-lint: Update ansible-lint to 24.7.0 (oravirt#471)'
+      - 'ansible-lint: fqcn[action-core] for ansible.builtin.yum due to OL7 compatibility
+        (oravirt#471)'
+      - 'antsibull-changelog: Upgrade version 0.29.0'
+      - 'beginner_patching: updated example to ansible-oracle 4.x (oravirt#469)'
+      - 'molecule: changes to dbfs for new dbfs-ol9 szenario (oravirt#469)'
+      - 'molecule: dbfs-ol9 for RDBMS prepatch testing (oravirt#469)'
+      - 'ocenv: version 2024-08-23 of ocenv environment script (oravirt#468)'
+      - 'oraswdb_install: Added support for prepatching in runInstaller for 19c (oravirt#469)'
+      - 'oraswdb_manage_patches: added parameter oraswdb_manage_patches_force_opatch_upgrade
+        for applyRU in runInstaller (oravirt#469)'
+      - 'tools: changed requirements_dev.txt for venv (oravirt#470)'
+      release_summary: '`ansible-oracle` 4.10.0 supports OL9/RHEL9 without the need
+        to install the software
+
+        from a golden image. The exmples for beginner_patching and RAC have been fixed
+        to
+
+        use the new pre-patching support in `oraswdb_install`.'
+    fragments:
+    - ansible-lint.yml
+    - ansible-lint2.yml
+    - antsibull.yml
+    - beginner_patching.yml
+    - builder.yml
+    - collection_dependencies.yml
+    - molecule_dbfs.yml
+    - molecule_dbfs_ol9.yml
+    - ocenv.yml
+    - orahost_meta_gi.yml
+    - oraswdb_manage_patches.yml
+    - prepatching_19c.yml
+    - release.yml
+    - rhel_ol7.yaml
+    release_date: '2024-09-01'
   4.2.0:
     changes:
       breaking_changes:

--- a/changelogs/fragments/ansible-lint.yml
+++ b/changelogs/fragments/ansible-lint.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "ansible-lint: Update ansible-lint to 24.7.0 (oravirt#471)"

--- a/changelogs/fragments/ansible-lint2.yml
+++ b/changelogs/fragments/ansible-lint2.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "ansible-lint: fqcn[action-core] for ansible.builtin.yum due to OL7 compatibility (oravirt#471)"

--- a/changelogs/fragments/antsibull.yml
+++ b/changelogs/fragments/antsibull.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "antsibull-changelog: Upgrade version 0.29.0"

--- a/changelogs/fragments/antsibull.yml
+++ b/changelogs/fragments/antsibull.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "antsibull-changelog: Upgrade version 0.29.0"

--- a/changelogs/fragments/beginner_patching.yml
+++ b/changelogs/fragments/beginner_patching.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "beginner_patching: updated example to ansible-oracle 4.x (oravirt#469)"

--- a/changelogs/fragments/builder.yml
+++ b/changelogs/fragments/builder.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - "ansible-builder: moved to new base image (oravirt#470)"
-  - "tools: changed requirements_dev.txt for venv (oravirt#470)"

--- a/changelogs/fragments/collection_dependencies.yml
+++ b/changelogs/fragments/collection_dependencies.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "added missing collection dependencies (oravirt#469)"

--- a/changelogs/fragments/molecule_dbfs.yml
+++ b/changelogs/fragments/molecule_dbfs.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: changes to dbfs for new dbfs-ol9 szenario (oravirt#469)"

--- a/changelogs/fragments/molecule_dbfs_ol9.yml
+++ b/changelogs/fragments/molecule_dbfs_ol9.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: dbfs-ol9 for RDBMS prepatch testing (oravirt#469)"

--- a/changelogs/fragments/ocenv.yml
+++ b/changelogs/fragments/ocenv.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "ocenv: version 2024-08-23 of ocenv environment script (oravirt#468)"

--- a/changelogs/fragments/orahost_meta_gi.yml
+++ b/changelogs/fragments/orahost_meta_gi.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost_meta: Added default for oracle_install_option_gi to limit dependency to other roles (oravirt#467)"

--- a/changelogs/fragments/oraswdb_manage_patches.yml
+++ b/changelogs/fragments/oraswdb_manage_patches.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraswdb_manage_patches: added parameter oraswdb_manage_patches_force_opatch_upgrade for applyRU in runInstaller (oravirt#469)"

--- a/changelogs/fragments/prepatching_19c.yml
+++ b/changelogs/fragments/prepatching_19c.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraswdb_install: Added support for prepatching in runInstaller for 19c (oravirt#469)"

--- a/changelogs/fragments/rhel_ol7.yaml
+++ b/changelogs/fragments/rhel_ol7.yaml
@@ -1,3 +1,0 @@
----
-deprecated_features:
-  - "End of Life for Oracle Linux 7 and RHEL7 ()"

--- a/example/beginner_patching/ansible/requirements.yml
+++ b/example/beginner_patching/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.9.0
+    version: 4.10.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/example/rac/ansible/requirements.yml
+++ b/example/rac/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.9.0
+    version: 4.10.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.9.0
+version: 4.10.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:

--- a/tools/dev/requirements_antsibull.txt
+++ b/tools/dev/requirements_antsibull.txt
@@ -15,4 +15,4 @@
 # otherwise the ansible-doc gets errors due to problems with ansible-oracle-modules
 # They need some refactoring...
 ansible-core==2.15.9
-antsibull-changelog==0.23.0
+antsibull-changelog==0.29.0


### PR DESCRIPTION
v4.10.0
=======

Release Summary
---------------

`ansible-oracle` 4.10.0 supports OL9/RHEL9 without the need to install the software
from a golden image. The exmples for beginner_patching and RAC have been fixed to
use the new pre-patching support in `oraswdb_install`.

Minor Changes
-------------

- added missing collection dependencies (oravirt#469)
- ansible-builder: moved to new base image (oravirt#470)
- ansible-lint: Update ansible-lint to 24.7.0 (oravirt#471)
- ansible-lint: fqcn[action-core] for ansible.builtin.yum due to OL7 compatibility (oravirt#471)
- antsibull-changelog: Upgrade version 0.29.0 (oravirt#472)
- beginner_patching: updated example to ansible-oracle 4.x (oravirt#469)
- molecule: changes to dbfs for new dbfs-ol9 szenario (oravirt#469)
- molecule: dbfs-ol9 for RDBMS prepatch testing (oravirt#469)
- ocenv: version 2024-08-23 of ocenv environment script (oravirt#468)
- oraswdb_install: Added support for prepatching in runInstaller for 19c (oravirt#469)
- oraswdb_manage_patches: added parameter oraswdb_manage_patches_force_opatch_upgrade for applyRU in runInstaller (oravirt#469)
- tools: changed requirements_dev.txt for venv (oravirt#470)

Deprecated Features
-------------------

- End of Life for Oracle Linux 7 and RHEL7 (oravirt#466)

Bugfixes
--------

- orahost_meta: Added default for oracle_install_option_gi to limit dependency to other roles (oravirt#467)

