### PR TITLE
Issues with stage tmp solved

### DIFF
--- a/changelogs/fragments/tempdir-issues.yml
+++ b/changelogs/fragments/tempdir-issues.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "Fixed _JAVA_OPTIONS in script_env"
+  - "Ensure oracle_tmp_stage is present at all cluster nodes when patching GI"

--- a/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
@@ -56,7 +56,7 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ gip_opatch.0.state }}"
-    script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': '-Djava.io.tmpdir=' + orahost_meta_java_options} }}"
+    script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': orahost_meta_java_options} }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', grid_user) }}"
   vars:

--- a/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
@@ -10,6 +10,22 @@
   ansible.builtin.debug:
     var: gihome_patches.stdout_lines
 
+# opatch precheck runs cluvfy on all cluster nodes in {{ oracle_tmp_stage }}, although patching only one
+- name: post_install_patch | Ensure stage temp directory is present at all nodes when patching a cluster
+  when:
+    - orasw_meta_cluster_hostgroup is defined
+    - _oraswgi_manage_patches_crstype == 'crs'
+  ansible.builtin.file:
+    path: "{{ oracle_tmp_stage }}"
+    state: directory
+    owner: "{{ _grid_install_user }}"
+    group: "{{ oracle_group }}"
+    mode: "0775"
+  delegate_to: "{{ _oraswgi_manage_patches_cluster_host }}"
+  loop: "{{ groups[orasw_meta_cluster_hostgroup] | intersect(ansible_play_hosts) }}"
+  loop_control:
+    loop_var: _oraswgi_manage_patches_cluster_host
+
 - name: post_install_patch | Remove opatch apply patches from GI 19c+
   ansible.builtin.include_tasks: loop_remove_single_opatch.yml
   with_items:


### PR DESCRIPTION
There were two issues wit oracle stage temp directory, which are solved by this pull request:

- _JAVA_OPTIONS was like `-Djava.io.tmpdir=-Djava.io.tmpdir=<tempdir>`, while it should be `-Djava.io.tmpdir=<tempdir>` only
- When patching clusterware, several pre-checks run on all cluster nodes, not only the patching one. This fails if stage temp directory isn't present at the other nodes.