### PR TITLE
manage_pdb: Enter nested loop only when oracle_pdbs has an entry

### DIFF
--- a/changelogs/fragments/create_omf_database.yml
+++ b/changelogs/fragments/create_omf_database.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "manage_pdb: Enter nested loop only when oracle_pdbs has an entry"
+  - create OMF enabled databases using dbca's -useOMF flag

--- a/changelogs/fragments/create_omf_database.yml
+++ b/changelogs/fragments/create_omf_database.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - create OMF enabled databases using dbca's -useOMF flag
+  - "manage_pdb: Enter nested loop only when oracle_pdbs has an entry"

--- a/changelogs/fragments/pdbs-default-for-patching.yml
+++ b/changelogs/fragments/pdbs-default-for-patching.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "manage_pdb: Enter nested loop only when oracle_pdbs has an entry"

--- a/roles/oradb_manage_pdb/tasks/main.yml
+++ b/roles/oradb_manage_pdb/tasks/main.yml
@@ -27,7 +27,7 @@
       environment: "{{ _oracle_env }}"
       with_nested:
         - "{{ oracle_databases }}"
-        - "{{ oracle_pdbs | default([]) }}"
+        - "{{ oracle_pdbs }}"
       become: true
       become_user: "{{ oracle_user }}"
       loop_control:

--- a/roles/oradb_manage_pdb/tasks/main.yml
+++ b/roles/oradb_manage_pdb/tasks/main.yml
@@ -27,7 +27,7 @@
       environment: "{{ _oracle_env }}"
       with_nested:
         - "{{ oracle_databases }}"
-        - "{{ oracle_pdbs }}"
+        - "{{ oracle_pdbs | default([]) }}"
       become: true
       become_user: "{{ oracle_user }}"
       loop_control:


### PR DESCRIPTION
There is an issue when you run Playbooks that call the role "oradb_manage_pdb", when these are run on non-CDB databases.

- The task `manage pdb(s)` enters the `with_nested:` loop, despite the condition `when: oracle_pdbs is defined`.
- The reason is that the `when` part is evaluated _after_ parsing the loop variables. This results in the error:
    `msg: '''oracle_pdbs'' is undefined. ''oracle_pdbs'' is undefined'`
- This is expected behaviour of Ansible. See [Using Conditionals in Loops](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#using-conditionals-in-loops) in the Ansible docs.
- Workarounds:
  - Use `--skip-tags "pdb"` when running affected playbooks (e.g. "opatch.yml").
  - Remove or comment out the calls to "oradb_manage_pdb". But this isn't viable when running playbooks in a mixed CDB / non-CDB environment.
- Fix: Define an empty list as a default for `oracle_pdbs` in the `with_nested:` clause.

I filed it as a "minor change"; feel free to classify it as a bugfix.