### PR TITLE
Add feature to create OMF enabled databases

### DIFF
--- a/changelogs/fragments/create_omf_database.yml
+++ b/changelogs/fragments/create_omf_database.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - create OMF enabled databases using dbca's -useOMF flag

--- a/plugins/modules/oracle_db.py
+++ b/plugins/modules/oracle_db.py
@@ -160,6 +160,13 @@ options:
         Default: false
         type: bool
         choices: ['true', 'false']
+    omf:
+        description: >
+            Should Oracle Managed Files be used
+        required: false
+        Default: false
+        type: bool
+        choices: ['true', 'false']
     initparams:
         description: >
             List of dict for init.ora parameter.
@@ -472,6 +479,7 @@ def create_db(
     customscripts,
     datapatch,
     domain,
+    omf,
 ):
     initparam = ' -initParams '
     paramslist = ''
@@ -601,6 +609,13 @@ def create_db(
             # paramslist = ",".join(initparams)
             # initparam += ' %s' % (paramslist)
             initparam += ' %s' % (initparams)
+
+    if omf is not None:
+        if major_version >= '18.4':
+            if omf is True:
+                command += ' -useOMF true '
+            else:
+                command += ' -useOMF false '
 
     if initparam != ' -initParams ' or paramslist != "":
         command += initparam
@@ -1260,6 +1275,7 @@ def main():
             state               = dict(default="present", choices = ["present", "absent", "started", "restarted"]), # noqa E231
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']), # noqa E231
             port                = dict(required=False, default = 1521), # noqa E231
+            omf                 = dict(required=False, type='bool', default=False), #noqa E231
         ),
         mutually_exclusive=[['memory_percentage', 'memory_totalmb']],
     )
@@ -1305,6 +1321,7 @@ def main():
     state               = module.params["state"] # noqa E221
     hostname            = module.params["hostname"] # noqa E221
     port                = module.params["port"] # noqa E221
+    omf                 = module.params["omf"] # noqa E221
     # fmt: on
 
     # ld_library_path = '%s/lib' % (oracle_home)
@@ -1432,6 +1449,7 @@ def main():
                 customscripts,
                 datapatch,
                 domain,
+                omf,
             ):
                 newdb = True
                 ensure_db_state(

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -124,6 +124,7 @@
         flashback: "{{ odb.flashback | default(omit) }}"
         force_logging: "{{ odb.force_logging | default(omit) }}"
         initparams: "{{ _oradb_manage_db_init_params_list | default(omit) }}"
+        omf: "{{ odb.omf | default(omit) }}"
         output: verbose
         state: "{{ odb.state }}"
       become: true


### PR DESCRIPTION
Starting with Oracle 18.4, dbca has added the -useOMF parameter for creating OMF enabled databases. This pull request implements this feature.