### PR TITLE
Release 4.13.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ opitzconsulting.ansible\_oracle Release Notes
 
 .. contents:: Topics
 
+v4.13.2
+=======
+
+Bugfixes
+--------
+
+- oradb_manage_db: check if .bashrc exists before trying to disable ocenv
+- oraswgi_install: ansible.builtin.yum fails installing cvuqdisk on FIPS-enabled hosts due to missing package digest
+- oraswgi_manage_patches: roothas_prepatch.yml and roothas_postpatch.yml check wrong directory to determine if GI is locked/unlocked (oravirt#530)
+
 v4.13.1
 =======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -159,4 +159,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.13.1
+version: 4.13.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -764,6 +764,19 @@ releases:
     - oradb_tzupgrade_pdbs.yml
     - release-scripts.yml
     release_date: '2025-04-27'
+  4.13.2:
+    changes:
+      bugfixes:
+      - 'oradb_manage_db: check if .bashrc exists before trying to disable ocenv'
+      - 'oraswgi_install: ansible.builtin.yum fails installing cvuqdisk on FIPS-enabled
+        hosts due to missing package digest'
+      - 'oraswgi_manage_patches: roothas_prepatch.yml and roothas_postpatch.yml check
+        wrong directory to determine if GI is locked/unlocked (oravirt#530)'
+    fragments:
+    - bashrc_check_fix.yml
+    - cvuqdisk-on-fips.yml
+    - gi_locked_check.yml
+    release_date: '2025-10-25'
   4.2.0:
     changes:
       breaking_changes:

--- a/changelogs/fragments/bashrc_check_fix.yml
+++ b/changelogs/fragments/bashrc_check_fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oradb_manage_db: check if .bashrc exists before trying to disable ocenv"

--- a/changelogs/fragments/cvuqdisk-on-fips.yml
+++ b/changelogs/fragments/cvuqdisk-on-fips.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswgi_install: ansible.builtin.yum fails installing cvuqdisk on FIPS-enabled hosts due to missing package digest"

--- a/changelogs/fragments/gi_locked_check.yml
+++ b/changelogs/fragments/gi_locked_check.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "oraswgi_manage_patches: roothas_prepatch.yml and roothas_postpatch.yml check wrong directory to determine if GI is locked/unlocked (oravirt#530)"

--- a/example/beginner/ansible/requirements.yml
+++ b/example/beginner/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.13.1
+    version: 4.13.2
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/example/beginner_patching/ansible/requirements.yml
+++ b/example/beginner_patching/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.13.1
+    version: 4.13.2
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/example/rac/ansible/requirements.yml
+++ b/example/rac/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: opitzconsulting.ansible_oracle
-    version: 4.13.1
+    version: 4.13.2
 
   # following entry is for development only!
   # - name: opitzconsulting.ansible_oracle

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: opitzconsulting
 name: ansible_oracle
 description: "This is the collection of ansible-oracle from https://github.com/oravirt/ansible-oracle"
-version: 4.13.1
+version: 4.13.2
 repository: https://github.com/oravirt/ansible-oracle.git
 readme: README.md
 authors:


### PR DESCRIPTION
v4.13.2
=======

Bugfixes
--------

- oradb_manage_db: check if .bashrc exists before trying to disable ocenv
- oraswgi_install: ansible.builtin.yum fails installing cvuqdisk on FIPS-enabled hosts due to missing package digest
- oraswgi_manage_patches: roothas_prepatch.yml and roothas_postpatch.yml check wrong directory to determine if GI is locked/unlocked (oravirt#530)
