### PR TITLE
ssh keys and ssh user equivalence

### DIFF
--- a/changelogs/fragments/ssh-user-equivalence.yml
+++ b/changelogs/fragments/ssh-user-equivalence.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - ssh_key_type, ssh_key_bits, ssh_key_file of user's ssh key can now be configured
+  - host key types can now be configured
+bugfixes:
+  - file group of user's keyfile forced to {{ oracle_group }}
+  - ssh user equivalence has always to be set up for GI owner
+  - ssh user equivalence for DB owner only has to be set up for RAC

--- a/changelogs/fragments/ssh-user-equivalence.yml
+++ b/changelogs/fragments/ssh-user-equivalence.yml
@@ -4,6 +4,4 @@ minor_changes:
   - "orahost_meta, orahost_ssh: host key types can now be configured"
 bugfixes:
   - "orahost_ssh: file group of user's keyfile forced to {{ oracle_group }}"
-  - "orahost_ssh: ssh user equivalence has always to be set up for GI owner"
-  - "orahost_ssh: ssh user equivalence for DB owner only has to be set up for RAC"
   - "orahost_ssh: if only a subset of cluster nodes are in the play, key exchange failed"

--- a/changelogs/fragments/ssh-user-equivalence.yml
+++ b/changelogs/fragments/ssh-user-equivalence.yml
@@ -6,3 +6,4 @@ bugfixes:
   - "orahost_ssh: file group of user's keyfile forced to {{ oracle_group }}"
   - "orahost_ssh: ssh user equivalence has always to be set up for GI owner"
   - "orahost_ssh: ssh user equivalence for DB owner only has to be set up for RAC"
+  - "orahost_ssh: if only a subset of cluster nodes are in the play, key exchange failed"

--- a/plugins/modules/oracle_sqldba.py
+++ b/plugins/modules/oracle_sqldba.py
@@ -102,6 +102,10 @@ options:
         description: set NLS_LANG to the given value
     chdir:
         description: Working directory for SQL/script execution
