### PR TITLE
orasw_meta: empty oracle_databases broke orasw_download_patches

### DIFF
--- a/changelogs/fragments/download.yml
+++ b/changelogs/fragments/download.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "orasw_download_patches: bugfix for empty oracle_databases or oracle_pdbs (oravirt#480)"

--- a/changelogs/fragments/orasw_meta.yml
+++ b/changelogs/fragments/orasw_meta.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "orasw_meta: empty oracle_databases broke orasw_download_patches (oravirt#480)"

--- a/roles/orahost_meta/tasks/main.yml
+++ b/roles/orahost_meta/tasks/main.yml
@@ -93,5 +93,7 @@
 # Kernelsettings are not availible in molecule
 - name: Calculate kernel.sem
   ansible.builtin.include_tasks: calculate_kernel_semaphores.yml
+  when:
+    - oracle_databases | default([]) | length > 0
   tags:
     - molecule-notest

--- a/roles/orasw_download_patches/tasks/main.yml
+++ b/roles/orasw_download_patches/tasks/main.yml
@@ -36,9 +36,12 @@
     - name: Download APEX images
       ansible.builtin.include_tasks: apex.yml
       when:
-        - (oracle_databases | selectattr('apex_state', 'defined') | list | length > 0
+        - ((oracle_databases | default([]) | length > 0
+            and oracle_databases | selectattr('apex_state', 'defined') | list | length > 0)
           or
-           oracle_pdbs | selectattr('apex_state', 'defined') | list | length > 0
+           (oracle_databases | default([]) | length > 0
+           and oracle_pdbs | selectattr('apex_state', 'defined') | list | length > 0
+           )
           )
 
     - name: Login to Oracle


### PR DESCRIPTION
This PR improves #477 .