### PR TITLE
Forcing LANG to en_US.UTF8

### DIFF
--- a/changelogs/fragments/force-en_US-lang.yml
+++ b/changelogs/fragments/force-en_US-lang.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Ensure glibc-langpack-en is installed and LANG is forced to en_US.UTF-8 in oracle_db and oracle_datapatch modeules"

--- a/plugins/modules/oracle_datapatch.py
+++ b/plugins/modules/oracle_datapatch.py
@@ -78,6 +78,11 @@ options:
             The listener port to connect to the database
         required: false
         default: 1521
+    script_env:
+        description: >
+            Dictionary of environment settings to be passed to run_command
+        required: false
+        default: {}
 author: Mikael Sandström, oravirt@gmail.com, @oravirt
 '''
 
@@ -92,9 +97,9 @@ EXAMPLES = '''
 #     cx_oracle_exists = True
 
 
-def get_version(module, msg, oracle_home):
+def get_version(module, msg, oracle_home, script_env):
     command = '%s/bin/sqlplus -V' % (oracle_home)
-    (rc, stdout, stderr) = module.run_command(command)
+    (rc, stdout, stderr) = module.run_command(command, environ_update=script_env)
     if rc != 0:
         msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
         module.fail_json(msg=msg, changed=False)
@@ -183,7 +188,7 @@ def check_db_exists(module, msg, oracle_home, db_name, sid, db_unique_name):
                             return True
 
 
-def run_datapatch(module, msg, hostname, oracle_home, db_name, sid):
+def run_datapatch(module, msg, hostname, oracle_home, db_name, sid, script_env):
     if major_version > '11.2':
         if sid is not None:
             os.environ['ORACLE_SID'] = sid
@@ -191,7 +196,7 @@ def run_datapatch(module, msg, hostname, oracle_home, db_name, sid):
             os.environ['ORACLE_SID'] = db_name
 
         command = '%s/OPatch/datapatch -verbose' % (oracle_home)
-        (rc, stdout, stderr) = module.run_command(command)
+        (rc, stdout, stderr) = module.run_command(command, environ_update=script_env)
         if rc != 0:
             msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (
                 stdout,
@@ -339,6 +344,7 @@ def main():
             hostname=dict(required=False, default='localhost', aliases=['host']),
             service_name=dict(required=False, aliases=['sn']),
             port=dict(required=False, default=1521),
+            script_env=dict(required=False, type='dict', default={}),
         ),
     )
 
@@ -353,6 +359,7 @@ def main():
     hostname = module.params["hostname"]
     service_name = module.params["service_name"]
     port = module.params["port"]
+    script_env = module.params["script_env"]
 
     # ld_library_path = '%s/lib' % (oracle_home)
     if oracle_home is not None:
@@ -397,9 +404,9 @@ def main():
     else:
         service_name = db_name
     # Get the Oracle version
-    major_version = get_version(module, msg, oracle_home)
+    major_version = get_version(module, msg, oracle_home, script_env)
     if check_db_exists(module, msg, oracle_home, db_name, sid, db_unique_name):
-        if run_datapatch(module, msg, hostname, oracle_home, db_name, sid):
+        if run_datapatch(module, msg, hostname, oracle_home, db_name, sid, script_env):
             msg = 'Datapatch run successfully for database: %s' % (db_name)
             module.exit_json(msg=msg, changed=True)
         else:

--- a/plugins/modules/oracle_db.py
+++ b/plugins/modules/oracle_db.py
@@ -271,6 +271,11 @@ options:
         required: false
         type: str
         default: 1521
+    script_env:
+        description: >
+            Dictionary of environment settings to be passed to run_command
+        required: false
+        default: {}
 
 
 notes:
@@ -354,9 +359,9 @@ else:
     cx_oracle_exists = True
 
 
-def get_version(module, oracle_home):
+def get_version(module, oracle_home, script_env):
     command = '%s/bin/sqlplus -V' % (oracle_home)
-    (rc, stdout, stderr) = module.run_command(command)
+    (rc, stdout, stderr) = module.run_command(command, environ_update=script_env)
     if rc != 0:
         msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
         module.fail_json(msg=msg, changed=False)
