### PR TITLE
absolute filesources introduced to oracluvfy, orasw_meta, oraswgi_ins…

### DIFF
--- a/changelogs/fragments/absolute-filesources.yml
+++ b/changelogs/fragments/absolute-filesources.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - "location of files not located under oracle_sw_source_www/filename or oracle_sw_source_local/filename, or named other than {{filename}}, can be forced by absolute path/URL"

--- a/roles/oracluvfy/README.md
+++ b/roles/oracluvfy/README.md
@@ -7,6 +7,7 @@ Manage Cluster Verification Utility from Oracle
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
   - [oracluvfy_archive](#oracluvfy_archive)
+  - [oracluvfy_archive_filesource](#oracluvfy_archive_filesource)
   - [oracluvfy_force_update](#oracluvfy_force_update)
   - [oracluvfy_home](#oracluvfy_home)
 - [Discovered Tags](#discovered-tags)
@@ -30,6 +31,18 @@ ZIP Archive used by the role.
 
 ```YAML
 oracluvfy_archive: cvupack_linux_ol7_x86_64.zip
+```
+
+### oracluvfy_archive_filesource
+
+If `oracluvfy_archive` ist not placed under `oracle_sw_source_local` / `oracle_sw_source_www`,
+path can be forced using `oracluvfy_archive_filesource` instead.
+`oracluvfy_archive_filesource` must be the full path/URL, including the filename.
+
+#### Example usage
+
+```YAML
+oracluvfy_archive_filesource: /full/path/to/cvupack_linux_ol7_x86_64.zip
 ```
 
 ### oracluvfy_force_update

--- a/roles/oracluvfy/defaults/main.yml
+++ b/roles/oracluvfy/defaults/main.yml
@@ -8,6 +8,15 @@ oracluvfy_home: "{{ oracle_base }}/product/cluvfy"
 # @end
 oracluvfy_archive: cvupack_linux_ol7_x86_64.zip
 
+# @var oracluvfy_archive_filesource:description: >
+# If `oracluvfy_archive` ist not placed under `oracle_sw_source_local` / `oracle_sw_source_www`,
+# path can be forced using `oracluvfy_archive_filesource` instead.
+# `oracluvfy_archive_filesource` must be the full path/URL, including the filename.
+# @end
+# @var oracluvfy_archive_filesource:example: >
+# oracluvfy_archive_filesource: /full/path/to/cvupack_linux_ol7_x86_64.zip
+# @end
+
 # @var oracluvfy_force_update:description: >
 # Force unarchive of cluvfy in `oracluvfy_home`.
 # @end

--- a/roles/oracluvfy/tasks/install_cluvfy.yml
+++ b/roles/oracluvfy/tasks/install_cluvfy.yml
@@ -14,8 +14,8 @@
   block:
     - name: install_cluvfy | download cluvfy (copy)
       ansible.builtin.copy:
-        src: "{{ oracle_sw_source_local }}/{{ oracluvfy_archive }}"
-        dest: "{{ oracle_stage }}"
+        src: "{{ oracluvfy_archive_filesource | default(oracle_sw_source_local + '/' + oracluvfy_archive, true) }}"
+        dest: "{{ oracle_stage }}/{{ oracluvfy_archive }}"
         mode: 0664
         force: false
         remote_src: false
@@ -26,8 +26,8 @@
 
     - name: install_cluvfy | download cluvfy (www)
       ansible.builtin.get_url:
-        url: "{{ oracle_sw_source_www }}/{{ oracluvfy_archive }}"
-        dest: "{{ oracle_stage }}"
+        url: "{{ oracluvfy_archive_filesource | default(oracle_sw_source_www + '/' + oracluvfy_archive, true) }}"
+        dest: "{{ oracle_stage }}/{{ oracluvfy_archive }}"
         mode: 0644
         force: false
       when:

--- a/roles/orasw_meta/README.md
+++ b/roles/orasw_meta/README.md
@@ -126,6 +126,7 @@ The dictionary holds data for:
 | Attribute | Description |
 | --- | --- |
 | imagename | Set an optional name for a golden Image to install from. The archiv is read from same directory as the normal installation medias from Oracle. |
+| filesource | `imagename` can be replaced/overridden by `filesource` to provide an absolute path/url to the golden image (when not available in the normal installation place) |
 | edition | allowed values: `SE`, `SE2`, `EE`. default value: <todo> |
 | opatch_minversion | Is needed for patching. Automatically installs a new version of OPatch, when existing version is older then `opatch_minversion` |
 | oracle_home | |
@@ -807,9 +808,12 @@ oracle_stage_remote: '{{ oracle_stage }}'
 
 Defines the list of known Patches in `ansible-oracle`.
 
+Patch files are expected to be found by their `filename` under `oracle_sw_source_local`, or `oracle_sw_source_www` respectively,
+unless a `filesource` dict element provides a full path / complete URL to the patch file.
+
 Usage of this variable:
 
-If a complete software repository with pathches is used with a nfs-mount, this variable is not needed.
+If a complete software repository with patches is used with a nfs-mount, this variable is not needed.
 
 #### Default value
 
@@ -822,12 +826,14 @@ oracle_sw_patches: []
 ```YAML
 oracle_sw_patches:
   - filename: p28183653_122010_Linux-x86-64.zip
+    filesource: /mnt/patches/p28183653_122010_Linux-x86-64.zip
     patchid: 28183653
     version: 12.2.0.1
     patchversion: 12.2.0.1.180717
     description: GI-RU-July-2018
     creates: 28183653/28163133/files/suptools/orachk.zip
   - filename: p27468969_122010_Linux-x86-64.zip
+    filesource: https://downloadserver/patches?id=27468969
     patchid: 27468969
     version: 12.2.0.1
     patchversion: 12.2.0.1.180417

--- a/roles/orasw_meta/defaults/main.yml
+++ b/roles/orasw_meta/defaults/main.yml
@@ -256,6 +256,7 @@ dbenvdir: "{{ oracle_user_home }}/dbenv"
 # | Attribute | Description |
 # | --- | --- |
 # | imagename | Set an optional name for a golden Image to install from. The archiv is read from same directory as the normal installation medias from Oracle. |
+# | filesource | `imagename` can be replaced/overridden by `filesource` to provide an absolute path/url to the golden image (when not available in the normal installation place) |
 # | edition | allowed values: `SE`, `SE2`, `EE`. default value: <todo> |
 # | opatch_minversion | Is needed for patching. Automatically installs a new version of OPatch, when existing version is older then `opatch_minversion` |
 # | oracle_home | |
@@ -292,19 +293,24 @@ dbenvdir: "{{ oracle_user_home }}/dbenv"
 # @var oracle_sw_patches:description: >
 # Defines the list of known Patches in `ansible-oracle`.
 #
+# Patch files are expected to be found by their `filename` under `oracle_sw_source_local`, or `oracle_sw_source_www` respectively,
+# unless a `filesource` dict element provides a full path / complete URL to the patch file.
+#
 # Usage of this variable:
 #
-# If a complete software repository with pathches is used with a nfs-mount, this variable is not needed.
+# If a complete software repository with patches is used with a nfs-mount, this variable is not needed.
 # @end
 # @var oracle_sw_patches:example: >
 # oracle_sw_patches:
 #   - filename: p28183653_122010_Linux-x86-64.zip
+#     filesource: /mnt/patches/p28183653_122010_Linux-x86-64.zip
 #     patchid: 28183653
 #     version: 12.2.0.1
 #     patchversion: 12.2.0.1.180717
 #     description: GI-RU-July-2018
 #     creates: 28183653/28163133/files/suptools/orachk.zip
 #   - filename: p27468969_122010_Linux-x86-64.zip
+#     filesource: https://downloadserver/patches?id=27468969
 #     patchid: 27468969
 #     version: 12.2.0.1
 #     patchversion: 12.2.0.1.180417

--- a/roles/oraswdb_install/README.md
+++ b/roles/oraswdb_install/README.md
@@ -15,6 +15,7 @@ Install Oracle Database Software
   - [hostgroup_leaf](#hostgroup_leaf)
   - [hostinitdaemon](#hostinitdaemon)
   - [oracle_ee_options](#oracle_ee_options)
+  - [oracle_sw_image_db](#oracle_sw_image_db)
   - [oraswdb_install_forcechopt](#oraswdb_install_forcechopt)
   - [oraswdb_install_remove_install_images](#oraswdb_install_remove_install_images)
   - [ulimit_systemd_mapping](#ulimit_systemd_mapping)
@@ -133,6 +134,37 @@ hostinitdaemon: '{{ ansible_service_mgr }}'
 ```YAML
 oracle_ee_options: "{{ _oracle_ee_opiton_dict[db_homes_config[dbh.home]['version']]
   }}"
+```
+
+### oracle_sw_image_db
+
+Mapping for installation media for Oracle
+image files are expected to be found by their `filename` under `oracle_sw_source_local`, or `oracle_sw_source_www` respectively,
+unless a `filesource` dict element provides a full path / complete URL to the patch file.
+
+Formerly, this dict was defined directly as vars/_oraswdb_install_oracle_sw_image_db, where it still will be copied to for compatibility reasons
+
+#### Default value
+
+```YAML
+oracle_sw_image_db:
+  - {filename: LINUX.X64_213000_db_home.zip, version: 21.3.0.0, creates: install/.img.bin}
+  - {filename: LINUX.X64_193000_db_home.zip, version: 19.3.0.0, creates: install/.img.bin,
+    filesource: /mnt/software/LINUX.X64_193000_db_home.zip}
+  - {filename: LINUX.X64_180000_db_home.zip, version: 18.3.0.0, creates: install/.img.bin,
+    filesource: https://downloadserver/dbsw?version=18.3.0.0}
+  - {filename: linuxx64_12201_database.zip, version: 12.2.0.1, creates: database/runInstaller}
+  - {filename: linuxamd64_12102_database_1of2.zip, version: 12.1.0.2, creates: database/stage/sizes/oracle.server.Custom.sizes.properties}
+  - {filename: linuxamd64_12102_database_2of2.zip, version: 12.1.0.2, creates: database/install/.oui}
+  - {filename: linuxamd64_12c_database_1of2.zip, version: 12.1.0.1, creates: database/runInstaller}
+  - {filename: linuxamd64_12c_database_2of2.zip, version: 12.1.0.1, creates: database/runInstaller}
+  - {filename: p13390677_112040_Linux-x86-64_1of7.zip, version: 11.2.0.4, creates: database/install/resource/cons_zh_TW.nls}
+  - {filename: p13390677_112040_Linux-x86-64_2of7.zip, version: 11.2.0.4, creates: database/stage/Components/oracle.db/11.2.0.4.0/1/DataFiles/filegroup18.jar}
+  - {filename: p10404530_112030_Linux-x86-64_1of7.zip, version: 11.2.0.3, creates: database/readme.html}
+  - filename: p10404530_112030_Linux-x86-64_2of7.zip
+    version: 11.2.0.3
+    creates: 
+      database/stage/Components/oracle.sysman.console.db/11.2.0.3.0/1/DataFiles/filegroup2.jar
 ```
 
 ### oraswdb_install_forcechopt

--- a/roles/oraswdb_install/defaults/main.yml
+++ b/roles/oraswdb_install/defaults/main.yml
@@ -75,3 +75,26 @@ glogin_default_cdb:
   - "set heading on"
   - "set termout on"
   - "set time on"
+
+# @var oracle_sw_image_db:description: >
+# Mapping for installation media for Oracle
+# image files are expected to be found by their `filename` under `oracle_sw_source_local`, or `oracle_sw_source_www` respectively,
+# unless a `filesource` dict element provides a full path / complete URL to the patch file.
+#
+# Formerly, this dict was defined directly as vars/_oraswdb_install_oracle_sw_image_db, where it still will be copied to for compatibility reasons
+# @end
+oracle_sw_image_db:
+  - {filename: LINUX.X64_213000_db_home.zip, version: 21.3.0.0, creates: 'install/.img.bin'}
+  - {filename: LINUX.X64_193000_db_home.zip, version: 19.3.0.0, creates: 'install/.img.bin', filesource: /mnt/software/LINUX.X64_193000_db_home.zip}
+  - {filename: LINUX.X64_180000_db_home.zip, version: 18.3.0.0, creates: 'install/.img.bin', filesource: "https://downloadserver/dbsw?version=18.3.0.0"}
+  - {filename: linuxx64_12201_database.zip, version: 12.2.0.1, creates: 'database/runInstaller'}
+  - {filename: linuxamd64_12102_database_1of2.zip, version: 12.1.0.2, creates: 'database/stage/sizes/oracle.server.Custom.sizes.properties'}
+  - {filename: linuxamd64_12102_database_2of2.zip, version: 12.1.0.2, creates: 'database/install/.oui'}
+  - {filename: linuxamd64_12c_database_1of2.zip, version: 12.1.0.1, creates: 'database/runInstaller'}
+  - {filename: linuxamd64_12c_database_2of2.zip, version: 12.1.0.1, creates: 'database/runInstaller'}
+  - {filename: p13390677_112040_Linux-x86-64_1of7.zip, version: 11.2.0.4, creates: 'database/install/resource/cons_zh_TW.nls'}
+  - {filename: p13390677_112040_Linux-x86-64_2of7.zip, version: 11.2.0.4, creates: 'database/stage/Components/oracle.db/11.2.0.4.0/1/DataFiles/filegroup18.jar'}
+  - {filename: p10404530_112030_Linux-x86-64_1of7.zip, version: 11.2.0.3, creates: 'database/readme.html'}
+  - filename: p10404530_112030_Linux-x86-64_2of7.zip
+    version: 11.2.0.3
+    creates: 'database/stage/Components/oracle.sysman.console.db/11.2.0.3.0/1/DataFiles/filegroup2.jar'

--- a/roles/oraswdb_install/tasks/main.yml
+++ b/roles/oraswdb_install/tasks/main.yml
@@ -107,7 +107,7 @@
 
 - name: install_home_db | Transfer oracle installfiles to server (local)
   ansible.builtin.copy:
-    src: "{{ oracle_sw_source_local }}/{{ _local_oracle_sw_image_db }}"
+    src: "{{ _local_oracle_sw_absolute_image_db | default(oracle_sw_source_local + '/' + _local_oracle_sw_image_db, true) }}"
     dest: "{{ oracle_stage }}"
     mode: 0664
     force: false
@@ -131,7 +131,7 @@
 
 - name: install_home_db | Transfer oracle installfiles to server (www)
   ansible.builtin.get_url:
-    url: "{{ oracle_sw_source_www }}/{{ _local_oracle_sw_image_db }}"
+    url: "{{ _local_oracle_sw_absolute_image_db | default(oracle_sw_source_www + '/' + _local_oracle_sw_image_db, true) }}"
     dest: "{{ oracle_stage }}"
     mode: 0644
     force: false

--- a/roles/oraswdb_install/vars/main.yml
+++ b/roles/oraswdb_install/vars/main.yml
@@ -40,23 +40,7 @@ _oraswdb_install_patch_upisubdir: >-
   | ternary(osp_loop.unique_patchid,
   |  osp_loop.patchid) }}/
 
-
-# Mapping for installation media for Oracle
-_oraswdb_install_oracle_sw_image_db:
-  - {filename: LINUX.X64_213000_db_home.zip, version: 21.3.0.0, creates: 'install/.img.bin'}
-  - {filename: LINUX.X64_193000_db_home.zip, version: 19.3.0.0, creates: 'install/.img.bin'}
-  - {filename: LINUX.X64_180000_db_home.zip, version: 18.3.0.0, creates: 'install/.img.bin'}
-  - {filename: linuxx64_12201_database.zip, version: 12.2.0.1, creates: 'database/runInstaller'}
-  - {filename: linuxamd64_12102_database_1of2.zip, version: 12.1.0.2, creates: 'database/stage/sizes/oracle.server.Custom.sizes.properties'}
-  - {filename: linuxamd64_12102_database_2of2.zip, version: 12.1.0.2, creates: 'database/install/.oui'}
-  - {filename: linuxamd64_12c_database_1of2.zip, version: 12.1.0.1, creates: 'database/runInstaller'}
-  - {filename: linuxamd64_12c_database_2of2.zip, version: 12.1.0.1, creates: 'database/runInstaller'}
-  - {filename: p13390677_112040_Linux-x86-64_1of7.zip, version: 11.2.0.4, creates: 'database/install/resource/cons_zh_TW.nls'}
-  - {filename: p13390677_112040_Linux-x86-64_2of7.zip, version: 11.2.0.4, creates: 'database/stage/Components/oracle.db/11.2.0.4.0/1/DataFiles/filegroup18.jar'}
-  - {filename: p10404530_112030_Linux-x86-64_1of7.zip, version: 11.2.0.3, creates: 'database/readme.html'}
-  - filename: p10404530_112030_Linux-x86-64_2of7.zip
-    version: 11.2.0.3
-    creates: 'database/stage/Components/oracle.sysman.console.db/11.2.0.3.0/1/DataFiles/filegroup2.jar'
+_oraswdb_install_oracle_sw_image_db: "{{ oracle_sw_image_db }}"
 
 _oraswdb_install_oracle_directories:
   - {name: "{{ oracle_stage }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: 775}
@@ -85,4 +69,11 @@ _local_oracle_sw_image_db: >-
       | default((_oraswdb_install_oracle_sw_image_db
         | selectattr('version', 'equalto', db_homes_config[dbh.home]['version'])
         | list)[0]['filename']
+      ) }}
+
+_local_oracle_sw_absolute_image_db: >-
+  {{ db_homes_config[dbh.home].filesource
+      | default((_oraswdb_install_oracle_sw_image_db
+        | selectattr('version', 'equalto', db_homes_config[dbh.home]['version'])
+        | list)[0]['filesource']
       ) }}

--- a/roles/oraswdb_manage_patches/tasks/loop_opatch_apply.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_opatch_apply.yml
@@ -36,7 +36,7 @@
 
         - name: loop_opatch_apply | Copy oracle DB patch (opatch) to server (local)
           ansible.builtin.copy:
-            src: "{{ oracle_sw_source_local }}/{{ osp_loop.filename }}"
+            src: "{{ osp_loop.filesource | default(oracle_sw_source_local + '/' + osp_loop.filename, true) }}"
             dest: "{{ oracle_stage }}/{{ osp_loop.filename }}"
             mode: "0644"
             force: false
@@ -46,7 +46,7 @@
 
         - name: loop_opatch_apply | Copy oracle DB patch (opatch) to server (www)
           ansible.builtin.get_url:
-            url: "{{ oracle_sw_source_www }}/{{ osp_loop.filename }}"
+            url: "{{ osp_loop.filesource | default(oracle_sw_source_www + '/' + osp_loop.filename, true) }}"
             dest: "{{ oracle_stage }}/{{ osp_loop.filename }}"
             mode: "0644"
             force: false

--- a/roles/oraswdb_manage_patches/tasks/opatch-upgrade.yml
+++ b/roles/oraswdb_manage_patches/tasks/opatch-upgrade.yml
@@ -49,11 +49,15 @@
 
     - name: db_opatch | Copy oracle opatch to server (local)
       ansible.builtin.copy:
-        src: "{{ oracle_sw_source_local }}/{{ item.filename }}"
+        src: "{{ oop_loop.filesource | default(oracle_sw_source_local + '/' + oop_loop.filename, true) }}"
         dest: "{{ oracle_stage }}"
         mode: "0644"
         force: true
       with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
+      loop_control:
+        loop_var: oop_loop
+        label: >-
+          filename: {{ oop_loop.filename | default('') }}
       when:
         - oracle_sw_copy
         - is_sw_source_local
@@ -62,24 +66,24 @@
       tags:
         - oragridpatchpush
 
-    # - name: db_opatch | Copy oracle opatch to server (www)
-    #   ansible.builtin.get_url:
-    #     url: "{{ oracle_sw_source_www }}/{{ osp_loop.filename }}"
-    #     dest: "{{ oracle_stage }}"
-    #     mode: "0644"
-    #     force: true
-    #   with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
-    #   loop_control:
-    #     loop_var: oop_loop
-    #     label: >-
-    #       filename: {{ oop_loop.filename | default('') }}
-    #   when:
-    #     - oracle_sw_copy
-    #     - not is_sw_source_local
-    #   become: true
-    #   become_user: "{{ oracle_user }}"
-    #   tags:
-    #     - oragridpatchpush
+    - name: db_opatch | Copy oracle opatch to server (www)
+      ansible.builtin.get_url:
+        url: "{{ oop_loop.filesource | default(oracle_sw_source_www + '/' + oop_loop.filename, true) }}"
+        dest: "{{ oracle_stage }}"
+        mode: "0644"
+        force: true
+      with_items: "{{ oracle_opatch_patch | selectattr('version', 'equalto', db_version) }}"
+      loop_control:
+        loop_var: oop_loop
+        label: >-
+          filename: {{ oop_loop.filename | default('') }}
+      when:
+        - oracle_sw_copy
+        - not is_sw_source_local
+      become: true
+      become_user: "{{ oracle_user }}"
+      tags:
+        - oragridpatchpush
 
     - name: db_opatch | Extract OPatch to DB Home
       ansible.builtin.unarchive:

--- a/roles/oraswgi_install/README.md
+++ b/roles/oraswgi_install/README.md
@@ -215,6 +215,11 @@ oracle_scan_port: 1521
 
 ### oracle_sw_image_gi
 
+List of version sepcific GI installation images
+
+NOTE: Image files are expected to be found by their `filename` under `oracle_sw_source_local`, or `oracle_sw_source_www` respectively,
+unless a `filesource` dict element provides a full path / complete URL to the image file.
+
 #### Default value
 
 ```YAML
@@ -227,6 +232,18 @@ oracle_sw_image_gi:
   - {filename: linuxamd64_12102_grid_2of2.zip, version: 12.1.0.2, creates: grid/install/.oui}
   - {filename: linuxamd64_12c_grid_1of2.zip, version: 12.1.0.1}
   - {filename: linuxamd64_12c_grid_2of2.zip, version: 12.1.0.1}
+```
+
+#### Example usage
+
+```YAML
+oracle_sw_image_gi:
+  # LINUX.X64_213000_grid_home.zip located under `oracle_sw_source_local`
+  - {filename: LINUX.X64_213000_grid_home.zip, version: 21.3.0.0, creates: 'install/.img.bin'}
+  # LINUX.X64_193000_grid_home.zip located under /mnt/images
+  - {filename: LINUX.X64_193000_grid_home.zip, filesource: /mnt/images/LINUX.X64_193000_grid_home.zip, version: 19.3.0.0, creates: 'install/.img.bin'}
+  # LINUX.X64_180000_grid_home.zip download
+  - {filename: LINUX.X64_180000_grid_home.zip, filesource: https://downloadserver/images?id=180000_grid_home, version: 18.3.0.0, creates: 'install/.img.bin'}
 ```
 
 ### oracle_vip

--- a/roles/oraswgi_install/defaults/main.yml
+++ b/roles/oraswgi_install/defaults/main.yml
@@ -117,6 +117,19 @@ oracle_asm_storage_option: "{% if oracle_install_version_gi is version('12.2', '
 oracle_gi_gns_vip:
 
 # @var oracle_sw_image_gi:description: >
+# List of version sepcific GI installation images
+#
+# NOTE: Image files are expected to be found by their `filename` under `oracle_sw_source_local`, or `oracle_sw_source_www` respectively,
+# unless a `filesource` dict element provides a full path / complete URL to the image file.
+# @end
+# @var oracle_sw_image_gi:example: >
+# oracle_sw_image_gi:
+#   # LINUX.X64_213000_grid_home.zip located under `oracle_sw_source_local`
+#   - {filename: LINUX.X64_213000_grid_home.zip, version: 21.3.0.0, creates: 'install/.img.bin'}
+#   # LINUX.X64_193000_grid_home.zip located under /mnt/images
+#   - {filename: LINUX.X64_193000_grid_home.zip, filesource: /mnt/images/LINUX.X64_193000_grid_home.zip, version: 19.3.0.0, creates: 'install/.img.bin'}
+#   # LINUX.X64_180000_grid_home.zip download
+#   - {filename: LINUX.X64_180000_grid_home.zip, filesource: https://downloadserver/images?id=180000_grid_home, version: 18.3.0.0, creates: 'install/.img.bin'}
 # @end
 oracle_sw_image_gi:
   - {filename: LINUX.X64_213000_grid_home.zip, version: 21.3.0.0, creates: 'install/.img.bin'}

--- a/roles/oraswgi_install/tasks/curl.yml
+++ b/roles/oraswgi_install/tasks/curl.yml
@@ -1,6 +1,6 @@
 ---
 - name: install_home_gi | Copy oracle installfiles to server (GI) (web - curl)
-  ansible.builtin.shell: "curl -o {{ oracle_stage }}/{{ item.filename }} {{ oracle_sw_source_www }}/{{ item.filename }}"
+  ansible.builtin.shell: "curl -o {{ oracle_stage }}/{{ item.filename }} {{ item.filesource | default(oracle_sw_source_www + '/' + item.filename, true) }}"
   # noqa command-instead-of-shell command-instead-of-module
   with_items: "{{ oracle_sw_image_gi }}"
   become: true

--- a/roles/oraswgi_install/tasks/get_url.yml
+++ b/roles/oraswgi_install/tasks/get_url.yml
@@ -1,8 +1,8 @@
 ---
 - name: install_home_gi | Copy oracle installfiles to server (GI) (web - get_url)
   ansible.builtin.get_url:
-    url: "{{ oracle_sw_source_www }}/{{ item.filename }}"
-    dest: "{{ oracle_stage }}"
+    url: "{{ item.filesource | default(oracle_sw_source_www + '/' + item.filename, true) }}"
+    dest: "{{ oracle_stage }}/{{ item.filename }}"
     mode: "0775"
     force: false
   with_items: "{{ oracle_sw_image_gi }}"

--- a/roles/oraswgi_install/tasks/main_install.yml
+++ b/roles/oraswgi_install/tasks/main_install.yml
@@ -20,7 +20,7 @@
 
 - name: main_install | Copy oracle installfiles to server (GI) (local)
   ansible.builtin.copy:
-    src: "{{ oracle_sw_source_local }}/{{ item.filename }}"
+    src: "{{ item.filesource | default(oracle_sw_source_local + '/' + item.filename, true) }}"
     dest: "{{ oracle_stage }}"
     mode: "0775"
     force: false

--- a/roles/oraswgi_manage_patches/tasks/loop_stage_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_stage_patch.yml
@@ -56,7 +56,7 @@
 
         - name: Loop_stage_patch | Copy oracle GI patch (opatch) to server (local)
           ansible.builtin.copy:
-            src: "{{ oracle_sw_source_local }}/{{ osp_loop.filename }}"
+            src: "{{ osp_loop.filesource | default(oracle_sw_source_local + '/' + osp_loop.filename, true) }}"
             dest: "{{ oracle_stage }}/{{ osp_loop.filename }}"
             mode: "0644"
             force: false
@@ -66,7 +66,7 @@
 
         - name: Loop_stage_patch | Copy oracle GI patch (opatch) to server (www)
           ansible.builtin.get_url:
-            url: "{{ oracle_sw_source_www }}/{{ osp_loop.filename }}"
+            url: "{{ osp_loop.filesource | default(oracle_sw_source_www + '/' + osp_loop.filename, true) }}"
             dest: "{{ oracle_stage }}/{{ osp_loop.filename }}"
             mode: "0644"
             force: false

--- a/roles/oraswgi_manage_patches/tasks/opatch-upgrade.yml
+++ b/roles/oraswgi_manage_patches/tasks/opatch-upgrade.yml
@@ -36,7 +36,7 @@
 
     - name: Opatch-upgrade | Copy oracle opatch to server (www)
       ansible.builtin.get_url:
-        url: "{{ oracle_sw_source_www }}/{{ oop_loop.filename }}"
+        url: "{{ oop_loop.filesource | default(oracle_sw_source_www + '/' + oop_loop.filename, true) }}"
         dest: "{{ oracle_stage }}"
         mode: "0644"
         force: true
@@ -55,7 +55,7 @@
 
     - name: Opatch-upgrade | Copy oracle opatch to server (local)
       ansible.builtin.copy:
-        src: "{{ oracle_sw_source_local }}/{{ item.filename }}"
+        src: "{{ item.filesource | default(oracle_sw_source_local + '/' + item.filename, true) }}"
         dest: "{{ oracle_stage }}"
         mode: "0644"
         force: true


### PR DESCRIPTION
…tall, oraswdb_install, oraswdb_manage_patches, oraswgi_manage_patches

This enhancement allows to provide install images and patches anywhere in the filesystem or under any URL. It eliminates the requirement to have all files located directly under `oracle_sw_source_local` or `oracle_sw_source_www`. It's fully backward compatible as it defaults to the previous way of locating these files.