### PR TITLE
apply_options attribute introduced to feed additional options to opatch

### DIFF
--- a/changelogs/fragments/opatch-options.yml
+++ b/changelogs/fragments/opatch-options.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "`apply_options` attribute added to db_homes_config and gi_patches_config to set opatch and opatchauto options"

--- a/plugins/modules/oracle_opatch.py
+++ b/plugins/modules/oracle_opatch.py
@@ -108,6 +108,11 @@ options:
             Dictionary of environment settings to be passed to run_command
         required: false
         default: {}
+    apply_options:
+        description: >
+            List of options to append to opatch(auto) apply
+        required: false
+        default: []
 notes:
 requirements: [ "os","pwd","distutils.version" ]
 author: Mikael Sandström, oravirt@gmail.com, @oravirt
@@ -305,6 +310,7 @@ def apply_patch(
     stop_processes,
     rolling,
     script_env,
+    apply_options,
     output,
 ):
     '''
@@ -317,8 +323,8 @@ def apply_patch(
         ):
             module.fail_json(msg='Prereq checks failed')
 
+    opoptions = " ".join(apply_options)
     if opatchauto:
-        opoptions = ''
         if major_version < '12.1':
             opatch_cmd = 'opatch auto'
             if offline:
@@ -346,11 +352,12 @@ def apply_patch(
             stop_process(module, oracle_home)
 
         opatch_cmd = 'opatch'
-        command = '%s/OPatch/%s apply %s -oh %s -silent' % (
+        command = '%s/OPatch/%s apply %s -oh %s -silent %s' % (
             oracle_home,
             opatch_cmd,
             patch_base,
             oracle_home,
+            opoptions,
         )
 
     if ocm_response_file is not None and (
@@ -557,6 +564,7 @@ def main():
             hostname=dict(required=False, default='localhost', aliases=['host']),
             port=dict(required=False, type='int', default=1521),
             script_env=dict(required=False, type='dict', default={}),
+            apply_options=dict(required=False, type='list', default=[]),
         ),
     )
 
@@ -577,6 +585,7 @@ def main():
     hostname = module.params["hostname"]
     port = module.params["port"]
     script_env = module.params["script_env"]
+    apply_options = module.params["apply_options"]
 
     if not os.path.exists(oracle_home):
         msg = 'oracle_home: %s doesn\'t exist' % (oracle_home)
@@ -658,6 +667,7 @@ def main():
                 stop_processes,
                 rolling,
                 script_env,
+                apply_options,
                 output,
             ):
                 if patch_version is not None:

--- a/roles/orasw_meta/README.md
+++ b/roles/orasw_meta/README.md
@@ -141,7 +141,8 @@ The dictionary holds data for:
 | opatch_minversion | Is needed for patching. Automatically installs a new version of OPatch, when existing version is older then `opatch_minversion` |
 | oracle_home | |
 | oracle_home_name | Mandatory variable, when `readonly_home: true`. Oracle allows only characters, numbers and '_' as value in `oracle_home_name`. Do _not_ use '-' as a value!|
-| opatch | |
+| opatchauto | Bundle patches to be installed/removed using opatchauto |
+| opatch | One-off patches to be installed/removed using opatch |
 | readonly_home | Should `ansible-oracle` install this ORACLE_HOME as readonly home? Do _NOT_ change this attribute for an installed ORACLE_HOME. default value: false|
 | version | The base version for the ORACLE_HOME. Use the version from the official 1st release of Oracle. |
 
@@ -159,6 +160,30 @@ db_homes_config:
     home: db1_base
     version: 19.3.0.0
     edition: EE
+  1931_se2:
+    oracle_home: /u01/app/oracle/product/19.0.0/dbhome_1
+    version: 19.3.0.0
+    edition: SE2
+    opatch_minversion: "12.2.0.1.51"
+    opatchauto:
+      - patchid: 39062956
+        patchversion: 19.31.0.0.260421
+        state: present
+        path: 39062956/39062956/39036936
+        subpatches:
+          - 39034528 # Database
+          - 39039430 # OCW
+          - 39055473 # ACFS
+          - 39107855 # Tomcat
+          - 39107825 # DBWLM
+        apply_options:
+          - "-deleteInactivePatches"
+    opatch:
+      - patchid: 39473469
+        state: present
+        path: 39473469/39473469/39473469
+        apply_options:
+          - "-force_conflict"
 ```
 
 ### db_homes_installed

--- a/roles/orasw_meta/defaults/main.yml
+++ b/roles/orasw_meta/defaults/main.yml
@@ -274,7 +274,8 @@ dbenvdir: "{{ oracle_user_home }}/dbenv"
 # | opatch_minversion | Is needed for patching. Automatically installs a new version of OPatch, when existing version is older then `opatch_minversion` |
 # | oracle_home | |
 # | oracle_home_name | Mandatory variable, when `readonly_home: true`. Oracle allows only characters, numbers and '_' as value in `oracle_home_name`. Do _not_ use '-' as a value!|
-# | opatch | |
+# | opatchauto | Bundle patches to be installed/removed using opatchauto |
+# | opatch | One-off patches to be installed/removed using opatch |
 # | readonly_home | Should `ansible-oracle` install this ORACLE_HOME as readonly home? Do _NOT_ change this attribute for an installed ORACLE_HOME. default value: false|
 # | version | The base version for the ORACLE_HOME. Use the version from the official 1st release of Oracle. |
 #
@@ -290,6 +291,30 @@ dbenvdir: "{{ oracle_user_home }}/dbenv"
 #     home: db1_base
 #     version: 19.3.0.0
 #     edition: EE
+#   1931_se2:
+#     oracle_home: /u01/app/oracle/product/19.0.0/dbhome_1
+#     version: 19.3.0.0
+#     edition: SE2
+#     opatch_minversion: "12.2.0.1.51"
+#     opatchauto:
+#       - patchid: 39062956
+#         patchversion: 19.31.0.0.260421
+#         state: present
+#         path: 39062956/39062956/39036936
+#         subpatches:
+#           - 39034528 # Database
+#           - 39039430 # OCW
+#           - 39055473 # ACFS
+#           - 39107855 # Tomcat
+#           - 39107825 # DBWLM
+#         apply_options:
+#           - "-deleteInactivePatches"
+#     opatch:
+#       - patchid: 39473469
+#         state: present
+#         path: 39473469/39473469/39473469
+#         apply_options:
+#           - "-force_conflict"
 # @end
 
 # @todo information: db_homes_installed not used for a long time...

--- a/roles/oraswdb_manage_patches/tasks/loop_db-home-patch.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_db-home-patch.yml
@@ -72,6 +72,7 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ item.0.state }}"
+    apply_options: "{{ item.0.apply_options | default(omit) }}"
   with_subelements:
     - "{{ db_homes_config[dbh.home]['opatchauto'] }}"
     - subpatches

--- a/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswdb_manage_patches/tasks/loop_patchid.yml
@@ -81,6 +81,7 @@
     ocm_response_file: "{{ ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ dhc_opatch.state }}"
+    apply_options: "{{ dhc_opatch.apply_options | default(omit) }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', oracle_user) }}"
   register: _oracle_opatch_res

--- a/roles/oraswgi_manage_patches/tasks/loop_apply_single_opatch.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_apply_single_opatch.yml
@@ -14,6 +14,7 @@
     ocm_response_file: "{{ _oraswgi_manage_patches_ocm_response_file | default(omit) }}"
     output: verbose
     state: "{{ item.state }}"
+    apply_options: "{{ item.apply_options | default(omit) }}"
   notify: rootscript_postpatch
   vars:
     __opatchauto_patchtype: false  # opatch apply

--- a/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
+++ b/roles/oraswgi_manage_patches/tasks/loop_patchid.yml
@@ -57,6 +57,7 @@
     output: verbose
     state: "{{ gip_opatch.0.state }}"
     script_env: "{{ {'TMPDIR': orahost_meta_tmpdir, '_JAVA_OPTIONS': orahost_meta_java_options} }}"
+    apply_options: "{{ gip_opatch.0.apply_options | default(omit) }}"
   become: true
   become_user: "{{ __opatchauto_patchtype | ternary('root', grid_user) }}"
   vars:

--- a/roles/oraswgi_meta/README.md
+++ b/roles/oraswgi_meta/README.md
@@ -111,11 +111,15 @@ gi_patches_config:
             - 34139601  # ACFS Release Update 19.16.0.0.220719
             - 34318175  # TOMCAT RELEASE UPDATE 19.0.0.0.0
             - 34133642  # Database Release Update 19.16.0.0.220719
+          apply_options:
+            - "-deleteInactivePatches"
       opatch:
           # Oracle JavaVM Component Release Update (OJVM RU) 19.16.0.0.220719
           stop_processes: true
           state: present
           path: 19.16.0.0.220719/ojvm/p34086870_190000_Linux-x86-64.zip
+          apply_options:
+            - "-force_conflict"
           # Oracle Database 19c Important Recommended One-off Patches (Doc ID 555.1)
 gi_patches: "{{ gi_patches_config['19.16.0.0.220719'] }}"
 ```

--- a/roles/oraswgi_meta/defaults/main.yml
+++ b/roles/oraswgi_meta/defaults/main.yml
@@ -56,11 +56,15 @@ apply_patches_gi: true
 #             - 34139601  # ACFS Release Update 19.16.0.0.220719
 #             - 34318175  # TOMCAT RELEASE UPDATE 19.0.0.0.0
 #             - 34133642  # Database Release Update 19.16.0.0.220719
+#           apply_options:
+#             - "-deleteInactivePatches"
 #       opatch:
 #           # Oracle JavaVM Component Release Update (OJVM RU) 19.16.0.0.220719
 #           stop_processes: true
 #           state: present
 #           path: 19.16.0.0.220719/ojvm/p34086870_190000_Linux-x86-64.zip
+#           apply_options:
+#             - "-force_conflict"
 #           # Oracle Database 19c Important Recommended One-off Patches (Doc ID 555.1)
 # gi_patches: "{{ gi_patches_config['19.16.0.0.220719'] }}"
 # @end


### PR DESCRIPTION
This adds an optional `apply_options` attribute to `db_homes_config` and `gi_patches_config` to add a list of additional options to 'opatch(auto) apply` calls. Can be used to enable options like, e.g. `-deleteInactivePatches` - which was added to opatchauto as of v45 - or `-force_conflict`. But any other valid option can be given as well.