### PR TITLE
oraswdb_install erroneously complains about swap memory would be too low

### DIFF
--- a/changelogs/fragments/config_min_swap.yml
+++ b/changelogs/fragments/config_min_swap.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "oraswdb_install: make minimum required swap space a variable (and consider rounding)"

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -29,6 +29,7 @@ Meta role used by other roles to share variable defaults.
   - [orahost_meta_cv_assume_distid](#orahost_meta_cv_assume_distid)
   - [orahost_meta_java_options](#orahost_meta_java_options)
   - [orahost_meta_tmpdir](#orahost_meta_tmpdir)
+  - [orahost_min_swap_mb](#orahost_min_swap_mb)
   - [role_separation](#role_separation)
   - [scripts_folder](#scripts_folder)
   - [sysctl_kernel_sem_force](#sysctl_kernel_sem_force)
@@ -369,6 +370,20 @@ orahost_meta_java_options: >-
 
 ```YAML
 orahost_meta_tmpdir: '{{ oracle_tmp_stage }}'
+```
+
+### orahost_min_swap_mb
+
+Minimum amount of swap space (in MB) required for DB server.
+Note: We observed ansible_memory_mb.swap.total is 1MB less than configured
+swap (e.g. 16383 instead of 16384 for 16GB)
+
+**_Type:_** integer<br />
+
+#### Default value
+
+```YAML
+orahost_min_swap_mb: 16383
 ```
 
 ### role_separation

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -204,3 +204,11 @@ oracle_nr_bg_processes: 130
 # (collections: oracle_databases, oracle_asm_instance), even if calculated values are lower than current ones
 sysctl_kernel_sem_force: false
 # @end
+
+# @var orahost_min_swap_mb:description: >
+# Minimum amount of swap space (in MB) required for DB server.
+# Note: We observed ansible_memory_mb.swap.total is 1MB less than configured
+# swap (e.g. 16383 instead of 16384 for 16GB)
+# @end
+# @var orahost_min_swap_mb:type: integer
+orahost_min_swap_mb: 16383

--- a/roles/oraswdb_install/tasks/19.3.0.0.yml
+++ b/roles/oraswdb_install/tasks/19.3.0.0.yml
@@ -12,7 +12,7 @@
       ansible.builtin.assert:
         quiet: true
         that:
-          - ansible_memory_mb.swap.total > 16384
+          - ansible_memory_mb.swap.total >= {{ orahost_min_swap_mb }}
       tags:
         - assertswap
         - molecule-notest


### PR DESCRIPTION
In roles/oraswdb_install/tasks/19.3.0.0.yml asserting swap memory erroneously fails, though 16GB swap are configured. For any reason, on systems with 16GB swap, effective amount of swap is 16383M instead of 16384M.

```
# lvdisplay /dev/vg_sys/swap 
  --- Logical volume ---
  LV Path                /dev/vg_sys/swap
  LV Name                swap
  VG Name                vg_sys
  LV UUID                bSDIpB-v8Lv-eJvS-UcrM-X6sM-MxuM-a7FWyc
  LV Write Access        read/write
  LV Creation host, time localhost.localdomain, 2025-10-17 11:32:30 +0200
  LV Status              available
  # open                 1
  LV Size                16.00 GiB <---
  Current LE             4096
  Segments               1
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     256
  Block device           252:1

# free -m
               total        used        free      shared  buff/cache   available
Mem:           15666       14261        2009         124        2212        1405
Swap:          16383 <---   1797       14586
```

Although swap would be reflected correctly, the assert would fail too because it expects more than 16 GB swap (>16384, not >=16384).
To make this a bit more customizable, I introduced a variable orahost_min_swap_mb to replace the hard coded limit; and changed the comparison from > to >=