@@ -366,7 +371,7 @@ def get_version(module, oracle_home):
 
 
 # Check if the database exists
-def check_db_exists(module, oracle_home, db_name, sid, db_unique_name):
+def check_db_exists(module, oracle_home, db_name, sid, db_unique_name, script_env):
     global msg
 
     if sid is None:
@@ -378,7 +383,7 @@ def check_db_exists(module, oracle_home, db_name, sid, db_unique_name):
             checkdb = db_name
 
         command = "%s/bin/srvctl config database -d %s " % (oracle_home, checkdb)
-        (rc, stdout, stderr) = module.run_command(command)
+        (rc, stdout, stderr) = module.run_command(command, environ_update=script_env)
         if rc != 0:
             if 'PRCD-1229' in stdout:
                 # DB created, with different ORACLE_HOME
@@ -695,6 +700,7 @@ def ensure_db_state(
     default_tablespace,
     default_temp_tablespace,
     timezone,
+    script_env,
 ):
     cursor = getconn(module)
     global israc
@@ -819,6 +825,7 @@ def ensure_db_state(
                     instance_name,
                     israc,
                     change_restart_sql,
+                    script_env,
                 )
         else:
             if len(change_restart_sql) > 0:
@@ -832,6 +839,7 @@ def ensure_db_state(
                     instance_name,
                     israc,
                     change_restart_sql,
+                    script_env,
                 )
 
             if len(change_db_sql) > 0:
@@ -886,16 +894,25 @@ def apply_restart_changes(
     instance_name,
     israc,
     change_restart_sql,
+    script_env,
 ):
     open_mode = stop_db(module, oracle_home, db_name, db_unique_name, sid)
     start_instance(
-        module, oracle_home, db_name, db_unique_name, sid, 'mount', israc, instance_name
+        module,
+        oracle_home,
+        db_name,
+        db_unique_name,
+        sid,
+        script_env,
+        'mount',
+        israc,
+        instance_name,
     )
     cursor = getconn(module)
     for sql in change_restart_sql:
         execute_sql(module, cursor, sql)
     stop_db(module, oracle_home, db_name, db_unique_name, sid)
-    start_db(module, oracle_home, db_name, db_unique_name, sid, open_mode)
+    start_db(module, oracle_home, db_name, db_unique_name, sid, script_env, open_mode)
 
 
 def apply_norestart_changes(module, change_db_sql):
@@ -1022,13 +1039,23 @@ def stop_db(module, oracle_home, db_name, db_unique_name, sid):
             return open_mode[0][0]
 
 
-def start_db(module, oracle_home, db_name, db_unique_name, sid, open_mode=None):
+def start_db(
+    module, oracle_home, db_name, db_unique_name, sid, script_env, open_mode=None
+):
     # global debug
     # debug.append('start_db called with open_mode %s,
     #              calling start_instance' % \
     #              (open_mode or "None"))
     return start_instance(
-        module, oracle_home, db_name, db_unique_name, sid, open_mode, False, ''
+        module,
+        oracle_home,
+        db_name,
+        db_unique_name,
+        sid,
+        script_env,
+        open_mode,
+        False,
+        '',
     )
 
 
