### PR TITLE
oradb_tzupgrade: Add orasw_meta_internal as a dependent role

### DIFF
--- a/changelogs/fragments/oradb_tzupgrade_role_dependency.yml
+++ b/changelogs/fragments/oradb_tzupgrade_role_dependency.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oradb_tzupgrade: Add orasw_meta_internal as a dependent role"

--- a/roles/oradb_tzupgrade/README.md
+++ b/roles/oradb_tzupgrade/README.md
@@ -21,6 +21,7 @@ Manage timezone upgrades for an Oracle Database
 ## Dependencies
 
 - orahost_meta
+- orasw_meta_internal
 
 ## License
 

--- a/roles/oradb_tzupgrade/meta/main.yml
+++ b/roles/oradb_tzupgrade/meta/main.yml
@@ -26,3 +26,4 @@ galaxy_info:
 
 dependencies:
   - role: orahost_meta
+  - role: orasw_meta_internal


### PR DESCRIPTION
`_ora_home_db` is defined in `orasw_meta_internal` role and it should be added in the dependencies list. Otherwise, we may end up with an error like:

```
TASK [opitzconsulting.ansible_oracle.oradb_tzupgrade : oradb_tzupgrade | Perform timezone checks for CDB$ROOT and PDB$SEED first] *********************************************************************************************************************************************************
fatal: [vmorastest01]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: '_oracle_home_db' is undefined. '_oracle_home_db' is undefined\n\nThe error appears to be in '/home/devopsadm/profidans/lib/ansible_collections/opitzconsulting/ansible
_oracle/roles/oradb_tzupgrade/tasks/cdb.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: oradb_tzupgrade | Perform timezone checks for CDB$ROOT and PDB$SEED first\n  ^ here\n"} 
```