### PR TITLE
opatchauto fixes for patching clusters

### DIFF
--- a/changelogs/fragments/db-opatchauto.yml
+++ b/changelogs/fragments/db-opatchauto.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "Add orahost_meta_tmpdir and orahost_meta_java_options to dbhome's opatchauto call to enable non-default tmp dir, e.g. on hardened systems"
+  - "Ensure stage tmp is available on all cluster nodes because opatchauto runs remote checks from there"

--- a/plugins/modules/oracle_sqldba.py
+++ b/plugins/modules/oracle_sqldba.py
@@ -491,8 +491,14 @@ def main():
     if sqlselect is not None:
         if sqlselect.endswith(";"):
             sqlselect.rstrip(";")
-        sqlselect = "select dbms_xmlgen.getxml('" + sqlselect.replace("'", "''") + "') from dual;"
-        result = run_sql_p(sqlselect, username, password, scope, pdb_list, ignorable_err)
+        sqlselect = (
+            "select dbms_xmlgen.getxml('"
+            + sqlselect.replace("'", "''")
+            + "') from dual;"
+        )
+        result = run_sql_p(
+            sqlselect, username, password, scope, pdb_list, ignorable_err
+        )
     elif sql is not None:
         sql = os.linesep.join([s for s in sql.splitlines() if s.strip()])
         if not sql.endswith(";") and not sql.endswith("/"):
@@ -501,7 +507,9 @@ def main():
     elif sqlscript is not None:
         if not sqlscript.startswith("@"):
             sqlscript = "@" + sqlscript
-        result += run_sql_p(sqlscript, username, password, scope, pdb_list, ignorable_err)
+        result += run_sql_p(
+            sqlscript, username, password, scope, pdb_list, ignorable_err
+        )
     elif catcon_pl is not None:
         run_catcon_pl(catcon_pl)
 

--- a/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
@@ -81,6 +81,10 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ dhc_opatch.state }}"
+    script_env:
+      TMPDIR: "{{ orahost_meta_tmpdir }}"
+      _JAVA_OPTIONS: "{{ orahost_meta_java_options }}"
+      LANG: "{{ orasw_meta_forced_lang }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', oracle_user) }}"
   register: _oracle_opatch_res

--- a/roles/oraswdb_manage_patches/tasks/main.yml
+++ b/roles/oraswdb_manage_patches/tasks/main.yml
@@ -45,6 +45,21 @@
     - apply_patches_db
     - item.apply_patches | default(false)
 
+# opatchauto precheck runs on all cluster nodes in {{ oracle_tmp_stage }}, although patching only one
+- name: db_opatch | Ensure stage temp directory is present at all nodes when patching a cluster
+  when:
+    - orasw_meta_cluster_hostgroup is defined
+  ansible.builtin.file:
+    path: "{{ oracle_tmp_stage }}"
+    state: directory
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+    mode: "0775"
+  delegate_to: "{{ _oraswgi_manage_patches_cluster_host }}"
+  loop: "{{ groups[orasw_meta_cluster_hostgroup] }}"
+  loop_control:
+    loop_var: _oraswgi_manage_patches_cluster_host
+
 - name: Include loop_db-home-patch.yml
   ansible.builtin.include_tasks: loop_db-home-patch.yml
   with_items:


### PR DESCRIPTION
- oracle_tmp_stage has to be present on all cluster nodes (regardless of RAC) because opatchauto's pre-check expects it to exist at remote nodes, too
- temporary directories (and LANG) add to environment of oracle_opatch call. Required for systems where default temporary directory is flagged "noexec"