### PR TITLE
Scripts folder should be configurable

### DIFF
--- a/changelogs/fragments/scripts-folder-configurable.yml
+++ b/changelogs/fragments/scripts-folder-configurable.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_manage_db: make hard coded folder .Scripts configurable"

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -25,6 +25,7 @@ sets up the host generic stuff
   - [ntp_type](#ntp_type)
   - [ol6_repo_file](#ol6_repo_file)
   - [ol7_repo_file](#ol7_repo_file)
+  - [scripts_folder](#scripts_folder)
 - [Discovered Tags](#discovered-tags)
 - [Dependencies](#dependencies)
 - [License](#license)
@@ -392,6 +393,16 @@ The variable is used to cleanup the yum repolist for old installations.
 
 ```YAML
 ol7_repo_file: public-yum-ol7.repo
+```
+
+### scripts_folder
+
+Folder under Oracle user home dir to place scripts in
+
+#### Default value
+
+```YAML
+scripts_folder: .Scripts
 ```
 
 ## Discovered Tags

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -30,6 +30,9 @@ configure_public_yum_repo: true
 # @var configure_motd:description: Configure Message of the day
 configure_motd: true
 
+# @var scripts_folder:description: Folder under Oracle user home dir to place scripts in
+scripts_folder: .Scripts
+
 # @var motd_template:description: Used templatename for Message of the day
 motd_template: motd.j2
 

--- a/roles/oradb_manage_db/tasks/main.yml
+++ b/roles/oradb_manage_db/tasks/main.yml
@@ -65,7 +65,7 @@
 - name: manage_db | Add change-pdb script
   ansible.builtin.template:
     src: pdb.sql.j2
-    dest: "{{ oracle_user_home }}/.Scripts/chpdb.sql"
+    dest: "{{ oracle_user_home }}/{{ scripts_folder }}/chpdb.sql"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: 0644

--- a/roles/oradb_manage_db/tasks/main.yml
+++ b/roles/oradb_manage_db/tasks/main.yml
@@ -70,7 +70,7 @@
     group: "{{ oracle_group }}"
     mode: 0644
   tags: sql_script
-  when: 
+  when:
     - oracle_pdbs is defined
 
 - name: Create/Modify database

--- a/roles/oradb_manage_db/tasks/main.yml
+++ b/roles/oradb_manage_db/tasks/main.yml
@@ -70,6 +70,8 @@
     group: "{{ oracle_group }}"
     mode: 0644
   tags: sql_script
+  when: 
+    - oracle_pdbs is defined
 
 - name: Create/Modify database
   ansible.builtin.include_tasks: manage-db.yml

--- a/roles/oraswdb_install/templates/dotprofile-home.j2
+++ b/roles/oraswdb_install/templates/dotprofile-home.j2
@@ -19,7 +19,7 @@
         export LD_LIBRARY_PATH
         TNS_ADMIN=$ORACLE_HOME/network/admin
         export TNS_ADMIN
-        SQLPATH={{ oracle_user_home }}/.Scripts
+        SQLPATH={{ oracle_user_home }}/{{ scripts_folder }}
         export SQLPATH
         ORACLE_SID=
         export ORACLE_SID

--- a/roles/oraswdb_install/vars/main.yml
+++ b/roles/oraswdb_install/vars/main.yml
@@ -69,7 +69,7 @@ _oraswdb_install_oracle_directories:
   - {name: "{{ oracle_base }}/cfgtoollogs/dbca", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}/cfgtoollogs/sqlpatch", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
   - {name: "{{ oracle_base }}/cfgtoollogs/netca", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
-  - {name: "{{ oracle_user_home }}/.Scripts", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
+  - {name: "{{ oracle_user_home }}/{{ scripts_folder }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
 
 # choptcheck is a dummy for 'creates' during chopt-task to force an execution
 _oraswdb_install_choptcheck: "{% if oraswdb_install_forcechopt | bool %}dochopt{% endif %}"


### PR DESCRIPTION
As previously discussed with @Rendanic , there is a hard coded ".Scripts" folder created where e. g. "change_pdb.sql" is placed.
The folder name should be made configurable, so that it can be adapted to other naming conventions.

Additionally (but feel free to cherry pick), the script "change_pdb.sql" should only be copied to the target when `oracle_pdbs` is defined. So there's no unnecessary clutter when CDB/PDB architecture isn't used.

Cheers,
Uwe