### PR TITLE
Issues comparing / setting attributes of ASM diskgroups

### DIFF
--- a/changelogs/fragments/oracle_asmdg-issues.yml
+++ b/changelogs/fragments/oracle_asmdg-issues.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - "oracle_asmdg.py: wanted_attributes casted to list to reflect change in zip object type"
+  - "oracle_asmdg.py: compare sorted current_properties to sorted wanted_attributes, because we shouldn't rely on the list order of asm_diskgroups' attributes list is the same as querying v$asm_attribute returns"
+  - "oracle_asmdg.py: exclude read_only attributes when building current_properties from v$asm_attribute as they're also removed from wanted_attributes"
+  


### PR DESCRIPTION
There were several issues with oracle_asmdg.py that prevented setting of ASM diskgroup attributes correctly:

1. wanted_attributes, created from a zip() function, is an iterator. Thus it's exhausted on first for loop and comparison to current_properties constantly returns false later on, regardless if diskgroup's attributes match. Apparently this is changed behavior from python2 to python3. wanted_attributes is now casted to list in that case.
2. current_properties is build from a query against ASM views. wanted_attributes is build from diskgroup attributes taken from inventory. If attributes are in different order in those lists (what's very likely, because there's no order by clause in the query, and shouldn't be btw*) comparing wanted_attributes to current_properties would return false even if the attribute values match. Lists now are sorted for comparison.
3. If ASM diskgroup definition contains r/o attributes in inventory, they're removed from wanted_attributes but not from current_properties. Comparing wanted_attributes to current_properties would return false even if all attributes match, just because wanted_attributes is a shorter list than current_properties. Read only attributes now are excluded from v$asm_attribute

\* It doesn't make sense to generally sort wanted_attributes, apart from the point we compare it to current_properties. Actually it might be neccessary to list ASM attributes in a specific order, e.g. compatible.asm has to be raised before compatible.rdbms can be.
