### PR TITLE
* With SEHA, srvctl might start a database at an other node and conse…

### DIFF
--- a/changelogs/fragments/seha-support-for-datapatch.yml
+++ b/changelogs/fragments/seha-support-for-datapatch.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "On cluster setups, srvctl now starts the databases at the local host (oravirt #573)"
+  - "On cluster setups, datapatch assumes the database to exist only if it's defined AND running at the local host (oravirt #573)"

--- a/plugins/modules/oracle_datapatch.py
+++ b/plugins/modules/oracle_datapatch.py
@@ -109,15 +109,32 @@ def check_db_exists(module, msg, oracle_home, db_name, sid, db_unique_name):
             checkdb = db_unique_name
         else:
             checkdb = db_name
-        command = "%s/bin/srvctl config database -d %s " % (oracle_home, checkdb)
-        (rc, stdout, stderr) = module.run_command(command)
+        if is_cluster:
+            # for cluster, assume SEHA and check if database is up at the local host
+            # (otherwise we can't datapatch it)
+            command = (
+                "%(oracle_home)s/bin/srvctl config database -d %(checkdb)s && \
+                %(oracle_home)s/bin/srvctl status database -d %(checkdb)s | \
+                grep -q %(shortname)s"
+                % {
+                    'oracle_home': oracle_home,
+                    'checkdb': checkdb,
+                    'shortname': os.uname()[1].split('.')[0],
+                }
+            )
+        else:
+            command = "%s/bin/srvctl config database -d %s" % (oracle_home, checkdb)
+
+        # cluster check command needs a shell, because we run multiple commands and pipe
+        (rc, stdout, stderr) = module.run_command(command, use_unsafe_shell=is_cluster)
+
         if rc != 0:
             if '%s' % (db_name) in stdout:  # <-- db doesn't exist
                 return False
             else:
                 msg = 'Error: command is  %s. stdout is %s' % (command, stdout)
                 return False
-        elif 'Database name: %s' % (db_name) in stdout:  # <-- Database already exist
+        else:
             return True
     else:
         existingdbs = []
@@ -305,6 +322,7 @@ def main():
     global port
     global output
     global cursor
+    global is_cluster
 
     cursor = None
 
@@ -352,6 +370,15 @@ def main():
         gimanaged = True
     else:
         gimanaged = False
+
+    # If gimanaged, check whether it's Oracle Restart or Oracle Clusterware
+    is_cluster = False
+    ocr_loc = '/etc/oracle/ocr.loc'
+    if gimanaged and os.path.exists(ocr_loc):
+        ocr_grep = subprocess.run(
+            ['grep', '-Piq', '^\\s*local_only\\s*=\\s*false', ocr_loc]
+        )
+        is_cluster = not bool(ocr_grep.returncode)
 
     # if not cx_oracle_exists:
     #     msg = (

--- a/plugins/modules/oracle_db.py
+++ b/plugins/modules/oracle_db.py
@@ -1078,7 +1078,17 @@ def start_instance(
                     instance_name,
                 )
             else:
-                command = '%s/bin/srvctl start database -d %s ' % (oracle_home, db_name)
+                if is_cluster:
+                    command = '%s/bin/srvctl start database -d %s -node %s ' % (
+                        oracle_home,
+                        db_name,
+                        os.uname()[1].split('.')[0],
+                    )
+                else:
+                    command = '%s/bin/srvctl start database -d %s ' % (
+                        oracle_home,
+                        db_name,
+                    )
             if open_mode is not None:
                 command += ' -o %s ' % (open_mode)
             (rc, stdout, stderr) = module.run_command(command)
@@ -1224,6 +1234,7 @@ def main():
     global verboselist
     global domain
     global cursor
+    global is_cluster
 
     cursor = None
 
@@ -1275,7 +1286,7 @@ def main():
             state               = dict(default="present", choices = ["present", "absent", "started", "restarted"]), # noqa E231
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']), # noqa E231
             port                = dict(required=False, default = 1521), # noqa E231
-            omf                 = dict(required=False, type='bool', default=False), #noqa E231
+            omf                 = dict(required=False, type='bool', default=False), # noqa E231
         ),
         mutually_exclusive=[['memory_percentage', 'memory_totalmb']],
     )
@@ -1347,6 +1358,15 @@ def main():
         if not cx_oracle_exists:
             msg = "The cx_Oracle module is required. 'pip install cx_Oracle' should do the trick. If cx_Oracle is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH are set"  # noqa E501
             module.fail_json(msg=msg)
+
+    # If gimanaged, check whether it's Oracle Restart or Oracle Clusterware
+    is_cluster = False
+    ocr_loc = '/etc/oracle/ocr.loc'
+    if gimanaged and os.path.exists(ocr_loc):
+        ocr_grep = subprocess.run(
+            ['grep', '-Piq', '^\\s*local_only\\s*=\\s*false', ocr_loc]
+        )
+        is_cluster = not bool(ocr_grep.returncode)
 
     # Connection details for database
     user = 'sys'


### PR DESCRIPTION
…quently we'd fail to datapatch it. Thus we now try to explicitly start it at the local node.

  And we we assume the database to exist only if it's up AND running at the local node.
* Checking the "Database name:" part of database configuration doesn't seem to be neccessary at that point, as we already know the database is there. As dbname is an optional attribute there's good chance for false negative just because the attibute wasn't set.
* Fixes #573 