### PR TITLE
fix for _oradb_tzupgrade_candidate_pdbs fact

### DIFF
--- a/changelogs/fragments/tz_cdb_upgrade_issue.yml
+++ b/changelogs/fragments/tz_cdb_upgrade_issue.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - set and check _oradb_tzupgrade_candidate_pdbs fact when upgrading timezone for a CDB database

--- a/roles/oradb_tzupgrade/tasks/cdb.yml
+++ b/roles/oradb_tzupgrade/tasks/cdb.yml
@@ -35,14 +35,14 @@
 
 - name: oradb_tzupgrade | Set facts for pdbs_info
   ansible.builtin.set_fact:
-    candidate_pdbs: "{{ pdbs_info.state.ROW[0].PDB_LIST | default('') }}"
+    _oradb_tzupgrade_candidate_pdbs: "{{ pdbs_info.state.ROW[0].PDB_LIST | default('') }}"
 
 - name: oradb_tzupgrade | Show facts for pdbs_info
   ansible.builtin.debug:
     msg: "Candidate PDBs: {{ _oradb_tzupgrade_candidate_pdbs }}"
 
 - name: oradb_tzupgrade | Upgrade timezone
-  when: candidate_pdbs != ""
+  when: _oradb_tzupgrade_candidate_pdbs != ""
   block:
 
     - name: oradb_tzupgrade | Perform timezone checks for the candidate PDBs


### PR DESCRIPTION
When upgrading timezone for a CDB database it fails with:

```
TASK [opitzconsulting.ansible_oracle.oradb_tzupgrade : oradb_tzupgrade | Show facts for pdbs_info] ***                                                                                             
Wednesday 23 October 2024  22:15:43 +0200 (0:00:00.055)       0:03:57.589 *****                                                                                                                    
fatal: [mol-oracle-pdvmoras99-snapcdb]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: '_oradb_tzupgrade_candidate_pdbs' is undefined. '_oradb_tzupgrade
_candidate_pdbs' is undefined\n\nThe error appears to be in '/home/devopsadm/.ansible/collections/ansible_collections/opitzconsulting/ansible_oracle/roles/oradb_tzupgrade/tasks/cdb.yml': line 40, 
column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: oradb_tzupgrade | Show facts for pdbs_info\n  ^ here\n"}   
```
