### PR TITLE
listener home check fixed

### DIFF
--- a/changelogs/listener-home-check.yml
+++ b/changelogs/listener-home-check.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oracle_opatch.py: complete oratab entry was used to match listener home, instead of using the oracle_home part only (oravirt#532)"

--- a/plugins/modules/oracle_opatch.py
+++ b/plugins/modules/oracle_opatch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os
@@ -401,7 +401,8 @@ def stop_process(module, oracle_home):
                 elif len(line.split(':')) >= 2 and line.split(':')[1] == oracle_home:
                     # Find listener for ORACLE_HOME
                     p = subprocess.Popen(
-                        'ps -o cmd -C tnslsnr | grep "^%s/bin/tnslsnr "' % (line),
+                        'ps -o cmd -C tnslsnr | grep "^%s/bin/tnslsnr "'
+                        % (oracle_home),
                         shell=True,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,


### PR DESCRIPTION
When checking for listeners running out of the oracle_home to be patched, complete oratab entry was used to match listener home, instead of using the oracle_home part only
Fixes #532 