### PR TITLE
Release 4.12.0

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,6 +11,9 @@ skip_list:
 
 exclude_paths:
   - .github
+  - .ansible
+  - example
+  - extensions
   - dbhome-conversion
   - docker
   - plugins/modules

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ example/*/ansible/navigator/replay/*json
 example/*/ansible/context
 ansible-navigator.log
 navigator/replay/*json
+.ansible

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,27 @@ opitzconsulting.ansible\_oracle Release Notes
 
 .. contents:: Topics
 
+v4.12.0
+=======
+
+Minor Changes
+-------------
+
+- ansible-lint: more excludes (oravirt#505)
+- common: remove screen from default rhel8,9 package list (oravirt#496)
+- orahost: firewall_service should default to firewalld on OL/EL 8 (oravirt#499)
+
+Bugfixes
+--------
+
+- common: Exclude alias interfaces when templating motd.j2 (oravirt#486)
+- common: force bool type in certain conditionals
+- fix for re global flags when extracting sga/processes parameters in orahost_meta (oravirt#493)
+- orahost_meta: Aggregate SGAs fails if no sga_target or sga_max_size is defined (oravirt#498)
+- orahost_meta: Applying 'lower' filter to oracle_databases+oracle_asm_instance converts list to string (oravirt#484)
+- oraswdb_manage_patches, oraswgi_manage_patches: make unarchive check work for combo patches too (oravirt#482)
+- set and check _oradb_tzupgrade_candidate_pdbs fact when upgrading timezone for a CDB database (oravirt#490)
+
 v4.11.1
 =======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.11.1
+version: 4.12.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -692,6 +692,36 @@ releases:
     - download.yml
     - orasw_meta.yml
     release_date: '2024-10-06'
+  4.12.0:
+    changes:
+      bugfixes:
+      - 'common: Exclude alias interfaces when templating motd.j2 (oravirt#486)'
+      - 'common: force bool type in certain conditionals'
+      - fix for re global flags when extracting sga/processes parameters in orahost_meta
+        (oravirt#493)
+      - 'orahost_meta: Aggregate SGAs fails if no sga_target or sga_max_size is defined
+        (oravirt#498)'
+      - 'orahost_meta: Applying ''lower'' filter to oracle_databases+oracle_asm_instance
+        converts list to string (oravirt#484)'
+      - 'oraswdb_manage_patches, oraswgi_manage_patches: make unarchive check work
+        for combo patches too (oravirt#482)'
+      - set and check _oradb_tzupgrade_candidate_pdbs fact when upgrading timezone
+        for a CDB database (oravirt#490)
+      minor_changes:
+      - 'ansible-lint: more excludes (oravirt#505)'
+      - 'common: remove screen from default rhel8,9 package list (oravirt#496)'
+      - 'orahost: firewall_service should default to firewalld on OL/EL 8 (oravirt#499)'
+    fragments:
+    - aggregate_sgas_fix.yml
+    - ansible-lint.yml
+    - motd.yml
+    - orahost_firewall.yml
+    - re_global_flags_fix.yml
+    - remove_screen_from_default.yml
+    - sga_calculation.yml
+    - tz_cdb_upgrade_issue.yml
+    - unarchive-check.yml
+    release_date: '2025-03-02'
   4.2.0:
     changes:
       breaking_changes:

--- a/changelogs/fragments/aggregate_sgas_fix.yml
+++ b/changelogs/fragments/aggregate_sgas_fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost_meta: Aggregate SGAs fails if no sga_target or sga_max_size is defined (oravirt#497)"

--- a/changelogs/fragments/ansible-lint.yml
+++ b/changelogs/fragments/ansible-lint.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "ansible-lint: more excludes (oravirt#505)"

--- a/changelogs/fragments/motd.yml
+++ b/changelogs/fragments/motd.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "common: Exclude alias interfaces when templating motd.j2 (oravirt#486)"
-  - "common: force bool type in certain conditionals"

--- a/changelogs/fragments/orahost_firewall.yml
+++ b/changelogs/fragments/orahost_firewall.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "orahost: firewall_service should default to firewalld on OL/EL 8 ()"

--- a/changelogs/fragments/re_global_flags_fix.yml
+++ b/changelogs/fragments/re_global_flags_fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - fix for re global flags when extracting sga/processes parameters in orahost_meta

--- a/changelogs/fragments/remove_screen_from_default.yml
+++ b/changelogs/fragments/remove_screen_from_default.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "common: remove screen from default rhel8,9 package list (oravirt#495)"

--- a/changelogs/fragments/sga_calculation.yml
+++ b/changelogs/fragments/sga_calculation.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost_meta: Applying 'lower' filter to oracle_databases+oracle_asm_instance converts list to string (oravirt#484)"

--- a/changelogs/fragments/tz_cdb_upgrade_issue.yml
+++ b/changelogs/fragments/tz_cdb_upgrade_issue.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - set and check _oradb_tzupgrade_candidate_pdbs fact when upgrading timezone for a CDB database

--- a/changelogs/fragments/unarchive-check.yml
+++ b/changelogs/fragments/unarchive-check.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswdb_manage_patches, oraswgi_manage_patches: make unarchive check work for combo patches too (oravirt#482)"

--- a/example/beginner_patching/ansible/requirements.yml
+++ b/example/beginner_patching/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.11.1
+    version: 4.12.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/example/rac/ansible/requirements.yml
+++ b/example/rac/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.11.1
+    version: 4.12.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.11.1
+version: 4.12.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.12.0
=======

Minor Changes
-------------

- ansible-lint: more excludes (oravirt#505)
- common: remove screen from default rhel8,9 package list (oravirt#496)
- orahost: firewall_service should default to firewalld on OL/EL 8 (oravirt#499)

Bugfixes
--------

- common: Exclude alias interfaces when templating motd.j2 (oravirt#486)
- common: force bool type in certain conditionals
- fix for re global flags when extracting sga/processes parameters in orahost_meta (oravirt#493)
- orahost_meta: Aggregate SGAs fails if no sga_target or sga_max_size is defined (oravirt#498)
- orahost_meta: Applying 'lower' filter to oracle_databases+oracle_asm_instance converts list to string (oravirt#484)
- oraswdb_manage_patches, oraswgi_manage_patches: make unarchive check work for combo patches too (oravirt#482)
- set and check _oradb_tzupgrade_candidate_pdbs fact when upgrading timezone for a CDB database (oravirt#490)
