### PR TITLE
fix for re global flags expression

### DIFF
--- a/changelogs/fragments/re_global_flags_fix.yml
+++ b/changelogs/fragments/re_global_flags_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix for re global flags when extracting sga/processes parameters in orahost_meta

--- a/roles/orahost_meta/tasks/main.yml
+++ b/roles/orahost_meta/tasks/main.yml
@@ -42,15 +42,15 @@
       ansible.builtin.set_fact:
         __orahost_oracle_database_sgas: >-
           {{ (__orahost_oracle_database_sgas | default([])) +
-          (( __orahost_oracle_database_init_parameter | selectattr('name', 'match', '^(?i)sga_max_size$') ) | length > 0 )
-          | ternary(__orahost_oracle_database_init_parameter | selectattr('name', 'match', '^(?i)sga_max_size$'),
-                    __orahost_oracle_database_init_parameter | selectattr('name', 'match', '^(?i)sga_target$')) }}
+          (( __orahost_oracle_database_init_parameter | selectattr('name', 'match', '(?i)^sga_max_size$') ) | length > 0 )
+          | ternary(__orahost_oracle_database_init_parameter | selectattr('name', 'match', '(?i)^sga_max_size$'),
+                    __orahost_oracle_database_init_parameter | selectattr('name', 'match', '(?i)^sga_target$')) }}
       loop: >-
         {{ ((oracle_databases | default([])) + (oracle_asm_instance | default([])))
         | map(attribute='init_parameters', default=[]) }}
       loop_control:
         loop_var: __orahost_oracle_database_init_parameter
-      when: (__orahost_oracle_database_init_parameter | selectattr('name', 'match', '^(?i)(sga_target|sga_max_size)$')) | length > 0
+      when: (__orahost_oracle_database_init_parameter | selectattr('name', 'match', '(?i)^(sga_target|sga_max_size)$')) | length > 0
 
     - name: Aggregate SGAs
       ansible.builtin.include_tasks: aggregate_sgas.yml
@@ -65,7 +65,7 @@
     {{ ((oracle_databases | default([])) + (oracle_asm_instance | default([])))
     | map(attribute='init_parameters', default=[])
     | flatten
-    | selectattr('name', 'match', '^(?i)processes$') }}
+    | selectattr('name', 'match', '(?i)^processes$') }}
   loop_control:
     loop_var: __orahost_oracle_database_processes
     label: "{{ __orahost_oracle_database_processes.name + ': ' + __orahost_oracle_database_processes.value | string }}"


### PR DESCRIPTION
Hello,

When trying to provision a new Oracle setup, the following error is raised:

```
TASK [opitzconsulting.ansible_oracle.orahost_meta : Extract SGA parameters, choose sga_max_size over sga_target if both are definied] ***
task path: /Users/talek/.ansible/collections/ansible_collections/opitzconsulting/ansible_oracle/roles/orahost_meta/tasks/main.yml:41 
Thursday 07 November 2024  18:43:16 +0200 (0:00:00.029)       0:00:12.053 *****                                                                                                                                                                                         
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: re.error: global flags not at the start of the expression at position 1
fatal: [mol-main-abc]: FAILED! => {"msg": "Unexpected failure during module execution: global flags not at the start of the expression at position 1", "stdout": ""}
```

It seems that Ansible/Python is picky and expects that the global `(?i)` option to be specified at the very beginning of the regex:

```
talek@MacBookPro ~ % ansible -m debug localhost -a "msg='{{ 'SGA_target' | regex_search('^(?i)sga_target$') }}'"
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: re.error: global flags not at the start of the expression at position 1
localhost | FAILED! => {
    "changed": false
}
talek@MacBookPro ~ % ansible -m debug localhost -a "msg='{{ 'SGA_target' | regex_search('(?i)^sga_target$') }}'"
localhost | SUCCESS => {
    "msg": "SGA_target"
}
```