+    ignorable_err:
+        description: Optional list of ORA, TNS, PLS or SP2 errors.
+        required: false
+        default: None
 
 author: Dietmar Uhlig, Robotron (www.robotron.de)
 '''
@@ -171,6 +175,8 @@ db_postinstall:
     sqlselect: "select value from gv$parameter where name = 'job_queue_processes'"
     oracle_home: "{{ oracle_db_home }}"
     oracle_db_name: "{{ oracle_db_name }}"
+    ignorable_err:
+      - "ORA-01555"
   register: jqpresult
 
 - name: Store job_queue_processes
@@ -186,6 +192,7 @@ err_msg = None
 oracle_home = ""
 pdb_list = ""
 sql_process = None
+ignorable_err = ""
 
 # Maximum runtime for sqlplus and catcon.pl in seconds. 0 means no timeout.
 timeout = 0
@@ -220,6 +227,8 @@ def sqlplus():
 def conn(username, password):
     if username is None:
         return "conn / as sysdba\n"
+    elif username.lower() == "sys":
+        return "conn " + "/".join([username, password]) + " as sysdba\n"
     else:
         return "conn " + "/".join([username, password]) + "\n"
 
@@ -231,6 +240,9 @@ def sql_input(sql, username, password, pdb):
 
     if pdb is not None:
         sql_scr += "alter session set container = " + pdb + ";\n"
+    # Sometimes the previous settings are lost after connecting, so setting it again
+    sql_scr += "set heading off echo off feedback off termout on\n"
+    sql_scr += "set long 1000000 pagesize 0 linesize 1000 trimspool on\n"
     sql_scr += sql + "\n"
     sql_scr += "exit;\n"
     return sql_scr
@@ -243,20 +255,20 @@ def kill_process():
     err_msg = "Timeout occured after %d seconds. " % timeout
 
 
-def run_sql_p(sql, username, password, scope, pdb_list):
+def run_sql_p(sql, username, password, scope, pdb_list, ignorable_err):
     global changed, err_msg, sql_process
 
     err_msg = ""
     result = ""
     if scope == 'pdbs':
         for pdb in pdb_list.split():
-            result += run_sql(sql, username, password, pdb)
+            result += run_sql(sql, username, password, pdb, ignorable_err)
     else:
-        result = run_sql(sql, username, password, None)
+        result = run_sql(sql, username, password, None, ignorable_err)
     return result
 
 
-def run_sql(sql, username, password, pdb):
+def run_sql(sql, username, password, pdb, ignorable_err):
     global changed, err_msg, sql_process
 
     t = None
@@ -284,30 +296,34 @@ def run_sql(sql, username, password, pdb):
             serr,
         )
         return "[ERR]"
-    sqlerr_pat = re.compile("^(ORA|TNS|SP2)-[0-9]+", re.MULTILINE)
-    sqlplus_err = sqlerr_pat.search(sout.decode())
-    if sqlplus_err:
-        err_msg += "[ERR] sqlplus: %s\nERR Code: %s.\n" % (sql_cmd, sqlplus_err.group())
-        return "[ERR]\n%s\n" % sout.strip()
-
+    sqlerr_pat = re.compile(r"^\s*((?:ORA|PLS|TNS|SP2)-\d+)", re.MULTILINE)
+    sqlplus_err = sqlerr_pat.findall(sout.decode())
+    if len(sqlplus_err) > 0:
+        if ignorable_err is None:
+            ignorable_err = []
+        relevant_errs = [x for x in sqlplus_err if x not in ignorable_err]
+        for relevant_err in relevant_errs:
+            err_msg += "[ERR] sqlplus: %s\nERR Code: %s.\n" % (sql_cmd, relevant_err)
+        if relevant_errs:
+            return "[ERR]\n%s\n" % sout.strip()
     changed = True
     return sout.decode('utf-8').strip()
 
 
-def check_creates_sql(sql, scope):
+def check_creates_sql(sql, scope, ignorable_err):
     global pdb_list, err_msg
 
     err_msg = ""
     if not sql.endswith(";"):
         sql += ";"
-    if scope == 'cdb':
-        res = run_sql(sql, None, None, None)
+    if scope == "cdb":
+        res = run_sql(sql, None, None, None, ignorable_err)
         # error handling see call of check_creates_sql
         return False if not res or res == "0" else True
     else:
         checked_pdb_list = ""
         for pdb in pdb_list.split():
-            res = run_sql(sql, None, None, pdb)
+            res = run_sql(sql, None, None, pdb, ignorable_err)
             # error handling see call of check_creates_sql
             if not res or res == "0":
                 checked_pdb_list += " " + pdb
@@ -316,7 +332,7 @@ def check_creates_sql(sql, scope):
 
 
 def is_container():
-    return run_sql("select cdb from gv$database;", None, None, None) == 'YES'
+    return run_sql("select cdb from gv$database;", None, None, None, []) == "YES"
 
 
 def get_all_pdbs():
@@ -326,7 +342,7 @@ def get_all_pdbs():
         "select listagg(pdb_name, ' ') within group (order by pdb_name) "
         "Sfrom dba_pdbs where status = 'NORMAL' and pdb_name <> 'PDB$SEED';"
     )
-    pdb_list = 'CDB$ROOT ' + run_sql(sql, None, None, None)
+    pdb_list = "CDB$ROOT " + run_sql(sql, None, None, None, [])
 
 
 def run_catcon_pl(catcon_pl):
@@ -334,7 +350,7 @@ def run_catcon_pl(catcon_pl):
     global oracle_home, changed, result, err_msg, pdb_list, sql_process
 
     err_msg = ""
-    catcon_pl = re.sub("^(\$ORACLE_HOME|\?)", oracle_home, catcon_pl)  # noqa W805
+    catcon_pl = re.sub(r"^(\$ORACLE_HOME|\?)", oracle_home, catcon_pl)  # noqa W805
     logdir = tempfile.mkdtemp()
     catcon_cmd = [
         os.path.join(oracle_home, "perl", "bin", "perl"),
@@ -385,8 +401,7 @@ def run_catcon_pl(catcon_pl):
 
 
 def main():
-    global oracle_home, changed, result, err_msg, pdb_list
-
+    global oracle_home, changed, result, err_msg, pdb_list, ignorable_err
     module = AnsibleModule(
         argument_spec=dict(
             sql=dict(required=False),
@@ -406,6 +421,9 @@ def main():
             oracle_db_name=dict(required=True),
             nls_lang=dict(required=False),
             chdir=dict(required=False),
+            ignorable_err=dict(
+                required=False,
+            ),
         ),
         mutually_exclusive=[
             ['sql', 'sqlscript', 'catcon_pl', 'sqlselect'],
@@ -426,6 +444,7 @@ def main():
     oracle_db_name = module.params["oracle_db_name"]
     nls_lang = module.params["nls_lang"]
     workdir = module.params["chdir"]
+    ignorable_err = module.params["ignorable_err"]
 
     os.environ["ORACLE_HOME"] = oracle_home
     os.environ["ORACLE_SID"] = oracle_db_name
@@ -459,7 +478,7 @@ def main():
             )
 
     if creates_sql is not None:
-        already_done = check_creates_sql(creates_sql, scope)
+        already_done = check_creates_sql(creates_sql, scope, ignorable_err)
         if err_msg:
             module.fail_json(msg="%s\n%s" % (result, err_msg), changed=False)
         else:
@@ -477,16 +496,20 @@ def main():
             + sqlselect.replace("'", "''")
             + "') from dual;"
         )
-        result = run_sql_p(sqlselect, username, password, scope, pdb_list)
+        result = run_sql_p(
+            sqlselect, username, password, scope, pdb_list, ignorable_err
+        )
     elif sql is not None:
         sql = os.linesep.join([s for s in sql.splitlines() if s.strip()])
         if not sql.endswith(";") and not sql.endswith("/"):
             sql += ";"
-        result += run_sql_p(sql, username, password, scope, pdb_list)
+        result += run_sql_p(sql, username, password, scope, pdb_list, ignorable_err)
     elif sqlscript is not None:
         if not sqlscript.startswith("@"):
             sqlscript = "@" + sqlscript
-        result += run_sql_p(sqlscript, username, password, scope, pdb_list)
+        result += run_sql_p(
+            sqlscript, username, password, scope, pdb_list, ignorable_err
+        )
     elif catcon_pl is not None:
         run_catcon_pl(catcon_pl)
 

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -85,6 +85,9 @@
     uid: "{{ item.uid | default(omit) }}"
     home: "{{ item.home | default(omit) }}"
     generate_ssh_key: true
+    ssh_key_type: "{{ orahost_ssh_key_type }}"
+    ssh_key_bits: "{{ orahost_ssh_key_size }}"
+    ssh_key_file: ".ssh/id_{{ orahost_ssh_key_type }}"
     append: true
     state: present
     password: "{{ item.passwd | default(omit) }}"
@@ -100,6 +103,9 @@
     uid: "{{ item.uid | default(omit) }}"
     home: "{{ item.home | default(omit) }}"
     generate_ssh_key: true
+    ssh_key_type: "{{ orahost_ssh_key_type }}"
+    ssh_key_bits: "{{ orahost_ssh_key_size }}"
+    ssh_key_file: ".ssh/id_{{ orahost_ssh_key_type }}"
     append: true
     state: present
     password: "{{ item.passwd | default(omit) }}"

--- a/roles/orahost_meta/README.md
+++ b/roles/orahost_meta/README.md
@@ -29,6 +29,9 @@ Meta role used by other roles to share variable defaults.
   - [orahost_meta_cv_assume_distid](#orahost_meta_cv_assume_distid)
   - [orahost_meta_java_options](#orahost_meta_java_options)
   - [orahost_meta_tmpdir](#orahost_meta_tmpdir)
+  - [orahost_ssh_hostkeytypes](#orahost_ssh_hostkeytypes)
+  - [orahost_ssh_key_size](#orahost_ssh_key_size)
+  - [orahost_ssh_key_type](#orahost_ssh_key_type)
   - [role_separation](#role_separation)
   - [scripts_folder](#scripts_folder)
   - [sysctl_kernel_sem_force](#sysctl_kernel_sem_force)
@@ -369,6 +372,40 @@ orahost_meta_java_options: >-
 
 ```YAML
 orahost_meta_tmpdir: '{{ oracle_tmp_stage }}'
+```
+
+### orahost_ssh_hostkeytypes
+
+SSH host key types to collect/deploy among hosts
+Please note, ed25519 is not supported on FIPS enabled systems and though better not collected
+
+#### Default value
+
+```YAML
+orahost_ssh_hostkeytypes:
+  - dsa
+  - rsa
+  - ecdsa
+```
+
+### orahost_ssh_key_size
+
+SSH key size of {{ orahost_ssh_key_type }}
+
+#### Default value
+
+```YAML
+orahost_ssh_key_size: 4096
+```
+
+### orahost_ssh_key_type
+
+SSH key type for oracle and grid users' SSH Keys
+
+#### Default value
+
+```YAML
+orahost_ssh_key_type: rsa
 ```
 
 ### role_separation

--- a/roles/orahost_meta/defaults/main.yml
+++ b/roles/orahost_meta/defaults/main.yml
@@ -203,4 +203,21 @@ oracle_nr_bg_processes: 130
 # Force setting kernel.sem depending on configured instances
 # (collections: oracle_databases, oracle_asm_instance), even if calculated values are lower than current ones
 sysctl_kernel_sem_force: false
+
+# @var orahost_ssh_key_type:description: >
+# SSH key type for oracle and grid users' SSH Keys
 # @end
+orahost_ssh_key_type: rsa
+# @var orahost_ssh_key_size:description: >
+# SSH key size of {{ orahost_ssh_key_type }}
+# @end
+orahost_ssh_key_size: 4096
+
+# @var orahost_ssh_hostkeytypes:description: >
+# SSH host key types to collect/deploy among hosts
+# Please note, ed25519 is not supported on FIPS enabled systems and though better not collected
+# @end
+orahost_ssh_hostkeytypes:
+  - dsa
+  - rsa
+  - ecdsa

--- a/roles/orahost_ssh/README.md
+++ b/roles/orahost_ssh/README.md
@@ -30,7 +30,7 @@ Example for oracle:
 #### Default value
 
 ```YAML
-orahost_ssh_keyname: id_ed25519
+orahost_ssh_keyname: id_{{ orahost_ssh_key_type }}
 ```
 
 

--- a/roles/orahost_ssh/defaults/main.yml
+++ b/roles/orahost_ssh/defaults/main.yml
@@ -6,4 +6,4 @@
 #
 # /home/oracle/.ssh/{{ orahost_ssh_keyname }}
 # @end
-orahost_ssh_keyname: id_ed25519
+orahost_ssh_keyname: "id_{{ orahost_ssh_key_type }}"

--- a/roles/orahost_ssh/tasks/loop_osuser.yml
+++ b/roles/orahost_ssh/tasks/loop_osuser.yml
@@ -7,7 +7,8 @@
   ansible.builtin.file:
     path: "{{ _key_owner_home }}/.ssh"
     owner: "{{ _key_owner }}"
-    mode: 0700
+    group: "{{ _key_group }}"
+    mode: "0700"
     state: directory
 
 # Keys are only created when not existing.
@@ -15,7 +16,11 @@
   community.crypto.openssh_keypair:
     path: "{{ _key_owner_home }}/.ssh/{{ orahost_ssh_keyname }}"
     owner: "{{ _key_owner }}"
-    type: ed25519
+    group: "{{ _key_group }}"
+    force: false
+    mode: "0600"
+    size: "{{ orahost_ssh_key_size }}"
+    type: "{{ orahost_ssh_key_type }}"
 
 - name: Read public key from remote host for user {{ _key_owner }}
   ansible.builtin.slurp:
@@ -32,17 +37,30 @@
     state: present
   with_items: "{{ groups[orasw_meta_cluster_hostgroup] }}"
 
-- name: Read host key from remote host with ssh-keyscan
-  ansible.builtin.command: ssh-keyscan -t ecdsa-sha2-nistp256 {{ ansible_hostname }}
+- name: Read host keys from remote host with ssh-keyscan
+  ansible.builtin.command: ssh-keyscan -t {{ orahost_ssh_hostkeytypes | join(',') }} {{ ansible_hostname }}
   register: ssh_hostkey_res
   changed_when: ssh_hostkey_res.rc == 0
 
+- name: Ensure known_hosts file exists with right permissions
+  ansible.builtin.file:
+    path: "{{ _key_owner_home }}/.ssh/known_hosts"
+    state: touch
+    owner: "{{ _key_owner }}"
+    group: "{{ _key_group }}"
+    mode: "0600"
+  register: _known_hosts_state
+  changed_when: _known_hosts_state.diff.before.state == 'absent'
+
 - name: Add hostkeys to user {{ _key_owner }}
   ansible.builtin.known_hosts:
-    name: "{{ _hostkey_line | split(' ') | first }}"
-    key: "{{ _hostkey_line }}"
+    name: "{{ _hostkey_for_host[0] | split(' ') | first }}"
+    key: "{{ _hostkey_for_host[0] }}"
     path: "{{ _key_owner_home }}/.ssh/known_hosts"
     state: present
-  with_items: "{{ groups[orasw_meta_cluster_hostgroup] }}"
-  vars:
-    _hostkey_line: "{{ hostvars[item]['ssh_hostkey_res']['stdout_lines'] | first }}"
+  delegate_to: "{{ _hostkey_for_host[1] }}"
+  loop: "{{ ssh_hostkey_res.stdout_lines | product(groups[orasw_meta_cluster_hostgroup]) }}"
+  loop_control:
+    loop_var: _hostkey_for_host
+    label: "{{ (_hostkey_for_host[0] | split(' '))[0] }} {{ (_hostkey_for_host[0] | split(' '))[1] }}"
+  throttle: 1

--- a/roles/orahost_ssh/tasks/loop_osuser.yml
+++ b/roles/orahost_ssh/tasks/loop_osuser.yml
@@ -35,7 +35,7 @@
       {{ hostvars[item]['ssh_pubkey_res']['content'] | b64decode | split('\n') | first }}
     user: "{{ _key_owner }}"
     state: present
-  with_items: "{{ groups[orasw_meta_cluster_hostgroup] }}"
+  with_items: "{{ groups[orasw_meta_cluster_hostgroup] | intersect(ansible_play_hosts) }}"
 
 - name: Read host keys from remote host with ssh-keyscan
   ansible.builtin.command: ssh-keyscan -t {{ orahost_ssh_hostkeytypes | join(',') }} {{ ansible_hostname }}
@@ -59,7 +59,7 @@
     path: "{{ _key_owner_home }}/.ssh/known_hosts"
     state: present
   delegate_to: "{{ _hostkey_for_host[1] }}"
-  loop: "{{ ssh_hostkey_res.stdout_lines | product(groups[orasw_meta_cluster_hostgroup]) }}"
+  loop: "{{ ssh_hostkey_res.stdout_lines | product(groups[orasw_meta_cluster_hostgroup] | intersect(ansible_play_hosts)) }}"
   loop_control:
     loop_var: _hostkey_for_host
     label: "{{ (_hostkey_for_host[0] | split(' '))[0] }} {{ (_hostkey_for_host[0] | split(' '))[1] }}"

--- a/roles/orahost_ssh/tasks/loop_osuser.yml
+++ b/roles/orahost_ssh/tasks/loop_osuser.yml
@@ -63,4 +63,5 @@
   loop_control:
     loop_var: _hostkey_for_host
     label: "{{ (_hostkey_for_host[0] | split(' '))[0] }} {{ (_hostkey_for_host[0] | split(' '))[1] }}"
+  when: not _hostkey_for_host[0].startswith('#')
   throttle: 1

--- a/roles/orahost_ssh/tasks/main.yml
+++ b/roles/orahost_ssh/tasks/main.yml
@@ -9,12 +9,14 @@
       vars:
         _key_owner_home: "{{ oracle_user_home }}"
         _key_owner: "{{ oracle_user }}"
+        _key_group: "{{ oracle_group }}"
+      when:
+        - oracle_databases is defined
+        - oracle_databases | selectattr('oracle_db_type','contains','RAC') | length > 0
 
     - name: SSH-Keys for {{ _grid_install_user }}
       ansible.builtin.include_tasks: loop_osuser.yml
       vars:
         _key_owner_home: "{{ grid_user_home }}"
         _key_owner: "{{ _grid_install_user }}"
-      when:
-        - role_separation | bool
-        - oracle_user != _grid_install_user
+        _key_group: "{{ oracle_group }}"

--- a/roles/orahost_ssh/tasks/main.yml
+++ b/roles/orahost_ssh/tasks/main.yml
@@ -10,9 +10,6 @@
         _key_owner_home: "{{ oracle_user_home }}"
         _key_owner: "{{ oracle_user }}"
         _key_group: "{{ oracle_group }}"
-      when:
-        - oracle_databases is defined
-        - oracle_databases | selectattr('oracle_db_type','contains','RAC') | length > 0
 
     - name: SSH-Keys for {{ _grid_install_user }}
       ansible.builtin.include_tasks: loop_osuser.yml
@@ -20,3 +17,6 @@
         _key_owner_home: "{{ grid_user_home }}"
         _key_owner: "{{ _grid_install_user }}"
         _key_group: "{{ oracle_group }}"
+      when:
+        - role_separation | bool
+        - oracle_user != _grid_install_user


### PR DESCRIPTION
Changes:
- User and host ssh keys types and lengths can now be configured to meet individual security requirements, e.g. user ssh keypairs were hard coded to ed25519 in orahost_ssh/tasks/loop_osuser.yml, but ed25519 ist not accepted on FIPS enabled systems.
Bugfixes:
- File group of user ssh keys is now set to `{{oracle_group}}`, was omitted and thus `root` before
- With user role separation, ssh user equivalence for DB software owner was set up although not necessary for non-RAC, and it potentially violates least-privilege principles