@@ -1038,6 +1065,7 @@ def start_instance(
     db_name,
     db_unique_name,
     sid,
+    script_env,
     open_mode=None,
     israc=False,
     instance_name='',
@@ -1058,7 +1086,7 @@ def start_instance(
         else:
             command = '%s/bin/srvctl status database -d %s ' % (oracle_home, db_name)
 
-        (rc, stdout, stderr) = module.run_command(command)
+        (rc, stdout, stderr) = module.run_command(command, environ_update=script_env)
         if rc != 0:
             msg = 'Error(start_instance) - STDOUT: %s, STDERR: %s, COMMAND: %s' % (
                 stdout,
@@ -1091,7 +1119,9 @@ def start_instance(
                     )
             if open_mode is not None:
                 command += ' -o %s ' % (open_mode)
-            (rc, stdout, stderr) = module.run_command(command)
+            (rc, stdout, stderr) = module.run_command(
+                command, environ_update=script_env
+            )
 
             # To allow the DB to register with the listener,
             # as following tasks may want to connect to it immediately and fail
@@ -1287,6 +1317,7 @@ def main():
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']), # noqa E231
             port                = dict(required=False, default = 1521), # noqa E231
             omf                 = dict(required=False, type='bool', default=False), # noqa E231
+            script_env          = dict(required=False, type='dict', default={}), # noqa E231
         ),
         mutually_exclusive=[['memory_percentage', 'memory_totalmb']],
     )
@@ -1333,6 +1364,7 @@ def main():
     hostname            = module.params["hostname"] # noqa E221
     port                = module.params["port"] # noqa E221
     omf                 = module.params["omf"] # noqa E221
+    script_env          = module.params["script_env"] # noqa E221
     # fmt: on
 
     # ld_library_path = '%s/lib' % (oracle_home)
@@ -1380,7 +1412,7 @@ def main():
         service_name = "%s.%s" % (service_name, domain)
 
     # Get the Oracle version
-    major_version = get_version(module, oracle_home)
+    major_version = get_version(module, oracle_home, script_env)
 
     if state == 'started' or state == 'restarted':
         msg = "oracle_home: %s db_name: %s sid: %s db_unique_name: %s" % (
@@ -1391,7 +1423,9 @@ def main():
         )
         spf_restart_needed = False
 
-        if not check_db_exists(module, oracle_home, db_name, sid, db_unique_name):
+        if not check_db_exists(
+            module, oracle_home, db_name, sid, db_unique_name, script_env
+        ):
             msg = "Database not found. %s" % msg
             module.fail_json(msg=msg, changed=False)
 
@@ -1411,11 +1445,17 @@ def main():
                     open_mode = None
 
                 start_db_state = start_db(
-                    module, oracle_home, db_name, db_unique_name, sid, open_mode
+                    module,
+                    oracle_home,
+                    db_name,
+                    db_unique_name,
+                    sid,
+                    script_env,
+                    open_mode,
                 )
             else:
                 start_db_state = start_db(
-                    module, oracle_home, db_name, db_unique_name, sid
+                    module, oracle_home, db_name, db_unique_name, sid, script_env
                 )
 
             if start_db_state == 'changed' and not spf_restart_needed:
@@ -1440,7 +1480,9 @@ def main():
                 module.fail_json(msg=msg, changed=False)
 
     elif state == 'present':
-        if not check_db_exists(module, oracle_home, db_name, sid, db_unique_name):
+        if not check_db_exists(
+            module, oracle_home, db_name, sid, db_unique_name, script_env
+        ):
             if create_db(
                 module,
                 oracle_home,
@@ -1486,6 +1528,7 @@ def main():
                     default_tablespace,
                     default_temp_tablespace,
                     timezone,
+                    script_env,
                 )
 
             else:
@@ -1505,12 +1548,15 @@ def main():
                 default_tablespace,
                 default_temp_tablespace,
                 timezone,
+                script_env,
             )
             # msg = 'Database %s already exists' % (db_name)
             # module.exit_json(msg=msg, changed=False)
 
     elif state == 'absent':
-        if check_db_exists(module, oracle_home, db_name, sid, db_unique_name):
+        if check_db_exists(
+            module, oracle_home, db_name, sid, db_unique_name, script_env
+        ):
             if remove_db(
                 module, oracle_home, db_name, sid, db_unique_name, sys_password
             ):

--- a/plugins/modules/oracle_sqldba.py
+++ b/plugins/modules/oracle_sqldba.py
@@ -102,6 +102,10 @@ options:
         description: set NLS_LANG to the given value
     chdir:
         description: Working directory for SQL/script execution
