### PR TITLE
[BUG] missing parameter in remove_grants function im module 

### DIFF
--- a/plugins/modules/oracle_grants.py
+++ b/plugins/modules/oracle_grants.py
@@ -788,7 +788,7 @@ def main():
     elif (state == 'absent' or state == 'REMOVEALL') and schema:
         # module.exit_json(msg='absent & schema', changed=False)
         if check_user_exists(module, msg, cursor, schema):
-            if remove_grants(module, msg, cursor, schema, grants, state):
+            if remove_grants(module, msg, cursor, schema, grants, object_privs, state):
                 # msg = 'The schema %s has been dropped successfully' % schema
                 module.exit_json(msg=msg, changed=True)
         else:
@@ -799,7 +799,7 @@ def main():
     elif (state == 'absent' or state == 'REMOVEALL') and role:
         # module.exit_json(msg='absent & role', changed=False)
         if check_role_exists(module, msg, cursor, role):
-            if remove_grants(module, msg, cursor, role, grants, state):
+            if remove_grants(module, msg, cursor, role, grants, object_privs, state):
                 # msg = 'The schema %s has been dropped successfully' % schema
                 module.exit_json(msg=msg, changed=True)
         else:


### PR DESCRIPTION
I have found a problem with the `oracle_grants` module that is used to revoke or grant permissions. The function is missing a parameter.

I have a use case where via a playbook the application owner needs specific grant to finish in maintenance window his tasks for and after the job is done on his end the same playbook is used to revoke the provided grants.

I caught an exception that run in trace condition, see provided log output below and current running ansible version.
The problem also exists in the old v3.12 `(tag v3.12.0)` which is no longer maintained.


```
TASK [opitzconsulting.ansible_oracle.oradb_manage_grants : Manage schema grants (cdb)] ***********************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: remove_grants() missing 1 required positional argument: 'state'
failed: [hostname] (item=db_name: ORCL service: ORCL:1521 schema: SZK grants: ['grant any object privilege', 'grant any privilege'] state: absent" db_state: present) => {"ansible_loop_var": "odb", "changed": false, "module_stderr":
 "Traceback (most recent call last):\n  File \"<stdin>\", line 107, in <module>\n  File \"<stdin>\", line 99, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n
    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  
    File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  
    File \"/tmp/ansible_opitzconsulting.ansible_oracle.oracle_grants_payload_f_5ruvke/ansible_opitzconsulting.ansible_oracle.oracle_grants_payload.zip/ansible_collections/opitzconsulting/ansible_oracle/plugins/modules/oracle_grants.py\",
    line 817, in <module>\n  File \"/tmp/ansible_opitzconsulting.ansible_oracle.oracle_grants_payload_f_5ruvke/ansible_opitzconsulting.ansible_oracle.oracle_grants_payload.zip/ansible_collections/opitzconsulting/ansible_oracle/plugins/modules/oracle_grants.py\",
     line 794, in main\nTypeError: remove_grants() missing 1 required positional argument: 'state'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "odb": 



2025-02-13 17:08:20,520 p=108369 u=ansible n=ansible | ok: [hostname] => {
    "msg": "ansible-oracle version: 4.11.1"
}



(python39) (python39) [ansible@ansible_controller git]$ ansible --version
ansible [core 2.15.12]
  config file = None
  configured module search path = ['/home/ansible/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/venv/python39/lib64/python3.9/site-packages/ansible
  ansible collection location = /home/ansible/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/ansible/venv/python39/bin/ansible
  python version = 3.9.20 (main, Oct 24 2024, 07:04:44) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22.0.1)] (/home/ansible/venv/python39/bin/python3.9)
  jinja version = 3.1.4
  libyaml = True
(python39) (python39) [ansible@ansible_controller git]$ 

```


