### PR TITLE
Allow for db supplemental_logging in oradb_manage_db role

### DIFF
--- a/changelogs/fragments/supplogging.yml
+++ b/changelogs/fragments/supplogging.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "oradb_manage_db: allow for configuring supplemental_logging"

--- a/roles/oradb_manage_db/tasks/manage-db.yml
+++ b/roles/oradb_manage_db/tasks/manage-db.yml
@@ -123,6 +123,7 @@
         archivelog: "{{ odb.archivelog | default(omit) }}"
         flashback: "{{ odb.flashback | default(omit) }}"
         force_logging: "{{ odb.force_logging | default(omit) }}"
+        supplemental_logging: "{{ odb.supplemental_logging | default(omit) }}"
         initparams: "{{ _oradb_manage_db_init_params_list | default(omit) }}"
         omf: "{{ odb.omf | default(omit) }}"
         output: verbose


### PR DESCRIPTION
If an existing database is already configured with supplemental logging, oradb_manag_db role fails with:

```
TASK [opitzconsulting.ansible_oracle.oradb_manage_db : manage_db | create/manage database] *************************************************************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Something went wrong while executing sql - ORA-32589: unable to drop minimal supplemental logging sq
l: alter database drop supplemental log data"}
```

The reason is that the role is calling oracle_db module but without the supplemental log argument. This PR provides a fix for this issue.