### PR TITLE
Release 4.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ opitzconsulting.ansible\_oracle Release Notes
 
 .. contents:: Topics
 
+v4.13.0
+=======
+
+Minor Changes
+-------------
+
+- Added a guide on how to install Ansible-Oracle manually on a server without Internet access. (oravirt#506)
+- Fix typo for sql_zauberkasten (oravirt#509)
+- ansible-lint: more excludes (oravirt#505)
+- create OMF enabled databases using dbca's -useOMF flag (oravirt#507)
+- manage_pdb: Enter nested loop only when oracle_pdbs has an entry (oravirt#507)
+- oraapex: Added missing option to copy source from remote or local host (oravirt#512)
+- oradb_manage_db: make hard coded folder .Scripts configurable (oravirt#511)
+- oradb_tzupgrade: Add orasw_meta_internal as a dependent role (oravirt#510)
+
+Bugfixes
+--------
+
+- orahost_meta: move scripts_folder variable from common to orahost_meta (oravirt#504)
+
 v4.12.0
 =======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.12.0
+version: 4.13.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -722,6 +722,31 @@ releases:
     - tz_cdb_upgrade_issue.yml
     - unarchive-check.yml
     release_date: '2025-03-02'
+  4.13.0:
+    changes:
+      bugfixes:
+      - 'orahost_meta: move scripts_folder variable from common to orahost_meta (oravirt#504)'
+      minor_changes:
+      - Added a guide on how to install Ansible-Oracle manually on a server without
+        Internet access. (oravirt#506)
+      - Fix typo for sql_zauberkasten (oravirt#509)
+      - 'ansible-lint: more excludes (oravirt#505)'
+      - create OMF enabled databases using dbca's -useOMF flag (oravirt#507)
+      - 'manage_pdb: Enter nested loop only when oracle_pdbs has an entry (oravirt#507)'
+      - 'oraapex: Added missing option to copy source from remote or local host (oravirt#512)'
+      - 'oradb_manage_db: make hard coded folder .Scripts configurable (oravirt#511)'
+      - 'oradb_tzupgrade: Add orasw_meta_internal as a dependent role (oravirt#510)'
+    fragments:
+    - ansible-lint.yml
+    - apex_sw_local.yml
+    - create_omf_database.yml
+    - doc-local-install.yml
+    - oradb_tzupgrade_role_dependency.yml
+    - pdbs-default-for-patching.yml
+    - scripts-folder-configurable.yml
+    - scripts_folder_fix.yml
+    - typo-zauberkasten.yml
+    release_date: '2025-03-30'
   4.2.0:
     changes:
       breaking_changes:

--- a/changelogs/fragments/ansible-lint.yml
+++ b/changelogs/fragments/ansible-lint.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "ansible-lint: more excludes (oravirt#505)"

--- a/changelogs/fragments/apex_sw_local.yml
+++ b/changelogs/fragments/apex_sw_local.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oraapex: Added missing option to copy source from remote or local host (oravirt#512)"

--- a/changelogs/fragments/create_omf_database.yml
+++ b/changelogs/fragments/create_omf_database.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - create OMF enabled databases using dbca's -useOMF flag
+  - "create OMF enabled databases using dbca's -useOMF flag (oravirt#507)"

--- a/changelogs/fragments/create_omf_database.yml
+++ b/changelogs/fragments/create_omf_database.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "create OMF enabled databases using dbca's -useOMF flag (oravirt#507)"

--- a/changelogs/fragments/doc-local-install.yml
+++ b/changelogs/fragments/doc-local-install.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Added a guide on how to install Ansible-Oracle manually on a server without Internet access. (oravirt#506)"

--- a/changelogs/fragments/doc-local-install.yml
+++ b/changelogs/fragments/doc-local-install.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "Added a guide on how to install Ansible-Oracle manually on a server without Internet access."
+  - "Added a guide on how to install Ansible-Oracle manually on a server without Internet access. (oravirt#506)"

--- a/changelogs/fragments/oradb_tzupgrade_role_dependency.yml
+++ b/changelogs/fragments/oradb_tzupgrade_role_dependency.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_tzupgrade: Add orasw_meta_internal as a dependent role (oravirt#510)"

--- a/changelogs/fragments/oradb_tzupgrade_role_dependency.yml
+++ b/changelogs/fragments/oradb_tzupgrade_role_dependency.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "oradb_tzupgrade: Add orasw_meta_internal as a dependent role"
+  - "oradb_tzupgrade: Add orasw_meta_internal as a dependent role (oravirt#510)"

--- a/changelogs/fragments/pdbs-default-for-patching.yml
+++ b/changelogs/fragments/pdbs-default-for-patching.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "manage_pdb: Enter nested loop only when oracle_pdbs has an entry (oravirt#507)"

--- a/changelogs/fragments/pdbs-default-for-patching.yml
+++ b/changelogs/fragments/pdbs-default-for-patching.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "manage_pdb: Enter nested loop only when oracle_pdbs has an entry"
+  - "manage_pdb: Enter nested loop only when oracle_pdbs has an entry (oravirt#507)"

--- a/changelogs/fragments/scripts-folder-configurable.yml
+++ b/changelogs/fragments/scripts-folder-configurable.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "oradb_manage_db: make hard coded folder .Scripts configurable (oravirt#511)"

--- a/changelogs/fragments/scripts-folder-configurable.yml
+++ b/changelogs/fragments/scripts-folder-configurable.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "oradb_manage_db: make hard coded folder .Scripts configurable"
+  - "oradb_manage_db: make hard coded folder .Scripts configurable (oravirt#511)"

--- a/changelogs/fragments/scripts_folder_fix.yml
+++ b/changelogs/fragments/scripts_folder_fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "orahost_meta: move scripts_folder variable from common to orahost_meta (oravirt#504)"

--- a/changelogs/fragments/scripts_folder_fix.yml
+++ b/changelogs/fragments/scripts_folder_fix.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "orahost_meta: move scripts_folder variable from common to orahost_meta"
+  - "orahost_meta: move scripts_folder variable from common to orahost_meta (oravirt#504)"

--- a/changelogs/fragments/typo-zauberkasten.yml
+++ b/changelogs/fragments/typo-zauberkasten.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "Fix typo for sql_zauberkasten"
+  - "Fix typo for sql_zauberkasten (oravirt#509)"

--- a/changelogs/fragments/typo-zauberkasten.yml
+++ b/changelogs/fragments/typo-zauberkasten.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "Fix typo for sql_zauberkasten (oravirt#509)"

--- a/example/beginner_patching/ansible/requirements.yml
+++ b/example/beginner_patching/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.12.0
+    version: 4.13.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/example/rac/ansible/requirements.yml
+++ b/example/rac/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.12.0
+    version: 4.13.0
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.12.0
+version: 4.13.0
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -394,12 +394,6 @@ The variable is used to cleanup the yum repolist for old installations.
 ol7_repo_file: public-yum-ol7.repo
 ```
 
-#### Default value
-
-```YAML
-scripts_folder: .Scripts
-```
-
 ## Discovered Tags
 
 **_common_assert_**

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -26,11 +26,11 @@ Meta role used by other roles to share variable defaults.
   - [oracle_tmp_stage](#oracle_tmp_stage)
   - [oracle_user](#oracle_user)
   - [oracle_user_home](#oracle_user_home)
-  - [scripts_folder](#scripts_folder)
   - [orahost_meta_cv_assume_distid](#orahost_meta_cv_assume_distid)
   - [orahost_meta_java_options](#orahost_meta_java_options)
   - [orahost_meta_tmpdir](#orahost_meta_tmpdir)
   - [role_separation](#role_separation)
+  - [scripts_folder](#scripts_folder)
   - [sysctl_kernel_sem_force](#sysctl_kernel_sem_force)
 - [Discovered Tags](#discovered-tags)
 - [Dependencies](#dependencies)
@@ -319,10 +319,6 @@ home directory for `oracle_user`.
 oracle_user_home: /home/oracle
 ```
 
-### scripts_folder
-
-Folder under Oracle user home dir to place scripts in
-
 ### orahost_meta_cv_assume_distid
 
 The variable is used by `oracle_script_env` and passed
@@ -384,6 +380,16 @@ See `grid_user` and `oracle_user` for Grid-Infrastructure user.
 
 ```YAML
 role_separation: false
+```
+
+### scripts_folder
+
+Folder under Oracle user home dir to place scripts in
+
+#### Default value
+
+```YAML
+scripts_folder: .Scripts
 ```
 
 ### sysctl_kernel_sem_force


### PR DESCRIPTION
v4.13.0
=======

Minor Changes
-------------

- Added a guide on how to install Ansible-Oracle manually on a server without Internet access. (oravirt#506)
- Fix typo for sql_zauberkasten (oravirt#509)
- ansible-lint: more excludes (oravirt#505)
- create OMF enabled databases using dbca's -useOMF flag (oravirt#507)
- manage_pdb: Enter nested loop only when oracle_pdbs has an entry (oravirt#507)
- oraapex: Added missing option to copy source from remote or local host (oravirt#512)
- oradb_manage_db: make hard coded folder .Scripts configurable (oravirt#511)
- oradb_tzupgrade: Add orasw_meta_internal as a dependent role (oravirt#510)

Bugfixes
--------

- orahost_meta: move scripts_folder variable from common to orahost_meta (oravirt#504)
