### PR TITLE
oradb_tzupgrade: compose the comma delimited list of PDBs using map

### DIFF
--- a/changelogs/fragments/oradb_tzupgrade_pdbs.yml
+++ b/changelogs/fragments/oradb_tzupgrade_pdbs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oradb_tzupgrade_pdbs: compose the list of PDBs in Ansible"

--- a/roles/oradb_tzupgrade/tasks/cdb.yml
+++ b/roles/oradb_tzupgrade/tasks/cdb.yml
@@ -1,5 +1,5 @@
 ---
-- name: oradb_tzupgrade | Perform timezone checks for CDB$ROOT and PDB$SEED first
+- name: cdb | Perform timezone checks for CDB$ROOT and PDB$SEED first
   opitzconsulting.ansible_oracle.oracle_sqldba:
     catcon_pl: "{{ _oracle_home_db }}/rdbms/admin/utltz_upg_check.sql"
     creates_sql: "{{ _oradb_tzupgrade_tz_check_query }}"
@@ -10,7 +10,7 @@
   become_user: "{{ oracle_user }}"
   become: true
 
-- name: oradb_tzupgrade | Upgrade timezone for CDB$ROOT and PDB$SEED
+- name: cdb | Upgrade timezone for CDB$ROOT and PDB$SEED
   opitzconsulting.ansible_oracle.oracle_sqldba:
     catcon_pl: "{{ _oracle_home_db }}/rdbms/admin/utltz_upg_apply.sql"
     creates_sql: "{{ _oradb_tzupgrade_tz_check_query }}"
@@ -21,7 +21,7 @@
   become_user: "{{ oracle_user }}"
   become: true
 
-- name: oradb_tzupgrade | Get all open PDBs
+- name: cdb | Get all open PDBs
   opitzconsulting.ansible_oracle.oracle_sqldba:
     sqlselect: >-
       select name pdb_list
@@ -33,19 +33,19 @@
   become: true
   register: pdbs_info
  
-- name: oradb_tzupgrade | Set facts for pdbs_info
+- name: cdb | Set facts for pdbs_info
   ansible.builtin.set_fact:
     _oradb_tzupgrade_candidate_pdbs: "{{ pdbs_info.state.ROW | map(attribute='PDB_LIST') | list | join(' ') }}"
 
-- name: oradb_tzupgrade | Show facts for pdbs_info
+- name: cdb | Show facts for pdbs_info
   ansible.builtin.debug:
     msg: "Candidate PDBs: {{ _oradb_tzupgrade_candidate_pdbs }}"
 
-- name: oradb_tzupgrade | Upgrade timezone
+- name: cdb | Upgrade timezone
   when: _oradb_tzupgrade_candidate_pdbs != ""
   block:
 
-    - name: oradb_tzupgrade | Perform timezone checks for the candidate PDBs
+    - name: cdb | Perform timezone checks for the candidate PDBs
       opitzconsulting.ansible_oracle.oracle_sqldba:
         catcon_pl: "{{ _oracle_home_db }}/rdbms/admin/utltz_upg_check.sql"
         creates_sql: "{{ _oradb_tzupgrade_tz_check_query }}"
@@ -56,7 +56,7 @@
       become_user: "{{ oracle_user }}"
       become: true
 
-    - name: oradb_tzupgrade | Upgrade timezone for the candidate PDBs
+    - name: cdb | Upgrade timezone for the candidate PDBs
       opitzconsulting.ansible_oracle.oracle_sqldba:
         catcon_pl: "{{ _oracle_home_db }}/rdbms/admin/utltz_upg_apply.sql"
         creates_sql: "{{ _oradb_tzupgrade_tz_check_query }}"
@@ -67,7 +67,7 @@
       become_user: "{{ oracle_user }}"
       become: true
 
-- name: oradb_tzupgrade | Get post upgrade timezone status info
+- name: cdb | Get post upgrade timezone status info
   opitzconsulting.ansible_oracle.oracle_sqldba:
     sql: |
       set tab off
@@ -91,6 +91,6 @@
   changed_when: false
   register: post_status_info
 