+    ignorable_err:
+        description: Optional list of ORA, TNS, PLS or SP2 errors.
+        required: false
+        default: None
 
 author: Dietmar Uhlig, Robotron (www.robotron.de)
 '''
@@ -171,6 +175,8 @@ db_postinstall:
     sqlselect: "select value from gv$parameter where name = 'job_queue_processes'"
     oracle_home: "{{ oracle_db_home }}"
     oracle_db_name: "{{ oracle_db_name }}"
+    ignorable_err:
+      - "ORA-01555"
   register: jqpresult
 
 - name: Store job_queue_processes
@@ -186,6 +192,7 @@ err_msg = None
 oracle_home = ""
 pdb_list = ""
 sql_process = None
+ignorable_err = ""
 
 # Maximum runtime for sqlplus and catcon.pl in seconds. 0 means no timeout.
 timeout = 0
@@ -220,6 +227,8 @@ def sqlplus():
 def conn(username, password):
     if username is None:
         return "conn / as sysdba\n"
+    elif username.lower() == "sys":
+        return "conn " + "/".join([username, password]) + " as sysdba\n"
     else:
         return "conn " + "/".join([username, password]) + "\n"
 
@@ -231,6 +240,9 @@ def sql_input(sql, username, password, pdb):
 
     if pdb is not None:
         sql_scr += "alter session set container = " + pdb + ";\n"
+    # Sometimes the previous settings are lost after connecting, so setting it again
+    sql_scr += "set heading off echo off feedback off termout on\n"
+    sql_scr += "set long 1000000 pagesize 0 linesize 1000 trimspool on\n"
     sql_scr += sql + "\n"
     sql_scr += "exit;\n"
     return sql_scr
@@ -243,20 +255,20 @@ def kill_process():
     err_msg = "Timeout occured after %d seconds. " % timeout
 
 
-def run_sql_p(sql, username, password, scope, pdb_list):
+def run_sql_p(sql, username, password, scope, pdb_list, ignorable_err):
     global changed, err_msg, sql_process
 
     err_msg = ""
     result = ""
     if scope == 'pdbs':
         for pdb in pdb_list.split():
-            result += run_sql(sql, username, password, pdb)
+            result += run_sql(sql, username, password, pdb, ignorable_err)
     else:
-        result = run_sql(sql, username, password, None)
+        result = run_sql(sql, username, password, None, ignorable_err)
     return result
 
 
-def run_sql(sql, username, password, pdb):
+def run_sql(sql, username, password, pdb, ignorable_err):
     global changed, err_msg, sql_process
 
     t = None
@@ -284,30 +296,34 @@ def run_sql(sql, username, password, pdb):
             serr,
         )
         return "[ERR]"
-    sqlerr_pat = re.compile("^(ORA|TNS|SP2)-[0-9]+", re.MULTILINE)
-    sqlplus_err = sqlerr_pat.search(sout.decode())
-    if sqlplus_err:
-        err_msg += "[ERR] sqlplus: %s\nERR Code: %s.\n" % (sql_cmd, sqlplus_err.group())
-        return "[ERR]\n%s\n" % sout.strip()
-
+    sqlerr_pat = re.compile(r"^\s*((?:ORA|PLS|TNS|SP2)-\d+)", re.MULTILINE)
+    sqlplus_err = sqlerr_pat.findall(sout.decode())
+    if len(sqlplus_err) > 0:
+        if ignorable_err is None:
+            ignorable_err = []
+        relevant_errs = [x for x in sqlplus_err if x not in ignorable_err]
+        for relevant_err in relevant_errs:
+            err_msg += "[ERR] sqlplus: %s\nERR Code: %s.\n" % (sql_cmd, relevant_err)
+        if relevant_errs:
+            return "[ERR]\n%s\n" % sout.strip()
     changed = True
     return sout.decode('utf-8').strip()
 
 
-def check_creates_sql(sql, scope):
+def check_creates_sql(sql, scope, ignorable_err):
     global pdb_list, err_msg
 
     err_msg = ""
     if not sql.endswith(";"):
         sql += ";"
-    if scope == 'cdb':
-        res = run_sql(sql, None, None, None)
+    if scope == "cdb":
+        res = run_sql(sql, None, None, None, ignorable_err)
         # error handling see call of check_creates_sql
         return False if not res or res == "0" else True
     else:
         checked_pdb_list = ""
         for pdb in pdb_list.split():
-            res = run_sql(sql, None, None, pdb)
+            res = run_sql(sql, None, None, pdb, ignorable_err)
             # error handling see call of check_creates_sql
             if not res or res == "0":
                 checked_pdb_list += " " + pdb
@@ -316,7 +332,7 @@ def check_creates_sql(sql, scope):
 
 
 def is_container():
-    return run_sql("select cdb from gv$database;", None, None, None) == 'YES'
+    return run_sql("select cdb from gv$database;", None, None, None, []) == "YES"
 
 
 def get_all_pdbs():
@@ -326,7 +342,7 @@ def get_all_pdbs():
         "select listagg(pdb_name, ' ') within group (order by pdb_name) "
         "Sfrom dba_pdbs where status = 'NORMAL' and pdb_name <> 'PDB$SEED';"
     )
-    pdb_list = 'CDB$ROOT ' + run_sql(sql, None, None, None)
+    pdb_list = "CDB$ROOT " + run_sql(sql, None, None, None, [])
 
 
 def run_catcon_pl(catcon_pl):
@@ -334,7 +350,7 @@ def run_catcon_pl(catcon_pl):
     global oracle_home, changed, result, err_msg, pdb_list, sql_process
 
     err_msg = ""
-    catcon_pl = re.sub("^(\$ORACLE_HOME|\?)", oracle_home, catcon_pl)  # noqa W805
+    catcon_pl = re.sub(r"^(\$ORACLE_HOME|\?)", oracle_home, catcon_pl)  # noqa W805
     logdir = tempfile.mkdtemp()
     catcon_cmd = [
         os.path.join(oracle_home, "perl", "bin", "perl"),
@@ -385,8 +401,7 @@ def run_catcon_pl(catcon_pl):
 
 
 def main():
-    global oracle_home, changed, result, err_msg, pdb_list
-
+    global oracle_home, changed, result, err_msg, pdb_list, ignorable_err
     module = AnsibleModule(
         argument_spec=dict(
             sql=dict(required=False),
@@ -406,6 +421,9 @@ def main():
             oracle_db_name=dict(required=True),
             nls_lang=dict(required=False),
             chdir=dict(required=False),
+            ignorable_err=dict(
+                required=False,
+            ),
         ),
         mutually_exclusive=[
             ['sql', 'sqlscript', 'catcon_pl', 'sqlselect'],
@@ -426,6 +444,7 @@ def main():
     oracle_db_name = module.params["oracle_db_name"]
     nls_lang = module.params["nls_lang"]
     workdir = module.params["chdir"]
+    ignorable_err = module.params["ignorable_err"]
 
     os.environ["ORACLE_HOME"] = oracle_home
     os.environ["ORACLE_SID"] = oracle_db_name
@@ -459,7 +478,7 @@ def main():
             )
 
     if creates_sql is not None:
-        already_done = check_creates_sql(creates_sql, scope)
+        already_done = check_creates_sql(creates_sql, scope, ignorable_err)
         if err_msg:
             module.fail_json(msg="%s\n%s" % (result, err_msg), changed=False)
         else:
@@ -477,16 +496,20 @@ def main():
             + sqlselect.replace("'", "''")
             + "') from dual;"
         )
-        result = run_sql_p(sqlselect, username, password, scope, pdb_list)
+        result = run_sql_p(
+            sqlselect, username, password, scope, pdb_list, ignorable_err
+        )
     elif sql is not None:
         sql = os.linesep.join([s for s in sql.splitlines() if s.strip()])
         if not sql.endswith(";") and not sql.endswith("/"):
             sql += ";"
-        result += run_sql_p(sql, username, password, scope, pdb_list)
+        result += run_sql_p(sql, username, password, scope, pdb_list, ignorable_err)
     elif sqlscript is not None:
         if not sqlscript.startswith("@"):
             sqlscript = "@" + sqlscript
-        result += run_sql_p(sqlscript, username, password, scope, pdb_list)
+        result += run_sql_p(
+            sqlscript, username, password, scope, pdb_list, ignorable_err
+        )
     elif catcon_pl is not None:
         run_catcon_pl(catcon_pl)
 

--- a/roles/oradb_datapatch/tasks/main.yml
+++ b/roles/oradb_datapatch/tasks/main.yml
@@ -23,6 +23,8 @@
     db_unique_name: "{{ odb.oracle_db_unique_name | default(omit) }}"
     sid: "{{ odb.oracle_db_instance_name | default(omit) }}"
     state: started
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   become: true
   become_user: "{{ oracle_user }}"
   with_items: "{{ oracle_databases | selectattr('state', 'equalto', 'present') }}"
@@ -50,6 +52,8 @@
     hostname: "{{ ansible_fqdn }}"
     service_name: "{{ _db_service_name }}"
     port: "{{ _listener_port_cdb }}"
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   loop: "{{ oracle_databases | selectattr('state', 'equalto', 'present') }}"
   become: true
   become_user: "{{ oracle_user }}"

--- a/roles/orahost/README.md
+++ b/roles/orahost/README.md
@@ -631,6 +631,7 @@ oracle_packages:
   - lsof
   - compat-openssl11
   - fontconfig
+  - glibc-langpack-en
 ```
 
 ### oracle_packages_sles_multi

--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -356,6 +356,7 @@ oracle_packages:
   - lsof
   - compat-openssl11
   - fontconfig
+  - glibc-langpack-en
 
 # @var oracle_packages_sles_multi:description: >
 # List of additinal RPMs for different SLES version.

--- a/roles/orasw_meta/README.md
+++ b/roles/orasw_meta/README.md
@@ -69,6 +69,7 @@ There are a lot of variables who are used by `orasw_meta`
   - [oracle_sw_source_www](#oracle_sw_source_www)
   - [orasw_meta_assert_oracle_databases](#orasw_meta_assert_oracle_databases)
   - [orasw_meta_cluster_hostgroup](#orasw_meta_cluster_hostgroup)
+  - [orasw_meta_forced_lang](#orasw_meta_forced_lang)
   - [proxy_env](#proxy_env)
   - [set_oracle_all_editions_options_state](#set_oracle_all_editions_options_state)
   - [shell_aliases](#shell_aliases)
@@ -987,6 +988,17 @@ Ansible Inventory hostgroup for RAC-Cluster.
 
 ```YAML
 orasw_meta_cluster_hostgroup: ''
+```
+
+### orasw_meta_forced_lang
+
+Certain modules (e.g. oracle_db and oracle_opatch) rely on English language outputs. This causes trouble if system
+has different locale settings. That's why we force the language in script environments.
+
+#### Default value
+
+```YAML
+orasw_meta_forced_lang: en_US.UTF-8
 ```
 
 ### proxy_env

--- a/roles/orasw_meta/defaults/main.yml
+++ b/roles/orasw_meta/defaults/main.yml
@@ -680,3 +680,9 @@ proxy_env:
 # @end
 # @var opatch_conflict_check:type: boolean
 opatch_conflict_check: true
+
+# @var orasw_meta_forced_lang:description: >
+# Certain modules (e.g. oracle_db and oracle_opatch) rely on English language outputs. This causes trouble if system
+# has different locale settings. That's why we force the language in script environments.
+# @end
+orasw_meta_forced_lang: en_US.UTF-8

--- a/roles/oraswdb_manage_patches/tasks/loop_db-home-patch.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_db-home-patch.yml
@@ -49,6 +49,8 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ item.state }}"
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   with_items:
     - "{{ db_homes_config[dbh.home]['opatch'] | selectattr('state', 'equalto', 'absent') }}"
   become: true
@@ -72,6 +74,8 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ item.0.state }}"
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   with_subelements:
     - "{{ db_homes_config[dbh.home]['opatchauto'] }}"
     - subpatches

--- a/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
@@ -81,6 +81,8 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ dhc_opatch.state }}"
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', oracle_user) }}"
   register: _oracle_opatch_res

--- a/roles/oraswdb_manage_patches/tasks/opatch-upgrade.yml
+++ b/roles/oraswdb_manage_patches/tasks/opatch-upgrade.yml
@@ -9,6 +9,8 @@
       opitzconsulting.ansible_oracle.oracle_opatch:
         oracle_home: "{{ oracle_home_db }}"
         state: opatchversion
+        script_env:
+          LANG: "{{ orasw_meta_forced_lang }}"
       register: current_opatch_version
       tags: current_opatch_version
       when: db_homes_config[dbh.home]['opatch_minversion'] is defined

--- a/roles/oraswgi_manage_patches/tasks/loop_apply_single_opatch.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_apply_single_opatch.yml
@@ -14,6 +14,8 @@
     ocm_response_file: "{{ _oraswgi_manage_patches_ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ item.state }}"
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   notify: rootscript_postpatch
   vars:
     __opatchauto_patchtype: false  # opatch apply

--- a/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
@@ -56,7 +56,7 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ gip_opatch.0.state }}"
-    script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': '-Djava.io.tmpdir=' + orahost_meta_java_options} }}"
+    script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': orahost_meta_java_options, 'LANG': orasw_meta_forced_lang} }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', grid_user) }}"
   vars:

--- a/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
@@ -56,7 +56,10 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ gip_opatch.0.state }}"
-    script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': orahost_meta_java_options, 'LANG': orasw_meta_forced_lang} }}"
+    script_env:
+      TMPDIR: "{{ orahost_meta_tmpdir }}"
+      _JAVA_OPTIONS: "{{ orahost_meta_java_options }}"
+      LANG: "{{ orasw_meta_forced_lang }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', grid_user) }}"
   vars:

--- a/roles/oraswgi_manage_patches/tasks/loop_remove_single_opatch.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_remove_single_opatch.yml
@@ -32,5 +32,7 @@
         ocm_response_file: "{{ _oraswgi_manage_patches_ocm_response_file | default(omit) }}"
         output: verbose
         state: "{{ gip_opatch.state }}"
+        script_env:
+          LANG: "{{ orasw_meta_forced_lang }}"
       become: true
       become_user: "{{ _grid_install_user }}"

--- a/roles/oraswgi_manage_patches/tasks/main.yml
+++ b/roles/oraswgi_manage_patches/tasks/main.yml
@@ -62,6 +62,8 @@
           opitzconsulting.ansible_oracle.oracle_opatch:
             oracle_home: "{{ oracle_home_gi }}"
             state: opatchversion
+            script_env:
+              LANG: "{{ orasw_meta_forced_lang }}"
           become: true
           become_user: "{{ _grid_install_user }}"
           register: current_opatch_version

--- a/roles/oraswgi_manage_patches/tasks/opatch-upgrade.yml
+++ b/roles/oraswgi_manage_patches/tasks/opatch-upgrade.yml
@@ -14,6 +14,8 @@
   opitzconsulting.ansible_oracle.oracle_opatch:
     oracle_home: "{{ oracle_home_gi }}"
     state: opatchversion
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   register: current_opatch_version
   tags: current_opatch_version
   become: true
@@ -101,6 +103,8 @@
       opitzconsulting.ansible_oracle.oracle_opatch:
         oracle_home: "{{ oracle_home_gi }}"
         state: opatchversion
+        script_env:
+          LANG: "{{ orasw_meta_forced_lang }}"
       register: current_opatch_version2
       tags: current_opatch_version
       become: true

--- a/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
+++ b/roles/oraswgi_manage_patches/tasks/post_install_patch.yml
@@ -41,6 +41,8 @@
     ocm_response_file: "{{ _oraswgi_manage_patches_ocm_response_file | default(omit) }}"
     output: verbose
     state: absent
+    script_env:
+      LANG: "{{ orasw_meta_forced_lang }}"
   with_items:
     - "{{ gi_patches[oracle_install_version_gi]['opatchauto'] | selectattr('state', 'equalto', 'absent') }}"
   loop_control:


### PR DESCRIPTION
oracle_datapatch.py and oracle_db.py partially operate on command outputs and rely on English language there. If system locale is set differently (e.g. de_DE.UTF-8), command output will be misinterpreted. With this fix, we ensure English language pack (glibc-langpack-en) is installed and the modules above are forced to set their script enironment to LANG=en_US.UTF-8