### PR TITLE
Release 4.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,36 @@ opitzconsulting.ansible\_oracle Release Notes
 
 .. contents:: Topics
 
+v4.11.0
+=======
+
+Release Summary
+---------------
+
+Roles for APEX and ORDS have been added in experimental state.
+The old issue with missing support for listener configuration in Oracle GI/Restart has been fixed.
+A new Playbook manage_sqlnet.ora has been added for easier configuration of listener.ora, sqlnet.ora and tnsnames.ora.
+
+Minor Changes
+-------------
+
+- ORDS: new experimental role to install and configure ORDS on OracleLinux (oravirt#473)
+- ansible-oracle Documentation fixes (oravirt#473)
+- beginner_patching: Inventory for ORDS + APEX (oravirt#473)
+- example rac: create multiple listener as example (oravirt#475)
+- galaxy: added new collection as dependency for RAC/Restart listener configuration (oravirt#475)
+- molecule: Added APEX and ORDS to dbfs-ol9 (oravirt#473)
+- molecule: added 2nd listener for testing (oravirt#475)
+- oraapex: New role to install APEX in databases - experimental (oravirt#473)
+- oradb_manage_db: Configure sqlnet.ora, listener.ora and tnsnames.ora wirh playbook manage_sqlnet.yml (oravirt#475)
+- orasw_download_patches: added support for downloading apex installation archives (oravirt#473)
+- orasw_meta: changed assert for playbook manage_sqlnet.yml on RAC/Restart (oravirt#475)
+
+Bugfixes
+--------
+
+- oraswgi_install: documentation changes for ansible-doctor make happy again (oravirt#474)
+
 v4.10.0
 =======
 
@@ -21,7 +51,7 @@ Minor Changes
 - ansible-builder: moved to new base image (oravirt#470)
 - ansible-lint: Update ansible-lint to 24.7.0 (oravirt#471)
 - ansible-lint: fqcn[action-core] for ansible.builtin.yum due to OL7 compatibility (oravirt#471)
-- antsibull-changelog: Upgrade version 0.29.0 (oravirt#472)
+- antsibull-changelog: Upgrade version 0.29.0
 - beginner_patching: updated example to ansible-oracle 4.x (oravirt#469)
 - molecule: changes to dbfs for new dbfs-ol9 szenario (oravirt#469)
 - molecule: dbfs-ol9 for RDBMS prepatch testing (oravirt#469)

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.10.0
+version: 4.11.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -635,6 +635,51 @@ releases:
     - release.yml
     - rhel_ol7.yaml
     release_date: '2024-09-01'
+  4.11.0:
+    changes:
+      bugfixes:
+      - 'oraswgi_install: documentation changes for ansible-doctor make happy again
+        (oravirt#474)'
+      minor_changes:
+      - 'ORDS: new experimental role to install and configure ORDS on OracleLinux
+        (oravirt#473)'
+      - ansible-oracle Documentation fixes (oravirt#473)
+      - 'beginner_patching: Inventory for ORDS + APEX (oravirt#473)'
+      - 'example rac: create multiple listener as example (oravirt#475)'
+      - 'galaxy: added new collection as dependency for RAC/Restart listener configuration
+        (oravirt#475)'
+      - 'molecule: Added APEX and ORDS to dbfs-ol9 (oravirt#473)'
+      - 'molecule: added 2nd listener for testing (oravirt#475)'
+      - 'oraapex: New role to install APEX in databases - experimental (oravirt#473)'
+      - 'oradb_manage_db: Configure sqlnet.ora, listener.ora and tnsnames.ora wirh
+        playbook manage_sqlnet.yml (oravirt#475)'
+      - 'orasw_download_patches: added support for downloading apex installation archives
+        (oravirt#473)'
+      - 'orasw_meta: changed assert for playbook manage_sqlnet.yml on RAC/Restart
+        (oravirt#475)'
+      release_summary: 'Roles for APEX and ORDS have been added in experimental state.
+
+        The old issue with missing support for listener configuration in Oracle GI/Restart
+        has been fixed.
+
+        A new Playbook manage_sqlnet.ora has been added for easier configuration of
+        listener.ora, sqlnet.ora and tnsnames.ora.
+
+        '
+    fragments:
+    - apex.yml
+    - apex_download.yml
+    - beginner.yml
+    - doc1.yml
+    - molecule.yml
+    - oraswgi_install.yml
+    - ords.yml
+    - release.yml
+    - sqlnet.yml
+    - sqlnet_meta.yml
+    - sqlnet_molecule.yml
+    - sqlnet_rac.yml
+    release_date: '2024-09-15'
   4.2.0:
     changes:
       breaking_changes:

--- a/changelogs/fragments/apex.yml
+++ b/changelogs/fragments/apex.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - "oraapex: New role to install APEX in databases - experimental (oravirt#473)"

--- a/changelogs/fragments/apex_download.yml
+++ b/changelogs/fragments/apex_download.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - "orasw_download_patches: added support for downloading apex installation archives (oravirt#473)"

--- a/changelogs/fragments/beginner.yml
+++ b/changelogs/fragments/beginner.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - "beginner_patching: Inventory for ORDS + APEX (oravirt#473)"

--- a/changelogs/fragments/doc1.yml
+++ b/changelogs/fragments/doc1.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - "ansible-oracle Documentation fixes (oravirt#473)"

--- a/changelogs/fragments/molecule.yml
+++ b/changelogs/fragments/molecule.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - "molecule: Added APEX and ORDS to dbfs-ol9 (oravirt#473)"

--- a/changelogs/fragments/oraswgi_install.yml
+++ b/changelogs/fragments/oraswgi_install.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswgi_install: documentation changes for ansible-doctor make happy again (oravirt#474)"

--- a/changelogs/fragments/ords.yml
+++ b/changelogs/fragments/ords.yml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - "ORDS: new experimental role to install and configure ORDS on OracleLinux (oravirt#473)"

--- a/changelogs/fragments/sqlnet.yml
+++ b/changelogs/fragments/sqlnet.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - "oradb_manage_db: Configure sqlnet.ora, listener.ora and tnsnames.ora wirh playbook manage_sqlnet.yml (oravirt#475)"
-  - "galaxy: added new collection as dependency for RAC/Restart listener configuration (oravirt#475)"

--- a/changelogs/fragments/sqlnet_meta.yml
+++ b/changelogs/fragments/sqlnet_meta.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "orasw_meta: changed assert for playbook manage_sqlnet.yml on RAC/Restart (oravirt#475)"

--- a/changelogs/fragments/sqlnet_molecule.yml
+++ b/changelogs/fragments/sqlnet_molecule.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "molecule: added 2nd listener for testing (oravirt#475)"

--- a/changelogs/fragments/sqlnet_rac.yml
+++ b/changelogs/fragments/sqlnet_rac.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "example rac: create multiple listener as example (oravirt#475)"

--- a/example/beginner_patching/ansible/requirements.yml
+++ b/example/beginner_patching/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.10.0
+    version: 4.11.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/example/rac/ansible/requirements.yml
+++ b/example/rac/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.10.0
+    version: 4.11.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.10.0
+version: 4.11.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
Release Summary
---------------

Roles for APEX and ORDS have been added in experimental state. The old issue with missing support for listener configuration in Oracle GI/Restart has been fixed. A new Playbook manage_sqlnet.ora has been added for easier configuration of listener.ora, sqlnet.ora and tnsnames.ora.

Minor Changes
-------------

- ORDS: new experimental role to install and configure ORDS on OracleLinux (oravirt#473)
- ansible-oracle Documentation fixes (oravirt#473)
- beginner_patching: Inventory for ORDS + APEX (oravirt#473)
- example rac: create multiple listener as example (oravirt#475)
- galaxy: added new collection as dependency for RAC/Restart listener configuration (oravirt#475)
- molecule: Added APEX and ORDS to dbfs-ol9 (oravirt#473)
- molecule: added 2nd listener for testing (oravirt#475)
- oraapex: New role to install APEX in databases - experimental (oravirt#473)
- oradb_manage_db: Configure sqlnet.ora, listener.ora and tnsnames.ora wirh playbook manage_sqlnet.yml (oravirt#475)
- orasw_download_patches: added support for downloading apex installation archives (oravirt#473)
- orasw_meta: changed assert for playbook manage_sqlnet.yml on RAC/Restart (oravirt#475)

Bugfixes
--------

- oraswgi_install: documentation changes for ansible-doctor make happy again (oravirt#474)