-- name: oradb_tzupgrade | Show post upgrade timezone status info
+- name: cdb | Show post upgrade timezone status info
   ansible.builtin.debug:
     msg: "{{ post_status_info.msg | split('\n') }}"

--- a/roles/oradb_tzupgrade/tasks/cdb.yml
+++ b/roles/oradb_tzupgrade/tasks/cdb.yml
@@ -24,7 +24,7 @@
 - name: oradb_tzupgrade | Get all open PDBs
   opitzconsulting.ansible_oracle.oracle_sqldba:
     sqlselect: >-
-      select listagg(name, ' ') within group (order by name) pdb_list
+      select name pdb_list
       from v$pdbs
       where open_mode in ('READ WRITE', 'MIGRATE')
     oracle_home: "{{ _oracle_home_db }}"
@@ -32,10 +32,10 @@
   become_user: "{{ oracle_user }}"
   become: true
   register: pdbs_info
-
+ 
 - name: oradb_tzupgrade | Set facts for pdbs_info
   ansible.builtin.set_fact:
-    _oradb_tzupgrade_candidate_pdbs: "{{ pdbs_info.state.ROW[0].PDB_LIST | default('') }}"
+    _oradb_tzupgrade_candidate_pdbs: "{{ pdbs_info.state.ROW | map(attribute='PDB_LIST') | list | join(' ') }}"
 
 - name: oradb_tzupgrade | Show facts for pdbs_info
   ansible.builtin.debug:

--- a/roles/oradb_tzupgrade/tasks/cdb.yml
+++ b/roles/oradb_tzupgrade/tasks/cdb.yml
@@ -32,7 +32,7 @@
   become_user: "{{ oracle_user }}"
   become: true
   register: pdbs_info
- 
+
 - name: cdb | Set facts for pdbs_info
   ansible.builtin.set_fact:
     _oradb_tzupgrade_candidate_pdbs: "{{ pdbs_info.state.ROW | map(attribute='PDB_LIST') | list | join(' ') }}"

--- a/roles/oradb_tzupgrade/tasks/main.yml
+++ b/roles/oradb_tzupgrade/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: oradb_tzupgrade | Loop over oracle_databases
+- name: Loop over oracle_databases
   ansible.builtin.include_tasks: >-
     {{ odb.is_container | default(false) | ternary('cdb', 'non_cdb') }}.yml
   with_items:

--- a/roles/oradb_tzupgrade/tasks/non_cdb.yml
+++ b/roles/oradb_tzupgrade/tasks/non_cdb.yml
@@ -1,5 +1,5 @@
 ---
-- name: oradb_tzupgrade | Perform timezone checks for a non-CDB database
+- name: non_cdb | Perform timezone checks for a non-CDB database
   opitzconsulting.ansible_oracle.oracle_sqldba:
     sql: "@?/rdbms/admin/utltz_upg_check.sql"
     creates_sql: "{{ _oradb_tzupgrade_tz_check_query }}"
@@ -8,7 +8,7 @@
   become: true
   become_user: "{{ oracle_user }}"
 
-- name: oradb_tzupgrade | Apply the timezone upgrade for the non-CDB database
+- name: non_cdb | Apply the timezone upgrade for the non-CDB database
   opitzconsulting.ansible_oracle.oracle_sqldba:
     sql: "@?/rdbms/admin/utltz_upg_apply.sql"
     creates_sql: "{{ _oradb_tzupgrade_tz_check_query }}"
@@ -17,7 +17,7 @@
   become: true
   become_user: "{{ oracle_user }}"
 
-- name: oradb_tzupgrade | Get post upgrade timezone status info
+- name: non_cdb | Get post upgrade timezone status info
   opitzconsulting.ansible_oracle.oracle_sqldba:
     sql: |
       set lines 200
@@ -35,6 +35,6 @@
   changed_when: false
   register: post_status_info
 
-- name: oradb_tzupgrade | Show post upgrade timezone status info
+- name: non_cdb | Show post upgrade timezone status info
   ansible.builtin.debug:
     msg: "{{ post_status_info.msg | split('\n') }}"


### PR DESCRIPTION
When many PDBs with long names are present, Oracle listagg aggregate function fails. This PR fixes this issue by doing the concatenation in Ansible using the map filter.